### PR TITLE
[ET-1079] Add Attendees nav button on Admin bar

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.3] TBD =
 
-* Tweak - New nav button added on WP Admin bar for direct link to Attendee Report page. [ET-1079]
+* Tweak - Introduce a new "Attendees" link to the WP Admin bar which can take you directly to the Attendees Report page. [ET-1079]
 
 = [5.1.2.1] 2021-03-30 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.3] TBD =
 
-
+* Tweak - New nav button added on WP Admin bar for direct link to Attendee Report page. [ET-1079]
 
 = [5.1.2.1] 2021-03-30 =
 

--- a/src/Tribe/Admin/Manager/Service_Provider.php
+++ b/src/Tribe/Admin/Manager/Service_Provider.php
@@ -135,7 +135,7 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 			return;
 		}
 
-		// If not is Admin Edit page Or not in front-end single view page, bail out.
+		// If this is not the Admin Edit page or not the singular frontend view, bail out.
 		if (
 			! ( is_admin() && 'edit' == tribe_get_request_var( 'action' ) )
 			&& ! is_single()
@@ -166,7 +166,7 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 		$wp_admin_bar->add_menu(
 			[
 				'id'    => 'event-tickets-attendees',
-				'title' => '<i class="ab-icon dashicons dashicons-groups"></i> ' . __( 'Attendees', 'event-tickets' ),
+				'title' => '<i class="ab-icon dashicons dashicons-groups"></i> ' . esc_html__( 'Attendees', 'event-tickets' ),
 				'href'  => $url,
 				'meta' => [
 					'title' => __( 'Manage attendees', 'event-tickets' ),

--- a/src/Tribe/Admin/Manager/Service_Provider.php
+++ b/src/Tribe/Admin/Manager/Service_Provider.php
@@ -30,7 +30,7 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 	 */
 	protected function hooks() {
 
-		add_action( 'admin_bar_menu', [ $this, 'add_attendees_view_button' ], 99 );
+		add_action( 'wp_before_admin_bar_render', [ $this, 'add_attendees_view_button' ], 20 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -125,10 +125,8 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 	 * Add the Attendee Report nav button to WP Admin Nav bar.
 	 *
 	 * @since TBD
-	 *
-	 * @param \WP_Admin_Bar $admin_bar WP_Admin_Bar instance, passed by reference.
 	 */
-	public function add_attendees_view_button( $admin_bar ) {
+	public function add_attendees_view_button() {
 
 		$url     = '';
 		$post_id = 0;
@@ -170,8 +168,10 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 			return;
 		}
 
+		global $wp_admin_bar;
+
 		// Add the Nav button node to nav menu.
-		$admin_bar->add_menu(
+		$wp_admin_bar->add_menu(
 			[
 				'id'    => 'event-tickets-attendees',
 				'title' => '<i class="ab-icon dashicons dashicons-groups"></i> ' . __( 'Attendees', 'event-tickets' ),

--- a/src/Tribe/Admin/Manager/Service_Provider.php
+++ b/src/Tribe/Admin/Manager/Service_Provider.php
@@ -128,6 +128,11 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 	 */
 	public function add_attendees_view_button() {
 
+		// Check user permission.
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
 		$url     = '';
 		$post_id = 0;
 

--- a/src/Tribe/Admin/Manager/Service_Provider.php
+++ b/src/Tribe/Admin/Manager/Service_Provider.php
@@ -136,24 +136,19 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 		$url     = '';
 		$post_id = 0;
 
-		// Set the URL for WP Admin.
-		if ( is_admin() && 'edit' == tribe_get_request_var( 'action' ) ) {
-			$post_id = tribe_get_request_var( 'post' );
+		// If not is Admin Edit page Or not in front-end single view page, bail out.
+		if (
+			! ( is_admin() && 'edit' == tribe_get_request_var( 'action' ) )
+			&& ! is_single()
+		) {
+			return;
 		}
 
-		// Set the URL for Front-end.
-		if ( is_single() ) {
-			$post = get_post();
-
-			if ( empty( $post ) ) {
-				return;
-			}
-
-			$post_id = $post->ID;
-		}
+		$post    = get_post();
+		$post_id = $post ? $post->ID : 0;
 
 		// If no valid post is found, bail out.
-		if ( 0 == $post_id ) {
+		if ( 0 === $post_id ) {
 			return;
 		}
 

--- a/src/Tribe/Admin/Manager/Service_Provider.php
+++ b/src/Tribe/Admin/Manager/Service_Provider.php
@@ -128,13 +128,12 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 	 */
 	public function add_attendees_view_button() {
 
+		global $wp_admin_bar;
+
 		// Check user permission.
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return;
 		}
-
-		$url     = '';
-		$post_id = 0;
 
 		// If not is Admin Edit page Or not in front-end single view page, bail out.
 		if (
@@ -161,14 +160,7 @@ class Service_Provider extends tad_DI52_ServiceProvider {
 
 		/** @var \Tribe__Tickets__Attendees $tickets_attendees */
 		$tickets_attendees = tribe( 'tickets.attendees' );
-		$url               = $tickets_attendees->get_report_link( get_post( $post_id ) );
-
-		// If the URL is not set, don't show the button.
-		if ( empty( $url ) ) {
-			return;
-		}
-
-		global $wp_admin_bar;
+		$url               = $tickets_attendees->get_report_link( $post );
 
 		// Add the Nav button node to nav menu.
 		$wp_admin_bar->add_menu(


### PR DESCRIPTION
### 🎫 Ticket

[ET-1079] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Show a Nav button in the WP Admin bar linking to the Attendee Reports Page.
* If Admin view -> It's only shown on the Event/Post type Editor view.
* For frontend -> It's only shown if the current page is a single view page.
* In both cases, it should be shown only if the Event/Post has any tickets.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥  https://d.pr/v/ajByTQ
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1079]: https://theeventscalendar.atlassian.net/browse/ET-1079