### PR TITLE
[ET-959] Adjusted banner content area

### DIFF
--- a/src/resources/postcss/tickets-admin-settings.pcss
+++ b/src/resources/postcss/tickets-admin-settings.pcss
@@ -12,13 +12,13 @@
 	}
 
 	p.event-tickets__admin-banner-help-text {
-		max-width: 660px;
+		max-width: 690px;
 	}
 }
 
 .event-tickets__admin-banner-help-links-wrapper {
 	display: flex;
-	max-width: 660px;
+	max-width: 690px;
 
 	div {
 		min-width: 50%;


### PR DESCRIPTION
[ET-959]

Screenshot:
<img width="1270" alt="Screen Shot 2021-03-25 at 3 07 45 AM" src="https://user-images.githubusercontent.com/7523321/112383410-479a7080-8d17-11eb-857e-b1ac926ef6b6.png">


[ET-959]: https://theeventscalendar.atlassian.net/browse/ET-959