### PR TITLE
[ETP-487] [ETP-517] Add function to get active providers for a post

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -57,45 +57,42 @@ class Tribe__Tickets__Assets {
 			]
 		);
 
-		if (
-			tribe_tickets_new_views_is_enabled()
-			|| tribe_tickets_rsvp_new_views_is_enabled()
-		) {
-			// Tickets loader library JS.
-			tribe_asset(
-				$tickets_main,
-				'tribe-tickets-loader',
-				'v2/tickets-loader.js',
-				[
-					'jquery',
-					'tribe-common',
+		// Tickets loader library JS.
+		tribe_asset(
+			$tickets_main,
+			'tribe-tickets-loader',
+			'v2/tickets-loader.js',
+			[
+				'jquery',
+				'tribe-common',
+			],
+			null,
+			[
+				'conditionals' => [ $this, 'should_enqueue_tickets_loader' ],
+				'groups'       => [
+					'tribe-tickets-block-assets',
+					'tribe-tickets-rsvp',
+					'tribe-tickets-registration-page',
 				],
-				null,
-				[
-					'groups' => [
-						'tribe-tickets-block-assets',
-						'tribe-tickets-rsvp',
-						'tribe-tickets-registration-page',
-					],
-				]
-			);
+			]
+		);
 
-			// @todo: Remove this once we solve the common breakpoints vs container based.
-			tribe_asset(
-				$tickets_main,
-				'tribe-common-responsive',
-				'common-responsive.css',
-				[ 'tribe-common-skeleton-style' ],
-				null,
-				[
-					'groups' => [
-						'tribe-tickets-block-assets',
-						'tribe-tickets-rsvp',
-						'tribe-tickets-registration-page',
-					],
-				]
-			);
-		}
+		// @todo: Remove this once we solve the common breakpoints vs container based.
+		tribe_asset(
+			$tickets_main,
+			'tribe-common-responsive',
+			'common-responsive.css',
+			[ 'tribe-common-skeleton-style' ],
+			null,
+			[
+				'conditionals' => [ $this, 'should_enqueue_tickets_loader' ],
+				'groups'       => [
+					'tribe-tickets-block-assets',
+					'tribe-tickets-rsvp',
+					'tribe-tickets-registration-page',
+				],
+			]
+		);
 
 		if ( tribe_tickets_new_views_is_enabled() ) {
 			// Tribe tickets utils.
@@ -353,6 +350,27 @@ class Tribe__Tickets__Assets {
 		}
 
 		return $is_on_valid_post_type || $is_on_ar_page;
+	}
+
+	/**
+	 * Check if we should enqueue the new Tickets Loader script.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_enqueue_tickets_loader() {
+		$are_new_views_enabled = tribe_tickets_new_views_is_enabled()
+			|| tribe_tickets_rsvp_new_views_is_enabled();
+
+		/**
+		 * Allow filtering whether the Tickets Loader script be enqueued.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $should_enqueue_tickets_loader Whether the Tickets Loader script be enqueued.
+		 */
+		return (bool) apply_filters( 'tribe_tickets_assets_should_enqueue_tickets_loader', $are_new_views_enabled );
 	}
 
 	/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3650,12 +3650,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$tickets_orm->by( 'event', $post_id );
 
 				if ( 0 < $tickets_orm->found() ) {
-					$provider_class = $provider;
+					$provider_class = $provider->class_name;
 
 					// Check whether to return the provider class names.
 					if ( ! $return_instances ) {
-						$provider       = $provider->class_name;
-						$provider_class = $provider;
+						$provider = $provider_class;
 					}
 
 					$active_providers[ $provider_class ] = $provider;

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_regular_tickets_block__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_regular_tickets_block__1.php
@@ -28,7 +28,7 @@
 	Tickets</h2>
 
 		<div id="tribe-tickets__notice__tickets-in-cart"  class="tribe-tickets__notice tribe-tickets__notice--barred tribe-tickets__notice--barred-left" >
-	
+
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-common-b3" >
 		The numbers below include tickets for this event already in your cart. Clicking "Get Tickets" will allow you to edit any existing attendee information as well as change ticket quantities.	</div>
 </div>
@@ -52,7 +52,7 @@
 
 	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
 		<span class="tribe-tickets__tickets-sale-price">
-		
+
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
 					<span class="tribe-amount">99.00</span>
@@ -60,14 +60,14 @@
 						</span>
 </div>
 
-	
+
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-	
+
 	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-	
+
 </div>
 
 	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
@@ -75,13 +75,13 @@
 	Sold Out</div>
 	</div>
 
-	
+
 		<input
 		name="attendee[optout]"
 		value="1"
 		type="hidden"
 	/>
-	
+
 </div>
 <div
 	id="tribe-block-tickets-item-15"
@@ -102,7 +102,7 @@
 
 	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
 		<span class="tribe-tickets__tickets-sale-price">
-		
+
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
 					<span class="tribe-amount">99.00</span>
@@ -110,14 +110,14 @@
 						</span>
 </div>
 
-	
+
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-	
+
 	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-	
+
 </div>
 
 	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
@@ -125,18 +125,18 @@
 	Sold Out</div>
 	</div>
 
-	
+
 		<input
 		name="attendee[optout]"
 		value="1"
 		type="hidden"
 	/>
-	
+
 </div>
 
 		<div class="tribe-tickets__tickets-footer">
 
-	
+
 	<div class="tribe-common-b2 tribe-tickets__tickets-footer-quantity">
 	<span class="tribe-tickets__tickets-footer-quantity-label">
 		Quantity:	</span>
@@ -147,7 +147,7 @@
 	<span class="tribe-tickets__tickets-footer-total-label">
 		Total:	</span>
 	<span class="tribe-tickets__tickets-footer-total-wrap">
-		
+
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
 					<span class="tribe-amount">0.00</span>
@@ -164,8 +164,8 @@
 
 </div>
 
-		
-		<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
+
+		<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tribe-tickets__rsvp-message--success-icon" >
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>

--- a/tests/wpunit/Tribe/Tickets/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/TicketsTest.php
@@ -379,11 +379,11 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * It should allow getting the ticket provider for a post.
+	 * It should not get the ticket provider for a post with inactive provider.
 	 *
 	 * @test
 	 */
-	public function should_allow_getting_ticket_provider_object_for_post_with_inactive_provider() {
+	public function should_not_get_ticket_provider_object_for_post_with_inactive_provider() {
 		/** @var Tribe__Tickets__Tickets_Handler $tickets_handler */
 		$tickets_handler = tribe( 'tickets.handler' );
 
@@ -394,6 +394,74 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 		] );
 
 		$this->assertEquals( false, Tickets::get_event_ticket_provider_object( $post_id ) );
+	}
+
+	/**
+	 * It should get empty list of active providers for a post with tickets that have an inactive provider.
+	 *
+	 * @test
+	 */
+	public function should_get_empty_list_of_active_providers_for_a_post_with_tickets_that_have_an_inactive_provider() {
+		/** @var Tribe__Tickets__Tickets_Handler $tickets_handler */
+		$tickets_handler = tribe( 'tickets.handler' );
+
+		$post_id = $this->factory->post->create( [
+			'meta_input' => [
+				$tickets_handler->key_provider_field => 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main',
+			],
+		] );
+
+		$this->assertEquals( [], Tickets::get_active_providers_for_post( $post_id ) );
+	}
+
+	/**
+	 * It should get the list of active providers for a post with tickets that have an inactive provider.
+	 *
+	 * @test
+	 */
+	public function should_get_the_list_of_active_providers_for_a_post_with_tickets_that_have_an_inactive_provider() {
+		/** @var Tribe__Tickets__Tickets_Handler $tickets_handler */
+		$tickets_handler = tribe( 'tickets.handler' );
+
+		$post_id = $this->factory->post->create( [
+			'meta_input' => [
+				$tickets_handler->key_provider_field => 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main',
+			],
+		] );
+
+		$this->create_rsvp_ticket( $post_id );
+		$this->create_paypal_ticket( $post_id, 1 );
+
+		$this->assertEquals( [
+			'Tribe__Tickets__RSVP',
+			'Tribe__Tickets__Commerce__PayPal__Main',
+		], Tickets::get_active_providers_for_post( $post_id ) );
+	}
+
+	/**
+	 * It should get the list of active provider objects for a post with tickets that have an inactive provider.
+	 *
+	 * @test
+	 */
+	public function should_get_the_list_of_active_provider_objects_for_a_post_with_tickets_that_have_an_inactive_provider() {
+		/** @var Tribe__Tickets__Tickets_Handler $tickets_handler */
+		$tickets_handler = tribe( 'tickets.handler' );
+
+		$post_id = $this->factory->post->create( [
+			'meta_input' => [
+				$tickets_handler->key_provider_field => 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main',
+			],
+		] );
+
+		$this->create_rsvp_ticket( $post_id );
+		$this->create_paypal_ticket( $post_id, 1 );
+
+		$active_providers = array_keys( Tickets::get_active_providers_for_post( $post_id, true ) );
+
+		$this->assertEquals( [
+			'Tribe__Tickets__RSVP',
+			'Tribe__Tickets__Commerce__PayPal__Main',
+		], $active_providers );
 	}
 
 }

--- a/tests/wpunit/Tribe/Tickets/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/TicketsTest.php
@@ -433,8 +433,8 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 		$this->create_paypal_ticket( $post_id, 1 );
 
 		$this->assertEquals( [
-			'Tribe__Tickets__RSVP',
-			'Tribe__Tickets__Commerce__PayPal__Main',
+			'Tribe__Tickets__RSVP' => 'Tribe__Tickets__RSVP',
+			'Tribe__Tickets__Commerce__PayPal__Main' => 'Tribe__Tickets__Commerce__PayPal__Main',
 		], Tickets::get_active_providers_for_post( $post_id ) );
 	}
 
@@ -456,12 +456,15 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 		$this->create_rsvp_ticket( $post_id );
 		$this->create_paypal_ticket( $post_id, 1 );
 
-		$active_providers = array_keys( Tickets::get_active_providers_for_post( $post_id, true ) );
+		$active_providers = Tickets::get_active_providers_for_post( $post_id, true );
+		$active_provider_keys = array_keys( $active_providers );
 
 		$this->assertEquals( [
 			'Tribe__Tickets__RSVP',
 			'Tribe__Tickets__Commerce__PayPal__Main',
-		], $active_providers );
+		], $active_provider_keys );
+		$this->assertInstanceOf( $active_providers['Tribe__Tickets__RSVP'], 'Tribe__Tickets__RSVP' );
+		$this->assertInstanceOf( $active_providers['Tribe__Tickets__Commerce__PayPal__Main'], 'Tribe__Tickets__Commerce__PayPal__Main' );
 	}
 
 }

--- a/tests/wpunit/Tribe/Tickets/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/TicketsTest.php
@@ -463,8 +463,8 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 			'Tribe__Tickets__RSVP',
 			'Tribe__Tickets__Commerce__PayPal__Main',
 		], $active_provider_keys );
-		$this->assertInstanceOf( $active_providers['Tribe__Tickets__RSVP'], 'Tribe__Tickets__RSVP' );
-		$this->assertInstanceOf( $active_providers['Tribe__Tickets__Commerce__PayPal__Main'], 'Tribe__Tickets__Commerce__PayPal__Main' );
+		$this->assertInstanceOf( 'Tribe__Tickets__RSVP', $active_providers['Tribe__Tickets__RSVP'] );
+		$this->assertInstanceOf( 'Tribe__Tickets__Commerce__PayPal__Main', $active_providers['Tribe__Tickets__Commerce__PayPal__Main'] );
 	}
 
 }


### PR DESCRIPTION
[ETP-487]
[ETP-517]

Dev Screencast: https://share.skc.dev/5zuAADwN

This PR addresses a need by ET+ to only get providers for a post that are active. Other functions return the current provider set for a post but does not take into account whether it's active and available at the code level.

This PR also fixes a problem with the tribe-tickets-loader asset not being registered when it's needed by ET+ even when new rsvp/ticket views are not enabled.

[ETP-487]: https://theeventscalendar.atlassian.net/browse/ETP-487
[ETP-517]: https://theeventscalendar.atlassian.net/browse/ETP-517