### PR TITLE
[ETP-639] Set local vars for ticket template to fix showing same ticket for all posts within Query loop

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Compatibility with WordPress 5.7 and jQuery 3.5.X [ET-992]
 * Fix - Prevent the Attendee Registration page from having the title coming from draft pages. [ETP-360]
 * Fix - Highlight the "Ticketed" and "Unticketed" filters in the WordPress when they're applied. [ET-1022]
+* Fix - Prevent duplicate tickets from showing in post loops. [ETP-639]
 * Tweak - Added new `Ticket Holder Name` and `Ticket Holder Email Address` columns to the Attendees Report export CSV file and update the previous `Customer` columns to label as `Purchaser`. [ETP-652]
 
 = [5.1.0] 2021-02-16 =

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1099,6 +1099,9 @@ class Tribe__Tickets__Tickets_View {
 		 */
 		$template->add_template_globals( $args );
 
+		// Add local vars to ensure that the data is passed properly within WP_Query Loop.
+		$template->set_values( $args, true );
+
 		// Enqueue assets.
 		tribe_asset_enqueue_group( 'tribe-tickets-block-assets' );
 


### PR DESCRIPTION
[ETP-639]

Before the fix, within any WP Query loop like the posts loop, the first ticket was shown for all posts:

<img width="561" alt="Screen Shot 2021-02-25 at 10 10 11 PM" src="https://user-images.githubusercontent.com/7523321/109181724-73791380-77b6-11eb-87dd-aebc89d08173.png">

After the fix, it is now showing the associated Ticket for each post:

<img width="641" alt="Screen Shot 2021-02-25 at 10 09 39 PM" src="https://user-images.githubusercontent.com/7523321/109181758-7d9b1200-77b6-11eb-8317-f636b41707b3.png">



[ETP-639]: https://theeventscalendar.atlassian.net/browse/ETP-639