### PR TITLE
[ET-791] Fix Attendee List block's shown attendance count

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,8 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.2.0] TBD =
 
+* Fix - Show total Attendance count for Attendee List Block view. [ET-791]
+
 = [5.1.3] 2021-04-22 =
 
 * Fix - Add TwentyTwentyOne theme compatibility for Tickets and RSVPs. [ET-1047]

--- a/src/Tribe/Editor/Blocks/Attendees.php
+++ b/src/Tribe/Editor/Blocks/Attendees.php
@@ -74,7 +74,8 @@ class Tribe__Tickets__Editor__Blocks__Attendees
 		/** @var \Tribe\Tickets\Events\Attendees_List $attendees_list */
 		$attendees_list = tribe( 'tickets.events.attendees-list' );
 
-		$args['attendees'] = $attendees_list->get_attendees_for_post( $post_id );
+		$args['attendees']       = $attendees_list->get_attendees_for_post( $post_id );
+		$args['attendees_total'] = $attendees_list->get_attendance_counts( $post_id );
 
 		// Add the rendering attributes into global context.
 		$template->add_template_globals( $args );

--- a/src/Tribe/Events/Attendees_List.php
+++ b/src/Tribe/Events/Attendees_List.php
@@ -326,8 +326,7 @@ class Attendees_List {
 	public function get_attendance_counts( $post_id ) {
 		$attendees_orm = tribe_attendees();
 
-		$attendees_orm->per_page( -1 )
-		              ->where( 'event', $post_id )
+		$attendees_orm->where( 'event', $post_id )
 		              ->where( 'rsvp_status__or_none', 'yes' );
 
 		return $attendees_orm->found();

--- a/src/Tribe/Events/Attendees_List.php
+++ b/src/Tribe/Events/Attendees_List.php
@@ -313,4 +313,23 @@ class Attendees_List {
 
 		return $is_visible_by_meta || $has_attendee_list_shortcode;
 	}
+
+	/**
+	 * Get total number of attendees that are confirmed.
+	 *
+	 * @since TBD
+	 *
+	 * @param int|string $post_id The post or event that is checked.
+	 *
+	 * @return int Total number of attendees attending the event.
+	 */
+	public function get_attendance_counts( $post_id ) {
+		$attendees_orm = tribe_attendees();
+
+		$attendees_orm->per_page( -1 )
+		              ->where( 'event', $post_id )
+		              ->where( 'rsvp_status__or_none', 'yes' );
+
+		return $attendees_orm->count();
+	}
 }

--- a/src/Tribe/Events/Attendees_List.php
+++ b/src/Tribe/Events/Attendees_List.php
@@ -330,6 +330,6 @@ class Attendees_List {
 		              ->where( 'event', $post_id )
 		              ->where( 'rsvp_status__or_none', 'yes' );
 
-		return $attendees_orm->count();
+		return $attendees_orm->found();
 	}
 }

--- a/src/views/blocks/attendees/description.php
+++ b/src/views/blocks/attendees/description.php
@@ -10,6 +10,8 @@
  *
  * @link https://evnt.is/1amp Help article for RSVP & Ticket template files.
  *
+ * @var	int	$attendees_total Total number of attendees confirmed for the event.
+ *
  * @since 4.9.2
  * @version 4.11.3
  *
@@ -21,7 +23,6 @@ if ( is_bool( $display_subtitle ) && ! $display_subtitle ) {
 }
 
 $post_id         = $this->get( 'post_id' );
-$attendees_total = count( $attendees );
 $message         = _n( 'One person is attending %2$s', '%d people are attending %s', $attendees_total, 'event-tickets' );
 ?>
 <p><?php


### PR DESCRIPTION
### 🎫 Ticket

[ET-791] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Previously it used to show only the number of purchasers instead of the total number of confirmed attendees.
* Now it should show the proper number of attendees as the title.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
**Before**
<img width="840" alt="Screen Shot 2021-04-29 at 3 53 13 PM" src="https://user-images.githubusercontent.com/7523321/116533371-1bb86f00-a903-11eb-8fed-87d33861ca3c.png">

**After the fix showing proper attendee count as 4:**
<img width="962" alt="Screen Shot 2021-04-29 at 3 52 38 PM" src="https://user-images.githubusercontent.com/7523321/116533416-2a9f2180-a903-11eb-9399-efd2bea82ec1.png">

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-791]: https://theeventscalendar.atlassian.net/browse/ET-791