### PR TITLE
[ET-1053] Hide past/future tickets from showing up in TEC cost range for Events.

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2704,14 +2704,21 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			$tickets = self::get_all_event_tickets( $post_id );
 
+			$wp_timezone = Tribe__Timezones::wp_timezone_string();
+
+			if ( Tribe__Timezones::is_utc_offset( $wp_timezone ) ) {
+				$wp_timezone = Tribe__Timezones::generate_timezone_string_from_utc_offset( $wp_timezone );
+			}
+
+			$timezone = new DateTimeZone( $wp_timezone );
+
 			foreach ( $tickets as $ticket ) {
 
-				$start_date = $ticket->start_date;
-				$end_date = $ticket->end_date;
+				$now        = Tribe__Date_Utils::build_date_object( 'now', $timezone );
+				$start_date = Tribe__Date_Utils::build_date_object( $ticket->start_date, $timezone );
+				$end_date   = Tribe__Date_Utils::build_date_object( $ticket->end_date, $timezone );
 
-				$now = strtotime( 'now' );
-
-				if ( ( strtotime( $end_date ) < $now ) || ( strtotime( $start_date ) > $now ) ) {
+				if ( $now > $end_date || $now < $start_date ) {
 					if ( ( $key = array_search( $ticket->price, $costs ) ) !== false ) {
 						unset( $costs[ $key ] );
 					}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2669,7 +2669,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				if ( in_array( $ticket->price, $prices ) ) {
 					continue;
 				}
-				// An empty price property can be ignored (but do add if the price is explicitly set to zero)
+
+				// An empty price property can be ignored (but do add if the price is explicitly set to zero).
 				if ( isset( $ticket->price ) && is_numeric( $ticket->price ) ) {
 					$prices[] = $ticket->price;
 				}
@@ -2688,7 +2689,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param string $meta Meta key name.
 		 * @param bool   $single determines if the requested meta should be a single item or an array of items.
 		 *
-		 * @return mixed
+		 * @return array The list of ticket costs with past tickets excluded possibly.
 		 */
 		public function exclude_past_tickets_from_cost_range( $costs, $post_id, $meta, $single ) {
 
@@ -2696,6 +2697,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				return $costs;
 			}
 
+			/**
+			 * Allow filtering of whether to exclude past tickets in the event cost range.
+			 *
+			 * @since TBD
+			 *
+			 * @param bool $exclude_past_tickets Whether to exclude past tickets in the event cost range.
+			 */
 			$exclude_past_tickets = apply_filters( 'event_tickets_exclude_past_tickets_from_cost_range', true );
 
 			if ( ! $exclude_past_tickets ) {
@@ -2718,8 +2726,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$start_date = Tribe__Date_Utils::build_date_object( $ticket->start_date, $timezone );
 				$end_date   = Tribe__Date_Utils::build_date_object( $ticket->end_date, $timezone );
 
-				if ( $now > $end_date || $now < $start_date ) {
-					if ( ( $key = array_search( $ticket->price, $costs ) ) !== false ) {
+				// If the ticket has not yet become available for sale or has already ended.
+				if ( $now < $start_date || $end_date < $now ) {
+					// Try to find the ticket price in the list of costs.
+					$key = array_search( $ticket->price, $costs );
+
+					// Remove the value from the list of costs if we found it.
+					if ( false !== $key ) {
 						unset( $costs[ $key ] );
 					}
 					continue;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2669,9 +2669,20 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					continue;
 				}
 
+				$start_date = $ticket->start_date;
+				$end_date = $ticket->end_date;
+
+				$now = strtotime( 'now' );
+
+				if ( ( strtotime( $end_date ) < $now ) || ( strtotime( $start_date ) > $now ) ) {
+					if ( ( $key = array_search( $ticket->price, $prices ) ) !== false ) {
+						unset( $prices[ $key ] );
+					}
+					continue;
+				}
 
 				// An empty price property can be ignored (but do add if the price is explicitly set to zero)
-				elseif ( isset( $ticket->price ) && is_numeric( $ticket->price ) ) {
+				if ( isset( $ticket->price ) && is_numeric( $ticket->price ) ) {
 					$prices[] = $ticket->price;
 				}
 			}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2668,19 +2668,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				if ( in_array( $ticket->price, $prices ) ) {
 					continue;
 				}
-
-				$start_date = $ticket->start_date;
-				$end_date = $ticket->end_date;
-
-				$now = strtotime( 'now' );
-
-				if ( ( strtotime( $end_date ) < $now ) || ( strtotime( $start_date ) > $now ) ) {
-					if ( ( $key = array_search( $ticket->price, $prices ) ) !== false ) {
-						unset( $prices[ $key ] );
-					}
-					continue;
-				}
-
 				// An empty price property can be ignored (but do add if the price is explicitly set to zero)
 				if ( isset( $ticket->price ) && is_numeric( $ticket->price ) ) {
 					$prices[] = $ticket->price;

--- a/tests/wpunit/Tribe/Tickets/Tickets/CostRangeTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets/CostRangeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tribe\Tickets\Tickets;
+
+use Tribe\Tickets\Test\Testcases\Ticket_Object_TestCase;
+
+class CostRangeTest extends Ticket_Object_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		// making sure the filter is on for the tests.
+		add_filter( 'event_tickets_exclude_past_tickets_from_cost_range', '__return_true' );
+	}
+
+	/**
+	 * It should show costs for all available tickets.
+	 *
+	 * @test
+	 */
+	public function should_show_all_costs_of_an_event() {
+		$event_id = $this->make_event();
+
+		$ticket1 = $this->create_paypal_ticket( $event_id, 10 );
+		$ticket2 = $this->create_paypal_ticket( $event_id, 20 );
+
+		$tickets = \Tribe__Tickets__Tickets::get_event_tickets( $event_id );
+
+		\Tribe__Events__API::update_event_cost( $event_id );
+
+		/** @var \Tribe__Events__Cost_Utils $cost_utils */
+		$cost_utils = tribe( 'tec.cost-utils' );
+
+		$costs = $cost_utils->get_event_costs( $event_id );
+
+		$this->assertEquals( 2, count( $costs ) );
+	}
+
+	/**
+	 * It should hide costs for past tickets.
+	 *
+	 * @test
+	 */
+	public function should_show_hide_costs_for_past_tickets() {
+		$event_id = $this->make_event();
+
+		$overrides = [
+			'ticket_start_date' => '2021-01-01',
+			'ticket_end_date'   => '2021-02-02',
+		];
+
+		$past_ticket = $this->create_paypal_ticket( $event_id, 20, $overrides );
+		$ticket      = $this->create_paypal_ticket( $event_id, 10 );
+
+		\Tribe__Events__API::update_event_cost($event_id);
+
+		$tickets = \Tribe__Tickets__Tickets::get_event_tickets( $event_id );
+
+		/** @var \Tribe__Events__Cost_Utils $cost_utils */
+		$cost_utils = tribe( 'tec.cost-utils' );
+
+		$costs = $cost_utils->get_event_costs( $event_id );
+
+		$this->assertEquals( 1, count( $costs ) );
+		$this->assertTrue( in_array( 10, $costs ) );
+	}
+
+	/**
+	 * It should hide costs for future tickets.
+	 *
+	 * @test
+	 */
+	public function should_hide_costs_for_future_tickets() {
+		$event_id = $this->make_event();
+
+		$overrides = [
+			'ticket_start_date' => '2030-01-01',
+			'ticket_end_date'   => '2030-02-02',
+		];
+
+		$future_ticket = $this->create_paypal_ticket( $event_id, 50, $overrides );
+		$ticket        = $this->create_paypal_ticket( $event_id, 10 );
+		$ticket        = $this->create_paypal_ticket( $event_id, 20 );
+		$ticket        = $this->create_paypal_ticket( $event_id, 30 );
+
+		\Tribe__Events__API::update_event_cost( $event_id );
+
+		$tickets = \Tribe__Tickets__Tickets::get_event_tickets( $event_id );
+
+		/** @var \Tribe__Events__Cost_Utils $cost_utils */
+		$cost_utils = tribe( 'tec.cost-utils' );
+
+		$costs = $cost_utils->get_event_costs( $event_id );
+
+		$this->assertEquals( 3, count( $costs ) );
+		$this->assertTrue( ! in_array( 50, $costs ) );
+	}
+
+	/**
+	 * It should not hide any costs if the filter is off.
+	 *
+	 * @test
+	 */
+	public function should_not_hide_costs_for_past_events_if_filter_is_off() {
+		$event_id = $this->make_event();
+
+		$overrides = [
+			'ticket_start_date' => '2021-01-01',
+			'ticket_end_date'   => '2021-02-02',
+		];
+
+		$past_ticket = $this->create_paypal_ticket( $event_id, 20, $overrides );
+		$ticket      = $this->create_paypal_ticket( $event_id, 10 );
+
+		add_filter( 'event_tickets_exclude_past_tickets_from_cost_range', '__return_false' );
+
+		\Tribe__Events__API::update_event_cost( $event_id );
+
+		$tickets = \Tribe__Tickets__Tickets::get_event_tickets( $event_id );
+
+		/** @var \Tribe__Events__Cost_Utils $cost_utils */
+		$cost_utils = tribe( 'tec.cost-utils' );
+
+		$costs = $cost_utils->get_event_costs( $event_id );
+
+		$this->assertEquals( 2, count( $costs ) );
+		$this->assertTrue( in_array( 10, $costs ) );
+		$this->assertTrue( in_array( 20, $costs ) );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1053] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Enable hiding of inactive tickets price from the TEC cost range for Event.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
 🎥 screencast:
https://d.pr/v/rzmC0e

### ✔️ Checklist
- [ ] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1053]: https://theeventscalendar.atlassian.net/browse/ET-1053