### PR TITLE
Prevent events being listed as Free on the day of the event

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Fixed shared capacity stock sync after attendee deletion, for TribeCommerce tickets. [ETP-285]
 * Fix - Fix the price number calculation for tickets that are using no decimals and thousand separator. [ET-1114]
+* Fix - Resolved issue where events with tickets were being shown as Free on the day of the event. [ET-1133]
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]
 
 = [5.1.4] 2021-05-12 =

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1604,10 +1604,10 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 * @return string $cost
 	 */
 	public function trigger_get_cost( $cost, $post_id, $unused_with_currency_symbol ) {
-
 		if (
 			empty( $cost )
 			&& tribe_events_has_tickets( get_post( $post_id ) )
+			&& tribe_tickets( 'rsvp' )->where( 'event', $post_id )->found()
 		) {
 			$cost = __( 'Free', 'event-tickets' );
 		}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2735,8 +2735,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			foreach ( $tickets as $ticket ) {
 
 				$now        = Tribe__Date_Utils::build_date_object( 'now', $timezone );
-				$start_date = Tribe__Date_Utils::build_date_object( $ticket->start_date, $timezone );
-				$end_date   = Tribe__Date_Utils::build_date_object( $ticket->end_date, $timezone );
+				$start_date = Tribe__Date_Utils::build_date_object( $ticket->start_date . ' ' . $ticket->start_time, $timezone );
+				$end_date   = Tribe__Date_Utils::build_date_object( $ticket->end_date . ' ' . $ticket->end_time, $timezone );
 
 				// If the ticket has not yet become available for sale or has already ended.
 				if ( $now < $start_date || $end_date < $now ) {


### PR DESCRIPTION
Unless, of course, it should be free :D

### 🎫 Ticket

[ET-1133]

### 🗒️ Description

This resolves an issue caused by the ticket dates being constructed without the start/end times being factored in.

### 🎥 Artifacts

https://d.pr/v/b5GOXb

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry.
- [x] My code is tested.
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1133]: https://theeventscalendar.atlassian.net/browse/ET-1133