### PR TITLE
[ET-1042] Disable creating users by default for new attendees

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.1.1] 2021-03-04 =
 
 * Fix - Compatibility with WordPress 5.7 and jQuery 3.5.X [ET-992]
+* Fix - Attendees will no longer have a new user created (if they did not already exist), which was introduced in Event Tickets 5.1.0. To turn this on, you can simply add the filter `add_filter( 'tribe_tickets_attendee_create_user_from_email', '__return_true' );`
 * Fix - Prevent the Attendee Registration page from having the title coming from draft pages. [ETP-360]
 * Fix - Highlight the "Ticketed" and "Unticketed" filters in the WordPress when they're applied. [ET-1022]
 * Fix - Prevent duplicate tickets from showing in post loops. [ETP-639]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -4033,7 +4033,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			}
 
 			$lookup_user_from_email = Arr::get( $args, 'use_existing_user', true );
-			$create_user_from_email = Arr::get( $args, 'create_user', true );
+			$create_user_from_email = Arr::get( $args, 'create_user', false );
 			$send_new_user_info     = Arr::get( $args, 'send_email', false );
 
 			/**


### PR DESCRIPTION
[ET-1042]

This PR disables creating new users for new attendees.

[ET-1042]: https://theeventscalendar.atlassian.net/browse/ET-1042