### PR TITLE
[ETP-719] Fix localize for tickets admin manager  (manual attendees problem)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,8 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.2.0] TBD =
 
+* Fix - Fix a JavaScript localization error that was breaking the manual attendees functionality. [ETP-719]
+
 = [5.1.3] 2021-04-22 =
 
 * Fix - Add TwentyTwentyOne theme compatibility for Tickets and RSVPs. [ET-1047]

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -275,7 +275,7 @@ class Tribe__Tickets__Assets {
 
 		$admin_manager_js_data = [
 			'tribeTicketsAdminManagerNonce' => wp_create_nonce( 'tribe_tickets_admin_manager_nonce' ),
-			'ajaxurl'                           => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
+			'ajaxurl'                       => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 		];
 
 		tribe_asset(
@@ -290,7 +290,7 @@ class Tribe__Tickets__Assets {
 			[
 				'localize' => [
 					[
-						'name' => 'TribeTickets',
+						'name' => 'TribeTicketsAdminManager',
 						'data' => $admin_manager_js_data,
 					],
 				],

--- a/src/resources/js/admin/tickets-manager.js
+++ b/src/resources/js/admin/tickets-manager.js
@@ -127,7 +127,7 @@ tribe.tickets.admin.manager = {};
 		const settings = obj.getAjaxSettings( $container );
 
 		// Set the security nonce.
-		data[ 'nonce' ] = TribeTickets.tribeTicketsAdminManagerNonce;
+		data[ 'nonce' ] = TribeTicketsAdminManager.tribeTicketsAdminManagerNonce;
 
 		// Pass the data received to the $.ajax settings
 		settings.data = data;
@@ -146,7 +146,7 @@ tribe.tickets.admin.manager = {};
 	 */
 	obj.getAjaxSettings = function( $container ) {
 		const ajaxSettings = {
-			url: TribeTickets.ajaxurl,
+			url: TribeTicketsAdminManager.ajaxurl,
 			method: 'POST',
 			beforeSend: obj.ajaxBeforeSend,
 			complete: obj.ajaxComplete,


### PR DESCRIPTION
### 🎫 Ticket

[ETP-719] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- use independent var to localize the tribe admin manager to prevent conflicts.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/688288a71bf54fb099ea7da0f00b6bea

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-719]: https://theeventscalendar.atlassian.net/browse/ETP-719