### PR TITLE
[ET-926] ET > Handle email resend limitations for spam prevention

### DIFF
--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1087,16 +1087,15 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	 * @param array $args      {
 	 *      The list of arguments to use for sending ticket emails.
 	 *
-	 *      @type string       $subject              The email subject.
-	 *      @type string       $content              The email content.
-	 *      @type string       $from_name            The name to send tickets from.
-	 *      @type string       $from_email           The email to send tickets from.
-	 *      @type array|string $headers              The list of headers to send.
-	 *      @type array        $attachments          The list of attachments to send.
-	 *      @type string       $provider             The provider slug (rsvp, tpp, woo, edd).
-	 *      @type int          $post_id              The post/event ID to send the emails for.
-	 *      @type string|int   $order_id             The order ID to send the emails for.
-	 *      @type string|int   $ticket_sent_meta_key The meta key to use for marking an attendee ticket as sent.
+	 *      @type string       $subject     The email subject.
+	 *      @type string       $content     The email content.
+	 *      @type string       $from_name   The name to send tickets from.
+	 *      @type string       $from_email  The email to send tickets from.
+	 *      @type array|string $headers     The list of headers to send.
+	 *      @type array        $attachments The list of attachments to send.
+	 *      @type string       $provider    The provider slug (rsvp, tpp, woo, edd).
+	 *      @type int          $post_id     The post/event ID to send the emails for.
+	 *      @type string|int   $order_id    The order ID to send the emails for.
 	 * }
 	 *
 	 * @return int The number of emails sent successfully.
@@ -1104,11 +1103,10 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	public function send_tickets_email_for_attendees( $attendees, $args = [] ) {
 		$args = array_merge(
 			[
-				'subject'              => tribe_get_option( 'ticket-paypal-confirmation-email-subject', false ),
-				'from_name'            => tribe_get_option( 'ticket-paypal-confirmation-email-sender-name', false ),
-				'from_email'           => tribe_get_option( 'ticket-paypal-confirmation-email-sender-email', false ),
-				'provider'             => 'tpp',
-				'ticket_sent_meta_key' => $this->attendee_ticket_sent,
+				'subject'    => tribe_get_option( 'ticket-paypal-confirmation-email-subject', false ),
+				'from_name'  => tribe_get_option( 'ticket-paypal-confirmation-email-sender-name', false ),
+				'from_email' => tribe_get_option( 'ticket-paypal-confirmation-email-sender-email', false ),
+				'provider'   => 'tpp',
 			],
 			$args
 		);
@@ -2930,7 +2928,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		$optout      = get_post_meta( $attendee->ID, $this->attendee_optout_key, true );
 		$status      = get_post_meta( $attendee->ID, $this->attendee_tpp_key, true );
 		$user_id     = get_post_meta( $attendee->ID, $this->attendee_user_id, true );
-		$ticket_sent = (bool) get_post_meta( $attendee->ID, $this->attendee_ticket_sent, true );
+		$ticket_sent = (int) get_post_meta( $attendee->ID, $this->attendee_ticket_sent, true );
 
 		if ( empty( $product_id ) ) {
 			return false;

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1311,7 +1311,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		if ( $sent ) {
 			foreach ( $all_attendees as $attendee ) {
-				$this->update_ticket_sent_counter( $attendee['qr_ticket_id'], $this->attendee_ticket_sent );
+				$this->update_ticket_sent_counter( $attendee['qr_ticket_id'] );
 
 				$this->update_attendee_activity_log(
 					$attendee['attendee_id'],
@@ -2019,7 +2019,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$status       = get_post_meta( $attendee->ID, self::ATTENDEE_RSVP_KEY, true );
 		$status_label = $this->tickets_view->get_rsvp_options( $status );
 		$user_id      = get_post_meta( $attendee->ID, self::ATTENDEE_USER_ID, true );
-		$ticket_sent  = (bool) get_post_meta( $attendee->ID, self::ATTENDEE_TICKET_SENT, true );
+		$ticket_sent  = (int) get_post_meta( $attendee->ID, $this->attendee_ticket_sent, true );
 
 		if ( empty( $product_id ) ) {
 			return false;
@@ -2057,7 +2057,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 				'user_id'            => $user_id,
 				'ticket_sent'        => $ticket_sent,
 
-			// Fields for Email Tickets.
+				// Fields for Email Tickets.
 				'event_id'           => get_post_meta( $attendee->ID, self::ATTENDEE_EVENT_KEY, true ),
 				'ticket_name'        => ! empty( $product ) ? $product->post_title : false,
 				'holder_name'        => get_post_meta( $attendee->ID, $this->full_name, true ),

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2222,16 +2222,15 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param array $args      {
 		 *      The list of arguments to use for sending ticket emails.
 		 *
-		 *      @type string       $subject              The email subject.
-		 *      @type string       $content              The email content.
-		 *      @type string       $from_name            The name to send tickets from.
-		 *      @type string       $from_email           The email to send tickets from.
-		 *      @type array|string $headers              The list of headers to send.
-		 *      @type array        $attachments          The list of attachments to send.
-		 *      @type string       $provider             The provider slug (rsvp, tpp, woo, edd).
-		 *      @type int          $post_id              The post/event ID to send the emails for.
-		 *      @type string|int   $order_id             The order ID to send the emails for.
-		 *      @type string|int   $ticket_sent_meta_key The meta key to use for marking an attendee ticket as sent.
+		 *      @type string       $subject     The email subject.
+		 *      @type string       $content     The email content.
+		 *      @type string       $from_name   The name to send tickets from.
+		 *      @type string       $from_email  The email to send tickets from.
+		 *      @type array|string $headers     The list of headers to send.
+		 *      @type array        $attachments The list of attachments to send.
+		 *      @type string       $provider    The provider slug (rsvp, tpp, woo, edd).
+		 *      @type int          $post_id     The post/event ID to send the emails for.
+		 *      @type string|int   $order_id    The order ID to send the emails for.
 		 * }
 		 *
 		 * @return int The number of emails sent successfully.
@@ -2288,16 +2287,15 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param array  $args    {
 		 *      The list of arguments to use for sending ticket emails.
 		 *
-		 *      @type string       $subject              The email subject.
-		 *      @type string       $content              The email content.
-		 *      @type string       $from_name            The name to send tickets from.
-		 *      @type string       $from_email           The email to send tickets from.
-		 *      @type array|string $headers              The list of headers to send.
-		 *      @type array        $attachments          The list of attachments to send.
-		 *      @type string       $provider             The provider slug (rsvp, tpp, woo, edd).
-		 *      @type int          $post_id              The post/event ID to send the emails for.
-		 *      @type string|int   $order_id             The order ID to send the emails for.
-		 *      @type string|int   $ticket_sent_meta_key The meta key to use for marking an attendee ticket as sent.
+		 *      @type string       $subject     The email subject.
+		 *      @type string       $content     The email content.
+		 *      @type string       $from_name   The name to send tickets from.
+		 *      @type string       $from_email  The email to send tickets from.
+		 *      @type array|string $headers     The list of headers to send.
+		 *      @type array        $attachments The list of attachments to send.
+		 *      @type string       $provider    The provider slug (rsvp, tpp, woo, edd).
+		 *      @type int          $post_id     The post/event ID to send the emails for.
+		 *      @type string|int   $order_id    The order ID to send the emails for.
 		 * }
 		 *
 		 * @return bool Whether email was sent to attendees.
@@ -2309,33 +2307,31 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			}
 
 			$defaults = [
-				'subject'              => '',
-				'content'              => '',
-				'from_name'            => '',
-				'from_email'           => '',
-				'headers'              => [],
-				'attachments'          => [],
-				'provider'             => 'ticket',
-				'post_id'              => 0,
-				'order_id'             => '',
-				'ticket_sent_meta_key' => '',
-				'send_callback'        => 'wp_mail',
+				'subject'       => '',
+				'content'       => '',
+				'from_name'     => '',
+				'from_email'    => '',
+				'headers'       => [],
+				'attachments'   => [],
+				'provider'      => 'ticket',
+				'post_id'       => 0,
+				'order_id'      => '',
+				'send_callback' => 'wp_mail',
 			];
 
 			// Set up the default arguments.
 			$args = array_merge( $defaults, $args );
 
-			$subject              = trim( (string) $args['subject'] );
-			$content              = trim( (string) $args['content'] );
-			$from_name            = trim( (string) $args['from_name'] );
-			$from_email           = trim( (string) $args['from_email'] );
-			$headers              = $args['headers'];
-			$attachments          = $args['attachments'];
-			$provider             = $args['provider'];
-			$post_id              = $args['post_id'];
-			$order_id             = $args['order_id'];
-			$ticket_sent_meta_key = $args['ticket_sent_meta_key'];
-			$send_callback        = $args['send_callback'];
+			$subject       = trim( (string) $args['subject'] );
+			$content       = trim( (string) $args['content'] );
+			$from_name     = trim( (string) $args['from_name'] );
+			$from_email    = trim( (string) $args['from_email'] );
+			$headers       = $args['headers'];
+			$attachments   = $args['attachments'];
+			$provider      = $args['provider'];
+			$post_id       = $args['post_id'];
+			$order_id      = $args['order_id'];
+			$send_callback = $args['send_callback'];
 
 			// If invalid send callback, do not send the email.
 			if ( ! is_callable( $send_callback ) ) {
@@ -2573,7 +2569,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			if ( $sent ) {
 				// Mark attendee ticket email as being sent for each attendee ticket.
 				foreach ( $tickets as $attendee ) {
-					$this->update_ticket_sent_counter( $attendee['attendee_id'], $this->attendee_ticket_sent );
+					$this->update_ticket_sent_counter( $attendee['attendee_id'] );
 
 					$this->update_attendee_activity_log(
 						$attendee['attendee_id'],
@@ -2590,16 +2586,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		/**
-		 * Update the email sent counter for attendee by 1.
+		 * Update the email sent counter for attendee by increasing it +1.
 		 *
 		 * @since TBD
 		 *
-		 * @param int    $attendee_id Attendee ID.
-		 * @param string $meta_key Meta Key that stores the count.
+		 * @param int $attendee_id The attendee ID.
 		 */
-		public function update_ticket_sent_counter( $attendee_id, $meta_key ) {
-			$prev_val = (int) get_post_meta( $attendee_id, $meta_key, true );
-			update_post_meta( $attendee_id, $meta_key, $prev_val + 1 );
+		public function update_ticket_sent_counter( $attendee_id ) {
+			$prev_val = (int) get_post_meta( $attendee_id, $this->attendee_ticket_sent, true );
+
+			update_post_meta( $attendee_id, $this->attendee_ticket_sent, $prev_val + 1 );
 		}
 
 		/**

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -1,4 +1,7 @@
 <?php
+
+use Tribe__Utils__Array as Arr;
+
 /**
  * Handles most actions related to a Ticket or Multiple ones
  */
@@ -104,6 +107,8 @@ class Tribe__Tickets__Tickets_Handler {
 
 		add_filter( 'updated_postmeta', array( $this, 'update_meta_date' ), 15, 4 );
 		add_action( 'wp_insert_post', array( $this, 'update_start_date' ), 15, 3 );
+
+		add_filter( 'tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', [ $this, 'maybe_disable_email_resend' ], 9, 3 );
 	}
 
 	/**
@@ -1613,6 +1618,46 @@ class Tribe__Tickets__Tickets_Handler {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Maybe disable the email resend if the attendee has reached their max limit.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool         $allow_resending_email Whether to allow email resending.
+	 * @param WP_Post|null $ticket                The ticket post object if available, otherwise null.
+	 * @param array|null   $attendee              The attendee information if available, otherwise null.
+	 *
+	 * @return bool Whether to allow email resending.
+	 */
+	public function maybe_disable_email_resend( $allow_resending_email, $ticket = null, $attendee = null ) {
+		// Check if we have an attendee to reference or resending has been disabled already.
+		if ( ! is_array( $attendee ) || ! $allow_resending_email ) {
+			return $allow_resending_email;
+		}
+
+		$ticket_sent = (int) Arr::get( $attendee, 'ticket_sent', 0 );
+
+		/**
+		 * Allow filtering the maximum number of emails can be resent to an attendee.
+		 *
+		 * Return -1 to remove the limit entirely.
+		 *
+		 * @since TBD
+		 *
+		 * @param int          $max_resend_limit The maximum number of emails can be resent to an attendee.
+		 * @param WP_Post|null $ticket           The ticket post object if available, otherwise null.
+		 * @param array|null   $attendee         The attendee information if available, otherwise null.
+		 */
+		$max_resend_limit = apply_filters( 'tribe_tickets_handler_email_max_resend_limit', 2, $ticket, $attendee );
+
+		// Check if limit is unlimited or if the attendee has been at/sent below the current limit.
+		if ( -1 === $max_resend_limit || $ticket_sent <= $max_resend_limit ) {
+			return $allow_resending_email;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/views/tickets/orders.php
+++ b/src/views/tickets/orders.php
@@ -52,11 +52,14 @@ $tribe_my_tickets_have_meta = false;
 /**
  * This filter allows the admin to control the re-send email option when an attendee's email is updated.
  *
- * @param bool Defaults to `true`.
- *
  * @since 5.0.3
+ * @since TBD Updated the parameters to match what is used in Event Tickets Plus.
+ *
+ * @param bool         $allow_resending_email Whether to allow email resending.
+ * @param WP_Post|null $ticket                The ticket post object if available, otherwise null.
+ * @param array|null   $attendee              The attendee information if available, otherwise null.
  */
-$allow_resending_email = (int) apply_filters( 'tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true );
+$allow_resending_email = (int) apply_filters( 'tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, null, null );
 
 /**
  * Display a notice if the user doesn't have tickets


### PR DESCRIPTION
[ET-926]

This PR handles preventing spam by limiting how many email resends can happen per attendee.

This ensures that the ticket sent counter is provided for the attendee and that the counter is functioning as expected with reduced complexity.

[ET-926]: https://theeventscalendar.atlassian.net/browse/ET-926