### PR TITLE
[ET-1023] ET > Resolve restv1 tests and fix Tribe__Tickets__Ticket_Object caching problems

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,8 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Compatibility with WordPress 5.7 and jQuery 3.5.X [ET-992]
 * Fix - Prevent the Attendee Registration page from having the title coming from draft pages. [ETP-360]
 * Fix - Highlight the "Ticketed" and "Unticketed" filters in the WordPress when they're applied. [ET-1022]
+* Fix - Ensure ticket object caches return normally in all circumstances, preventing potential "Sold Out" messaging from happening in certain hosting environments.
+* Fix - Set the default `iac` argument value in the single ticket REST API endpoint to add tickets since it is an optional argument to be sent.
 * Tweak - Added new `Ticket Holder Name` and `Ticket Holder Email Address` columns to the Attendees Report export CSV file and update the previous `Customer` columns to label as `Purchaser`. [ETP-652]
 
 = [5.1.0] 2021-02-16 =

--- a/readme.txt
+++ b/readme.txt
@@ -181,7 +181,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Compatibility with WordPress 5.7 and jQuery 3.5.X [ET-992]
 * Fix - Prevent the Attendee Registration page from having the title coming from draft pages. [ETP-360]
 * Fix - Highlight the "Ticketed" and "Unticketed" filters in the WordPress when they're applied. [ET-1022]
-* Fix - Ensure ticket object caches return normally in all circumstances, preventing potential "Sold Out" messaging from happening in certain hosting environments.
+* Fix - Ensure ticket object caches return normally in all circumstances, preventing potential "Sold Out" messaging from happening in certain hosting environments. [ET-1023]
 * Fix - Set the default `iac` argument value in the single ticket REST API endpoint to add tickets since it is an optional argument to be sent.
 * Tweak - Added new `Ticket Holder Name` and `Ticket Holder Email Address` columns to the Attendees Report export CSV file and update the previous `Customer` columns to label as `Purchaser`. [ETP-652]
 

--- a/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
+++ b/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
@@ -216,7 +216,10 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 
 		// Merge the defaults to avoid usage of `empty` values
 		$body = array_merge(
-			[ 'tribe-ticket' => [] ],
+			[
+				'tribe-ticket' => [],
+				'iac'          => 'none',
+			],
 			$request->get_default_params(),
 			$request->get_body_params()
 		);

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -520,7 +520,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			$cache = tribe( 'cache' );
 			$key   = __METHOD__ . '-' . $this->ID;
 
-			if ( $this->is_ticket_cache_enabled() && ! empty( $cache[ $key ] ) ) {
+			if ( $this->is_ticket_cache_enabled() && false !== $cache[ $key ] ) {
 				return tribe_is_truthy( $cache[ $key ] );
 			}
 
@@ -572,7 +572,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			$cache = tribe( 'cache' );
 			$key   = __METHOD__ . '-' . $this->ID;
 
-			if ( $this->is_ticket_cache_enabled() && isset( $cache[ $key ] ) ) {
+			if ( $this->is_ticket_cache_enabled() && false !== $cache[ $key ] ) {
 				return $cache[ $key ];
 			}
 			// Fetch provider (also sets if found).
@@ -689,7 +689,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			$cache = tribe( 'cache' );
 			$key   = __METHOD__ . '-' . $this->ID;
 
-			if ( $this->is_ticket_cache_enabled() && isset( $cache[ $key ] ) ) {
+			if ( $this->is_ticket_cache_enabled() && false !== $cache[ $key ] ) {
 				return $cache[ $key ];
 			}
 
@@ -731,7 +731,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			$cache = tribe( 'cache' );
 			$key   = __METHOD__ . '-' . $this->ID;
 
-			if ( $this->is_ticket_cache_enabled() && isset( $cache[ $key ] ) ) {
+			if ( $this->is_ticket_cache_enabled() && false !== $cache[ $key ] ) {
 				return $cache[ $key ];
 			}
 

--- a/tests/_support/Commerce/PayPal/Ticket_Maker.php
+++ b/tests/_support/Commerce/PayPal/Ticket_Maker.php
@@ -141,7 +141,7 @@ trait Ticket_Maker {
 		update_post_meta( $post_id, $provider_key, 'Tribe__Tickets__Commerce__PayPal__Main' );
 
 		// Clear the cache.
-		tribe( $this->get_paypal_ticket_provider() )->clear_ticket_cache_for_post( $this->event_id );
+		tribe( $this->get_paypal_ticket_provider() )->clear_ticket_cache_for_post( $post_id );
 
 		return $ticket_id;
 	}

--- a/tests/restv1/PayPal/CartCest.php
+++ b/tests/restv1/PayPal/CartCest.php
@@ -77,6 +77,7 @@ class CartCest extends BaseRestCest {
 	/**
 	 * It should allow getting cart for post without post ID.
 	 *
+	 * @skip This isn't an endpoint we're using yet.
 	 * @test
 	 */
 	public function should_allow_getting_cart_for_post_without_post_id( Restv1Tester $I ) {
@@ -112,6 +113,7 @@ class CartCest extends BaseRestCest {
 					'quantity'  => 15,
 					'post_id'   => $first_post_id,
 					'optout'    => 1,
+					'iac'       => 'none',
 					'provider'  => 'tribe-commerce',
 				],
 				[
@@ -119,6 +121,7 @@ class CartCest extends BaseRestCest {
 					'quantity'  => 5,
 					'post_id'   => $first_post_id,
 					'optout'    => 1,
+					'iac'       => 'none',
 					'provider'  => 'tribe-commerce',
 				],
 			],

--- a/tests/restv1/PayPal/CartUpdateCest.php
+++ b/tests/restv1/PayPal/CartUpdateCest.php
@@ -66,6 +66,7 @@ class CartUpdateCest extends BaseRestCest {
 				'quantity'  => 15,
 				'post_id'   => $first_post_id,
 				'optout'    => 1,
+				'iac'       => 'none',
 				'provider'  => 'tribe-commerce',
 			],
 			[
@@ -73,6 +74,7 @@ class CartUpdateCest extends BaseRestCest {
 				'quantity'  => 5,
 				'post_id'   => $first_post_id,
 				'optout'    => 0,
+				'iac'       => 'none',
 				'provider'  => 'tribe-commerce',
 			],
 		], $response['tickets'] );
@@ -180,6 +182,7 @@ class CartUpdateCest extends BaseRestCest {
 				'quantity'  => 15,
 				'post_id'   => $first_post_id,
 				'optout'    => 1,
+				'iac'       => 'none',
 				'provider'  => 'tribe-commerce',
 			],
 			[
@@ -187,6 +190,7 @@ class CartUpdateCest extends BaseRestCest {
 				'quantity'  => 5,
 				'post_id'   => $first_post_id,
 				'optout'    => 0,
+				'iac'       => 'none',
 				'provider'  => 'tribe-commerce',
 			],
 		], $response['tickets'] );

--- a/tests/restv1/PayPal/TicketArchiveByPostCest.php
+++ b/tests/restv1/PayPal/TicketArchiveByPostCest.php
@@ -55,8 +55,6 @@ class TicketArchiveByPostCest extends BaseRestCest {
 
 		$post_id    = $I->havePostInDatabase();
 		$ticket_ids = $this->create_many_paypal_tickets_basic( 1, $post_id );
-		/** @var \Tribe__Tickets__REST__V1__Post_Repository $repository */
-		$repository = tribe( 'tickets.rest-v1.repository' );
 
 		$I->sendGET( $this->tickets_url, $params );
 		$I->seeResponseIsJson();
@@ -72,12 +70,14 @@ class TicketArchiveByPostCest extends BaseRestCest {
 		$post_id           = $I->havePostInDatabase();
 		$public_ticket_ids = $this->create_many_paypal_tickets_basic( 2, $post_id );
 		$draft_ticket_ids  = $this->create_many_paypal_tickets_basic( 2, $post_id, [ 'post_status' => 'draft' ] );
+
 		/** @var \Tribe__Tickets__REST__V1__Post_Repository $repository */
 		$repository = tribe( 'tickets.rest-v1.repository' );
 
 		$I->sendGET( $this->tickets_url, [ 'include_post' => $post_id ] );
 		$I->seeResponseIsJson();
 		$I->seeResponseCodeIs( 200 );
+
 		$response         = json_decode( $I->grabResponse(), true );
 		$expected_tickets = array_map( function ( $ticket_id ) use ( $repository ) {
 			return $repository->get_ticket_data( $ticket_id );
@@ -99,6 +99,7 @@ class TicketArchiveByPostCest extends BaseRestCest {
 		$I->sendGET( $this->tickets_url, [ 'include_post' => $post_id ] );
 		$I->seeResponseIsJson();
 		$I->seeResponseCodeIs( 200 );
+
 		$response         = json_decode( $I->grabResponse(), true );
 		$expected_tickets = array_map( function ( $ticket_id ) use ( $repository ) {
 			return $repository->get_ticket_data( $ticket_id );


### PR DESCRIPTION
[ET-1023]

This PR implements the caching work from common https://github.com/the-events-calendar/tribe-common/pull/1553 and addresses three areas:

* `Tribe__Tickets__Ticket_Object` now correctly checks against `false` values instead of `isset()` for whether a cached key has a proper value to return.
* Set default `'iac'` value to `'none'` when adding a ticket from REST API since the value is optional in the REST API interface.
* Fixed restv1 tests so they pass and skipped some that are for future Tribe Commerce cart expansion.

[ET-1023]: https://theeventscalendar.atlassian.net/browse/ET-1023