### PR TITLE
[ET-1078] Blocks > Fix RSVP & Tickets block description

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-dom": "16.3.0",
     "react-google-maps": "^9.4.5",
     "react-input-autosize": "^2.2.1",
+    "react-textarea-autosize": "^8.3.2",
     "react-places-autocomplete": "^6.1.2",
     "react-redux": "^5.0.7",
     "react-scroll-to": "^1.2.2",

--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.3] TBD =
 
-* Fix - Fixed an issue where long descriptions were breaking the block for the Tickets and RSVP blocks. It's now using auto-size textarea. [ET-1078]
+* Fix - Fixed an issue with Tickets and RSVP blocks where long descriptions were breaking the block. They now use an auto-resizing textarea. [ET-1078]
 
 = [5.1.2.1] 2021-03-30 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.3] TBD =
 
-
+* Fix - Fixed an issue where long descriptions were breaking the block for the Tickets and RSVP blocks. It's now using auto-size textarea. [ET-1078]
 
 = [5.1.2.1] 2021-03-30 =
 

--- a/src/modules/blocks/rsvp/container-header/style.pcss
+++ b/src/modules/blocks/rsvp/container-header/style.pcss
@@ -14,7 +14,7 @@
 .tribe-editor__rsvp .tribe-editor__rsvp-container {
 
 	.tribe-editor__rsvp-container-header__title {
-		color: #000000;
+		color: #141827;
 		margin: 0;
 		padding-top: 3px;
 		font-weight: bold;
@@ -94,39 +94,40 @@
 .tribe-editor__rsvp {
 
 	.tribe-editor__rsvp-container-header__description-input {
-		/* !important required to override styles from react-input-autosize */
-		display: flex !important;
-		padding-top: 7px;
+		display: flex;
+		width: 95%;
+		background-color: transparent;
+		color: #5d5d5d;
+		margin: 0;
+		padding: 0;
+		border: none;
+		font-family: 'Helvetica Neue', Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
+		font-size: 12px;
+		line-height: 18px;
+		letter-spacing: 0.04px;
+		max-height: 108px;
+
+		font-size: 12px;
+		line-height: 1.38;
+
+		&:hover,
+		&:focus {
+			background-color: transparent;
+			box-shadow: none;
+		}
+
+		&:disabled {
+
+			&,
+			&:hover,
+			&:focus {
+				background-color: transparent;
+				color: #AEB4BB;
+			}
+		}
 
 		& > * {
 			flex: none;
-		}
-
-		& > input {
-			background-color: transparent;
-			color: #545D66;
-			margin: 0;
-			padding: 0;
-			border: none;
-			font-family: 'Helvetica Neue', Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
-			font-size: 12px;
-			line-height: 18px;
-			letter-spacing: 0.04px;
-
-			&:hover,
-			&:focus {
-				background-color: #FFFFFF;
-			}
-
-			&:disabled {
-
-				&,
-				&:hover,
-				&:focus {
-					background-color: transparent;
-					color: #AEB4BB;
-				}
-			}
 		}
 	}
 }

--- a/src/modules/blocks/rsvp/container-header/style.pcss
+++ b/src/modules/blocks/rsvp/container-header/style.pcss
@@ -107,9 +107,6 @@
 		letter-spacing: 0.04px;
 		max-height: 108px;
 
-		font-size: 12px;
-		line-height: 1.38;
-
 		&:hover,
 		&:focus {
 			background-color: transparent;

--- a/src/modules/blocks/rsvp/container-header/template.js
+++ b/src/modules/blocks/rsvp/container-header/template.js
@@ -4,6 +4,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import AutosizeInput from 'react-input-autosize';
+import TextareaAutosize from 'react-textarea-autosize';
 
 /**
  * WordPress dependencies
@@ -63,10 +64,10 @@ const getDescription = (
 ) => (
 	isSelected
 		? (
-			<AutosizeInput
+			<TextareaAutosize
 				className="tribe-editor__rsvp-container-header__description-input"
 				value={ tempDescription }
-				placeholder={ __( 'description', 'event-tickets' ) }
+				placeholder={ __( 'RSVP description', 'event-tickets' ) }
 				onChange={ onTempDescriptionChange }
 				disabled={ isDisabled }
 			/>

--- a/src/modules/blocks/ticket/container-content/advanced-options/move-delete/style.pcss
+++ b/src/modules/blocks/ticket/container-content/advanced-options/move-delete/style.pcss
@@ -3,7 +3,6 @@
 
 	& > button {
 		font-size: 15px !important;
-		letter-spacing: .38px;
 		line-height: 18px;
 		padding: 0;
 
@@ -18,7 +17,7 @@
 		}
 
 		&:last-child {
-			color: red;
+			color: #da394d;
 		}
 	}
 }

--- a/src/modules/blocks/ticket/container-header/description/style.pcss
+++ b/src/modules/blocks/ticket/container-header/description/style.pcss
@@ -16,26 +16,29 @@
 
 	.tribe-editor__ticket__container-header-description-input {
 		/* !important required to override styles from react-input-autosize */
-		display: flex !important;
-		padding-top: 7px;
+		display: flex;
+		background-color: transparent;
+		color: #545D66;
+		margin: 0;
+		padding: 0;
+		border: none;
+		font-size: 12px;
+		max-height: 108px;
+		line-height: 18px;
+		letter-spacing: 0.04px;
+		width: 100%;
+
+		&:disabled {
+			color: #AEB4BB;
+		}
+
+		&:focus {
+			box-shadow: none;
+			outline: none;
+		}
 
 		& > * {
 			flex: none;
-		}
-
-		& > input {
-			background-color: transparent;
-			color: #545D66;
-			margin: 0;
-			padding: 0;
-			border: none;
-			font-size: 12px;
-			line-height: 18px;
-			letter-spacing: 0.04px;
-
-			&:disabled {
-				color: #AEB4BB;
-			}
 		}
 	}
 }

--- a/src/modules/blocks/ticket/container-header/description/style.pcss
+++ b/src/modules/blocks/ticket/container-header/description/style.pcss
@@ -15,7 +15,6 @@
 .tribe-editor__ticket {
 
 	.tribe-editor__ticket__container-header-description-input {
-		/* !important required to override styles from react-input-autosize */
 		display: flex;
 		background-color: transparent;
 		color: #545D66;
@@ -32,6 +31,7 @@
 			color: #AEB4BB;
 		}
 
+		&:hover,
 		&:focus {
 			box-shadow: none;
 			outline: none;

--- a/src/modules/blocks/ticket/container-header/description/template.js
+++ b/src/modules/blocks/ticket/container-header/description/template.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import AutosizeInput from 'react-input-autosize';
+import TextareaAutosize from 'react-textarea-autosize';
 
 /**
  * Wordpress dependencies
@@ -24,7 +24,7 @@ const TicketContainerHeaderDescription = ( {
 } ) => (
 	isSelected
 		? (
-			<AutosizeInput
+			<TextareaAutosize
 				className="tribe-editor__ticket__container-header-description-input"
 				value={ tempDescription }
 				placeholder={ __( 'Description', 'event-tickets' ) }

--- a/src/modules/blocks/ticket/container-header/price/style.pcss
+++ b/src/modules/blocks/ticket/container-header/price/style.pcss
@@ -1,7 +1,7 @@
 .tribe-editor__ticket__container-header-price {
 	flex: none;
 	min-width: 65px;
-	color: #000000;
+	color: #141827;
 	margin: 0 20px 0 15px;
 	padding-bottom: 5px;
 	font-weight: bold;
@@ -23,7 +23,7 @@
 
 	& > input[type=number] {
 		background-color: transparent;
-		color: #000000;
+		color: #141827;
 		margin: 0;
 		padding: 0;
 		border: none;

--- a/src/modules/blocks/ticket/container-header/title/style.pcss
+++ b/src/modules/blocks/ticket/container-header/title/style.pcss
@@ -32,7 +32,7 @@
 	.tribe-editor__ticket__container-header-title-label {
 		flex: none;
 		max-width: calc(100% - 28px);
-		color: #000000;
+		color: #141827;
 		margin: 0;
 		padding-top: 3px;
 		font-weight: bold;

--- a/src/modules/elements/container-panel/style.pcss
+++ b/src/modules/elements/container-panel/style.pcss
@@ -12,6 +12,7 @@
 
 .tribe-editor__container-panel__icon {
 	flex: none;
+	text-align: center;
 
 	.tribe-editor__container-panel--rsvp & {
 		width: 100px;
@@ -19,7 +20,7 @@
 	}
 
 	.tribe-editor__container-panel--ticket & {
-		width: 68px;
+		width: 100px;
 		padding: 25px 4px;
 		background-color: #F8F9F9;
 	}
@@ -39,7 +40,7 @@
 
 	.tribe-editor__container-panel--ticket & {
 		flex: none;
-		width: calc(100% - 68px);
+		width: calc(100% - 100px);
 		padding: 30px 25px;
 	}
 }

--- a/src/modules/elements/inactive-block/style.pcss
+++ b/src/modules/elements/inactive-block/style.pcss
@@ -13,8 +13,8 @@
 	}
 
 	.tribe-editor__inactive-block--ticket & {
-		width: 68px;
-		padding: 25px 0 25px 12px;
+		width: 100px;
+		padding: 25px 20px 20px;
 	}
 }
 

--- a/src/modules/elements/settings-dashboard/style.pcss
+++ b/src/modules/elements/settings-dashboard/style.pcss
@@ -39,7 +39,7 @@
 }
 
 .tribe-editor__settings-dashboard__header-left-text {
-	color: #000000;
+	color: #141827;
 }
 
 .tribe-editor__settings-dashboard__close-button {


### PR DESCRIPTION
### 🎫 Ticket

[ET-1078] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Switching the tickets and RSVP blocks to have an autosize textarea so it doesn't break the block when using long descriptions.
- Few aesthetics amendments (i.e.: using the design system black)

### 🎥 Artifacts <!-- if applicable-->

https://www.loom.com/share/6c943f7a82034284b134eef49551054a

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1078]: https://theeventscalendar.atlassian.net/browse/ET-1078