### PR TITLE
[ET-995] Prevent problems with fatal errors from tickets that no longer exist

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.0.5] TBD =
 
-
+* Fix - Prevent potential fatal errors when referencing deleted Tribe Commerce tickets in PayPal orders and API calls. [ET-995]
 
 = [5.0.4.1] 2020-12-16 =
 

--- a/src/Tribe/Commerce/PayPal/Gateway.php
+++ b/src/Tribe/Commerce/PayPal/Gateway.php
@@ -192,6 +192,11 @@ class Tribe__Tickets__Commerce__PayPal__Gateway {
 		foreach ( $product_ids as $ticket_id ) {
 			$ticket = $paypal->get_ticket( $post->ID, $ticket_id );
 
+			// Skip the product if the ticket no longer exists.
+			if ( ! $ticket ) {
+				continue;
+			}
+
 			$quantity = 0;
 
 			if ( isset( $_POST['tribe_tickets'][ $ticket_id ]['quantity'] ) ) {
@@ -591,6 +596,11 @@ class Tribe__Tickets__Commerce__PayPal__Gateway {
 			}
 
 			$ticket = $paypal->get_ticket( $post_id, $ticket_id );
+
+			// Skip the ticket if it no longer exists.
+			if ( ! $ticket ) {
+				continue;
+			}
 
 			// Skip if the ticket in no longer in stock or is not sellable.
 			if (


### PR DESCRIPTION
[ET-995]

This error isn't encountered often and it's quite difficult to reproduce. But there are edge cases which can cause a fatal error. The fix involves confirming the `$ticket` response is in fact an object as expected, before calling it like an object.

[ET-995]: https://theeventscalendar.atlassian.net/browse/ET-995