### PR TITLE
[ETP-490] [ETP-522] [ETP-509] [ETP-485] Handle email send / resend functionality for Attendees ORM

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2241,6 +2241,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			// Collect the unique emails for attendees.
 			foreach ( $attendees as $attendee ) {
+				// If the attendee data is not provided, get it from the provider.
+				if ( ! is_array( $attendee ) ) {
+					$attendee = $this->get_attendee( $attendee );
+				}
+
+				// If invalid attendee is set, skip it.
+				if ( ! $attendee ) {
+					continue;
+				}
+
 				if ( ! isset( $unique_attendees[ $attendee['holder_email'] ] ) ) {
 					$unique_attendees[ $attendee['holder_email'] ] = [];
 				}


### PR DESCRIPTION
[ETP-490]
[ETP-522]
[ETP-509]
[ETP-485]

This handles the email send / resend functionality for Attendees ORM.

It also moves the cache clearing into the trigger create/update method to abstract better.

Dev screencast: https://share.skc.dev/geu4ZBwG

[ETP-490]: https://theeventscalendar.atlassian.net/browse/ETP-490

[ETP-522]: https://theeventscalendar.atlassian.net/browse/ETP-522
[ETP-509]: https://theeventscalendar.atlassian.net/browse/ETP-509
[ETP-485]: https://theeventscalendar.atlassian.net/browse/ETP-485