### PR TITLE
[ET-1056] Add translation support for going/not going status labels

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.3] TBD =
 
-
+* Fix - Added translation support for "Going" and "Not going" status labels. [ET-1056]
 
 = [5.1.2.1] 2021-03-30 =
 

--- a/src/Tribe/RSVP/Status/Going.php
+++ b/src/Tribe/RSVP/Status/Going.php
@@ -10,7 +10,7 @@
 class Tribe__Tickets__RSVP__Status__Going extends Tribe__Tickets__Status__Abstract {
 
 	//Order fulfilled and complete – requires no further action
-	public $name          = 'Going';
+	public $name;
 	public $provider_name = 'yes';
 	public $post_type     = 'tribe_rsvp_attendees';
 
@@ -22,5 +22,12 @@ class Tribe__Tickets__RSVP__Status__Going extends Tribe__Tickets__Status__Abstra
 	public $count_sales         = true;
 	public $count_completed     = true;
 
-
+	/**
+	 * Tribe__Tickets__RSVP__Status__Going constructor.
+	 *
+	 * @since TBD
+	 */
+	public function __construct() {
+		$this->name = __( 'Going', 'event-tickets' );
+	}
 }

--- a/src/Tribe/RSVP/Status/Not_Going.php
+++ b/src/Tribe/RSVP/Status/Not_Going.php
@@ -10,10 +10,19 @@
 class Tribe__Tickets__RSVP__Status__Not_Going extends Tribe__Tickets__Status__Abstract {
 
 	//Cancelled by an admin or the customer – no further action required (Cancelling an order does not affect stock quantity by default)
-	public $name          = 'Not going';
+	public $name;
 	public $provider_name = 'no';
 	public $post_type     = 'tribe_rsvp_attendees';
 
 	public $count_not_going = true;
+
+	/**
+	 * Tribe__Tickets__RSVP__Status__Not_Going constructor.
+	 *
+	 * @since TBD
+	 */
+	public function __construct() {
+		$this->name = __( 'Not going', 'event-tickets' );
+	}
 
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1056] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
On the My Tickets page, there is a selection of Going vs Not Going status which were not translation supported before: https://d.pr/i/Fggxqp

Now they should support translations.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
N/A

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1056]: https://theeventscalendar.atlassian.net/browse/ET-1056