### PR TITLE
[ETP-640] Update sales/stock for RSVPs

### DIFF
--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -1074,9 +1074,17 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 		// Maybe send the attendee email.
 		$this->maybe_send_attendee_email( $attendee->ID, $attendee_data );
 
-		// Clear the attendee cache if post_id is provided.
-		if ( ! empty( $this->updates['post_id'] ) && $this->attendee_provider ) {
-			$this->attendee_provider->clear_attendees_cache( $this->updates['post_id'] );
+		// Handle clearing the caches.
+		if ( $this->attendee_provider ) {
+			// Clear the attendee cache if post_id is provided.
+			if ( ! empty( $this->updates['post_id'] ) ) {
+				$this->attendee_provider->clear_attendees_cache( $this->updates['post_id'] );
+			}
+
+			// Clear the ticket cache if ticket is provided.
+			if ( $ticket ) {
+				$this->attendee_provider->clear_ticket_cache( $ticket->ID );
+			}
 		}
 	}
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2846,48 +2846,58 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	}
 
 	/**
-	 * Increases the sales for a ticket by an amount.
+	 * Increase the sales for a ticket by a specific quantity.
 	 *
 	 * @since 4.7
 	 * @since 4.10.2 added $shared_capacity and $global_stock parameter
 	 *
-	 * @param int         $ticket_id       The ticket post ID
-	 * @param int         $qty             the quanitity to modify stock
-	 * @param bool        $shared_capacity true or false if the ticket is using share capacity
-	 * @param object|null $global_stock    the object of Tribe__Tickets__Global_Stock or null
+	 * @param int                               $ticket_id       The ticket post ID.
+	 * @param int                               $quantity        The quanitity to increase the ticket sales by.
+	 * @param bool                              $shared_capacity Whether the ticket is using shared capacity.
+	 * @param Tribe__Tickets__Global_Stock|null $global_stock    The stock object or null.
 	 *
-	 * @return int
+	 * @return int The new sales amount.
 	 */
-	public function increase_ticket_sales_by( $ticket_id, $qty = 1, $shared_capacity = false, $global_stock = null ) {
-		$sales = (int) get_post_meta( $ticket_id, 'total_sales', true );
-		update_post_meta( $ticket_id, 'total_sales', $sales + $qty );
+	public function increase_ticket_sales_by( $ticket_id, $quantity = 1, $shared_capacity = false, $global_stock = null ) {
+		// Adjust sales.
+		$sales = (int) get_post_meta( $ticket_id, 'total_sales', true ) + $quantity;
+
+		update_post_meta( $ticket_id, 'total_sales', $sales );
 
 		if ( $shared_capacity && $global_stock instanceof Tribe__Tickets__Global_Stock ) {
-			$this->update_global_stock( $global_stock, $qty );
+			$this->update_global_stock( $global_stock, $quantity );
 		}
+
 		return $sales;
 	}
 
 	/**
-	 * Decreases the sales for a ticket by an amount.
+	 * Decrease the sales for a ticket by a specific quantity.
 	 *
 	 * @since 4.7
 	 * @since 4.10.2 added $shared_capacity and $global_stock parameter
 	 *
-	 * @param int         $ticket_id       The ticket post ID
-	 * @param int         $qty             the quanitity to modify stock
-	 * @param bool        $shared_capacity true or false if the ticket is using share capacity
-	 * @param object|null $global_stock    the object of Tribe__Tickets__Global_Stock or null
+	 * @param int                               $ticket_id       The ticket post ID.
+	 * @param int                               $quantity        The quanitity to increase the ticket sales by.
+	 * @param bool                              $shared_capacity Whether the ticket is using shared capacity.
+	 * @param Tribe__Tickets__Global_Stock|null $global_stock    The stock object or null.
 	 *
-	 * @return int
+	 * @return int The new sales amount.
 	 */
-	public function decrease_ticket_sales_by( $ticket_id, $qty = 1, $shared_capacity = false, $global_stock = null ) {
-		$sales = (int) get_post_meta( $ticket_id, 'total_sales', true );
-		update_post_meta( $ticket_id, 'total_sales', max( $sales - $qty, 0 ) );
+	public function decrease_ticket_sales_by( $ticket_id, $quantity = 1, $shared_capacity = false, $global_stock = null ) {
+		// Adjust sales.
+		$sales = (int) get_post_meta( $ticket_id, 'total_sales', true ) - $quantity;
+
+		// Prevent negatives.
+		$sales = max( $sales, 0 );
+
+		update_post_meta( $ticket_id, 'total_sales', $sales );
 
 		if ( $shared_capacity && $global_stock instanceof Tribe__Tickets__Global_Stock ) {
-			$this->update_global_stock( $global_stock, $qty, true );
+			$this->update_global_stock( $global_stock, $quantity, true );
 		}
+
+		return $sales;
 	}
 
 	/**
@@ -2900,8 +2910,8 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	 * @param bool                         $increase     Whether to increase stock, default is false.
 	 */
 	public function update_global_stock( $global_stock, $qty = 1, $increase = false ) {
-
 		$level = $global_stock->get_stock_level();
+
 		if ( $increase ) {
 			$new_level = (int) $level + (int) $qty;
 		} else {

--- a/src/Tribe/Repositories/Attendee/Commerce.php
+++ b/src/Tribe/Repositories/Attendee/Commerce.php
@@ -155,8 +155,6 @@ class Tribe__Tickets__Repositories__Attendee__Commerce extends Tribe__Tickets__A
 	 * @param Tribe__Tickets__Ticket_Object $ticket        The ticket object.
 	 */
 	public function trigger_create_actions( $attendee, $attendee_data, $ticket ) {
-		parent::trigger_create_actions( $attendee, $attendee_data, $ticket );
-
 		$attendee_id           = $attendee->ID;
 		$post_id               = Arr::get( $attendee_data, 'post_id' );
 		$order_id              = Arr::get( $attendee_data, 'order_id' );
@@ -195,6 +193,7 @@ class Tribe__Tickets__Repositories__Attendee__Commerce extends Tribe__Tickets__A
 		 */
 		do_action( 'event_tickets_tpp_attendee_updated', $attendee_id, $order_id, $product_id, $order_attendee_id, $attendee_order_status );
 
+		// Update the ticket sales numbers.
 		if ( $post_id ) {
 			$global_stock    = new Tribe__Tickets__Global_Stock( $post_id );
 			$shared_capacity = false;
@@ -203,17 +202,14 @@ class Tribe__Tickets__Repositories__Attendee__Commerce extends Tribe__Tickets__A
 				$shared_capacity = true;
 			}
 
-			switch ( $attendee_order_status ) {
-				case Tribe__Tickets__Commerce__PayPal__Stati::$completed:
-					$this->attendee_provider->increase_ticket_sales_by( $product_id, 1, $shared_capacity, $global_stock );
-					break;
-				case Tribe__Tickets__Commerce__PayPal__Stati::$refunded:
-					$this->attendee_provider->decrease_ticket_sales_by( $product_id, 1, $shared_capacity, $global_stock );
-					break;
-				default:
-					break;
+			if ( Tribe__Tickets__Commerce__PayPal__Stati::$completed === $attendee_order_status ) {
+				$this->attendee_provider->increase_ticket_sales_by( $product_id, 1, $shared_capacity, $global_stock );
+			} elseif ( Tribe__Tickets__Commerce__PayPal__Stati::$refunded === $attendee_order_status ) {
+				$this->attendee_provider->decrease_ticket_sales_by( $product_id, 1, $shared_capacity, $global_stock );
 			}
 		}
+
+		parent::trigger_create_actions( $attendee, $attendee_data, $ticket );
 	}
 
 	/**

--- a/src/Tribe/Repositories/Attendee/RSVP.php
+++ b/src/Tribe/Repositories/Attendee/RSVP.php
@@ -151,13 +151,12 @@ class Tribe__Tickets__Repositories__Attendee__RSVP extends Tribe__Tickets__Atten
 	 * @param Tribe__Tickets__Ticket_Object $ticket        The ticket object.
 	 */
 	public function trigger_create_actions( $attendee, $attendee_data, $ticket ) {
-		parent::trigger_create_actions( $attendee, $attendee_data, $ticket );
-
 		$attendee_id       = $attendee->ID;
 		$post_id           = Arr::get( $attendee_data, 'post_id' );
 		$order_id          = $attendee_data['order_id'];
 		$product_id        = $ticket->ID;
 		$order_attendee_id = Arr::get( $attendee_data, 'order_attendee_id' );
+		$attendee_status   = Arr::get( $attendee_data, 'attendee_status', 'yes' );
 
 		/**
 		 * RSVP specific action fired when a RSVP-driven attendee ticket for an event is generated.
@@ -191,6 +190,13 @@ class Tribe__Tickets__Repositories__Attendee__RSVP extends Tribe__Tickets__Atten
 			 */
 			do_action( 'event_tickets_rsvp_tickets_generated_for_product', $product_id, $order_id, 1 );
 		}
+
+		// Update the ticket sales numbers.
+		if ( $post_id && 'yes' === $attendee_status ) {
+			$this->attendee_provider->increase_ticket_sales_by( $product_id, 1 );
+		}
+
+		parent::trigger_create_actions( $attendee, $attendee_data, $ticket );
 	}
 
 	/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3429,6 +3429,35 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		/**
+		 * Clears the ticket cache for a given ticket ID.
+		 *
+		 * @since TBD
+		 *
+		 * @param int|object $ticket_id The ticket ID.
+		 */
+		public function clear_ticket_cache( $ticket_id ) {
+			if ( is_object( $ticket_id ) ) {
+				$ticket_id = $ticket_id->ID;
+			}
+
+			$methods = [
+				'Tribe__Tickets__Ticket_Object::is_in_stock',
+				'Tribe__Tickets__Ticket_Object::inventory',
+				'Tribe__Tickets__Ticket_Object::available',
+				'Tribe__Tickets__Ticket_Object::capacity',
+			];
+
+			/** @var Tribe__Cache $cache */
+			$cache = tribe( 'cache' );
+
+			foreach ( $methods as $method ) {
+				$key = $method . '-' . $ticket_id;
+
+				unset( $cache[ $key ] );
+			}
+		}
+
+		/**
 		 * Returns the action tag that should be used to print the front-end ticket form.
 		 *
 		 * This value is set in the Events > Settings > Tickets tab and is distinct between RSVP


### PR DESCRIPTION
[ETP-640]

Dev screencast: https://share.skc.dev/GGu60Ypn

This PR handles increasing/decreasing sales/stock for RSVPs in a more abstracted way.

The Attendees ORM now clears ticket cache properly.

The stock increase/decrease handling prevents negative numbers for sales and stock counts.

[ETP-640]: https://theeventscalendar.atlassian.net/browse/ETP-640