### PR TITLE
[ET-1114] Fix number calculation for prices with thousands separator and no decimals

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.5] TBD =
 
+* Fix - Fix the price number calculation for tickets that are using no decimals and thousand separator. [ET-1114]
 
 = [5.1.4] 2021-05-12 =
 

--- a/src/resources/js/tickets-block.js
+++ b/src/resources/js/tickets-block.js
@@ -668,7 +668,11 @@ window.tribe.tickets.block = {
 		let number = passedNumber;
 		const format = obj.getCurrencyFormatting();
 
-		if ( 0 === parseInt( format.number_of_decimals ) ) {
+		// If there are no number of decimals and no thousands separator we can return the number.
+		if (
+			0 === parseInt( format.number_of_decimals ) &&
+			'' === format.thousands_sep
+		) {
 			return number;
 		}
 

--- a/src/resources/js/v2/tickets-utils.js
+++ b/src/resources/js/v2/tickets-utils.js
@@ -96,7 +96,11 @@ tribe.tickets.utils = {};
 		let number = passedNumber;
 		const format = obj.getCurrencyFormatting( provider );
 
-		if ( 0 === parseInt( format.number_of_decimals ) ) {
+		// If there are no number of decimals and no thousands separator we can return the number.
+		if (
+			0 === parseInt( format.number_of_decimals ) &&
+			'' === format.thousands_sep
+		) {
 			return number;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1114] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We weren't accounting for the cases where they sell tickets:
 - With the price above a thousand.
 - And a thousand separator
 - And no decimals

Whenever the number has no decimal we were returning the number and not cleaning it, to make the proper calculations.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/29144cdfc2f748f989145f2119d229a8

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1114]: https://theeventscalendar.atlassian.net/browse/ET-1114