### PR TITLE
[ET-984] moved check in button to new template and added disabled attribute

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.3] TBD =
 
-
+* Fix - Disabled check-in for RSVPs with 'Not Going' status. [ET-984]
 
 = [5.1.2.1] 2021-03-30 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Add TwentyTwentyOne theme compatibility for Tickets and RSVPs. [ET-1047]
 * Fix - Added translation support for "Going" and "Not going" status labels. [ET-1056]
+* Fix - Disabled check-in for RSVP with "Not Going" status. [ET-984]
 * Fix - Fixed an issue with Tickets and RSVP blocks where long descriptions were breaking the block. They now use an auto-resizing textarea. [ET-1078]
 * Tweak - Introduce a new "Attendees" link to the WP Admin bar which can take you directly to the Attendees Report page. [ET-1079]
 * Tweak - Added the new `tribe_tickets_attendees_csv_export_delimiter` filter to allow changing the delimiter used when generating a CSV export of attendees. [ET-1055]

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -494,14 +494,11 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			return sprintf( $button_template, $item['order_id_link_src'], __( 'View order', 'event-tickets' ) );
 		}
 
-		$disabled_class = ! empty( $item['order_status'] ) && in_array( $item['order_status'], $check_in_stati ) ?
-			'' : 'button-disabled';
-
 		$context = [
 			'item'           => $item,
 			'attendee_table' => $this,
 			'provider'       => $provider,
-			'disabled_class' => $disabled_class,
+			'disable_checkin' => ! empty( $item['order_status'] ) && in_array( $item['order_status'], $check_in_stati, true ),
  		];
 
 		/** @var Tribe__Tickets__Admin__Views $admin_views */

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -494,50 +494,20 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			return sprintf( $button_template, $item['order_id_link_src'], __( 'View order', 'event-tickets' ) );
 		}
 
-		$button_classes = ! empty( $item['order_status'] ) && in_array( $item['order_status'], $check_in_stati ) ?
+		$disabled_class = ! empty( $item['order_status'] ) && in_array( $item['order_status'], $check_in_stati ) ?
 			'' : 'button-disabled';
 
-		if ( empty( $this->event ) ) {
-			$checkin   = sprintf(
-				'<button data-attendee-id="%d" data-provider="%s" class="%s tickets_checkin">%s</button>',
-				esc_attr( $item['attendee_id'] ),
-				esc_attr( $provider ),
-				esc_attr( $button_classes ),
-				esc_html__( 'Check In', 'event-tickets' )
-			);
-			$uncheckin = sprintf(
-				'<span class="delete"><button data-attendee-id="%d" data-provider="%s" class="tickets_uncheckin">%s</button></span>',
-				esc_attr( $item['attendee_id'] ),
-				esc_attr( $provider ),
-				sprintf(
-					'<div>%1$s</div><div>%2$s</div>',
-					esc_html__( 'Undo', 'event-tickets' ),
-					esc_html__( 'Check In', 'event-tickets' )
-				)
-			);
-		} else {
-			// add the additional `data-event-id` attribute if this is an event
-			$checkin   = sprintf(
-				'<button data-attendee-id="%d" data-event-id="%d" data-provider="%s" class="button-primary %s tickets_checkin">%s</button>',
-				esc_attr( $item['attendee_id'] ),
-				esc_attr( $this->event->ID ),
-				esc_attr( $provider ),
-				esc_attr( $button_classes ),
-				esc_html__( 'Check In', 'event-tickets' )
-			);
-			$uncheckin = sprintf(
-				'<span class="delete"><button data-attendee-id="%d" data-event-id="%d" data-provider="%s" class="button-secondary tickets_uncheckin">%s</button></span>',
-				esc_attr( $item['attendee_id'] ),
-				esc_attr( $this->event->ID ), esc_attr( $provider ),
-				sprintf(
-					'%1$s %2$s',
-					esc_html__( 'Undo', 'event-tickets' ),
-					esc_html__( 'Check In', 'event-tickets' )
-				)
-			);
-		}
+		$context = [
+			'item'           => $item,
+			'attendee_table' => $this,
+			'provider'       => $provider,
+			'disabled_class' => $disabled_class,
+ 		];
 
-		return $checkin . $uncheckin;
+		/** @var Tribe__Tickets__Admin__Views $admin_views */
+		$admin_views = tribe( 'tickets.admin.views' );
+
+		$admin_views->template( 'attendees-table/check-in-button', $context );
 	}
 
 	/**

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -495,9 +495,9 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		}
 
 		$context = [
-			'item'           => $item,
-			'attendee_table' => $this,
-			'provider'       => $provider,
+			'item'            => $item,
+			'attendee_table'  => $this,
+			'provider'        => $provider,
 			'disable_checkin' => ! empty( $item['order_status'] ) && in_array( $item['order_status'], $check_in_stati, true ),
  		];
 

--- a/src/admin-views/attendees-table/check-in-button.php
+++ b/src/admin-views/attendees-table/check-in-button.php
@@ -10,7 +10,7 @@
  * @var bool $disable_checkin Whether check-in is disabled.
  */
 
-$data_event_id  = $attendee_table->event ? 'data-event-id="' . $attendee_table->event->ID . '"' : '';
+$data_event_id  = $attendee_table->event ? 'data-event-id="' . esc_attr( $attendee_table->event->ID ) . '"' : '';
 $disabled_class = $disable_checkin ? 'button-disabled' : '';
 ?>
 

--- a/src/admin-views/attendees-table/check-in-button.php
+++ b/src/admin-views/attendees-table/check-in-button.php
@@ -7,19 +7,19 @@
  * @var array $item Current row item data.
  * @var Tribe__Tickets__Attendees_Table $attendee_table Attendees Table Object.
  * @var string $provider Commerce Provider Class name.
- * @var string $disabled_class Class for Disabled button.
+ * @var bool $disable_checkin Whether check-in is disabled.
  */
 
 $event_provider = $attendee_table->event ? 'data-provider="' . $attendee_table->event->ID . '"' : '';
-$disabled_attr  = ! empty( $disabled_class ) ? 'disabled' : '';
+$disabled_class = $disable_checkin ? 'button-disabled' : '';
 ?>
 
 <button
 	data-attendee-id="<?php echo esc_attr( $item['attendee_id'] ); ?>"
 	data-provider="<?php echo esc_attr( $provider ); ?>"
 	class="button-primary tickets_checkin <?php echo esc_attr( $disabled_class ); ?>"
-	<?php echo esc_attr( $event_provider ); ?>
-	<?php echo esc_attr( $disabled_attr ); ?> >
+	<?php echo $event_provider; ?>
+	<?php disabled( $disable_checkin ); ?> >
 		<?php esc_html_e( 'Check In', 'event-tickets' ) ?>
 </button>
 

--- a/src/admin-views/attendees-table/check-in-button.php
+++ b/src/admin-views/attendees-table/check-in-button.php
@@ -10,7 +10,7 @@
  * @var bool $disable_checkin Whether check-in is disabled.
  */
 
-$event_provider = $attendee_table->event ? 'data-provider="' . $attendee_table->event->ID . '"' : '';
+$data_event_id  = $attendee_table->event ? 'data-event-id="' . $attendee_table->event->ID . '"' : '';
 $disabled_class = $disable_checkin ? 'button-disabled' : '';
 ?>
 
@@ -18,7 +18,7 @@ $disabled_class = $disable_checkin ? 'button-disabled' : '';
 	data-attendee-id="<?php echo esc_attr( $item['attendee_id'] ); ?>"
 	data-provider="<?php echo esc_attr( $provider ); ?>"
 	class="button-primary tickets_checkin <?php echo esc_attr( $disabled_class ); ?>"
-	<?php echo $event_provider; ?>
+	<?php echo $data_event_id; ?>
 	<?php disabled( $disable_checkin ); ?> >
 		<?php esc_html_e( 'Check In', 'event-tickets' ) ?>
 </button>

--- a/src/admin-views/attendees-table/check-in-button.php
+++ b/src/admin-views/attendees-table/check-in-button.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Check In and Un Check In button for Attendee Table.
+ *
+ * @since TBD
+ *
+ * @var array $item Current row item data.
+ * @var Tribe__Tickets__Attendees_Table $attendee_table Attendees Table Object.
+ * @var string $provider Commerce Provider Class name.
+ * @var string $disabled_class Class for Disabled button.
+ */
+
+$event_provider = $attendee_table->event ? 'data-provider="' . $attendee_table->event->ID . '"' : '';
+$disabled_attr  = ! empty( $disabled_class ) ? 'disabled' : '';
+?>
+
+<button
+	data-attendee-id="<?php echo esc_attr( $item['attendee_id'] ); ?>"
+	data-provider="<?php echo esc_attr( $provider ); ?>"
+	class="button-primary tickets_checkin <?php echo esc_attr( $disabled_class ); ?>"
+	<?php echo esc_attr( $event_provider ); ?>
+	<?php echo esc_attr( $disabled_attr ); ?> >
+		<?php esc_html_e( 'Check In', 'event-tickets' ) ?>
+</button>
+
+<span class="delete">
+	<button
+		data-attendee-id="<?php echo esc_attr( $item['attendee_id'] ); ?>"
+		data-provider="<?php echo esc_attr( $provider ); ?>"
+		class="button-secondary tickets_uncheckin" >
+			<?php esc_html_e( 'Undo Check In', 'event-tickets' ) ?>
+	</button>
+</span>


### PR DESCRIPTION
### 🎫 Ticket

[ET-984] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Fixed checked in button issue where it was possible to check-in for disabled buttons.
* Moved button html to a separate admin template for better logic structure.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 https://d.pr/v/SePCTk
### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-984]: https://theeventscalendar.atlassian.net/browse/ET-984