### PR TITLE
Make sure we revert to false by default for excluding

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Fixed shared capacity stock sync after attendee deletion, for TribeCommerce tickets. [ETP-285]
 * Fix - Fix the price number calculation for tickets that are using no decimals and thousand separator. [ET-1114]
+* Fix - Revert to not hiding past sale tickets from Cost range in Events [ET-1133]
 * Fix - Resolved issue where events with tickets were being shown as Free on the day of the event. [ET-1133]
 * Tweak - When using The Events Calendar and Event Tickets split the admin footer rating link 50/50. [ET-1120]
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2716,7 +2716,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 *
 			 * @param bool $exclude_past_tickets Whether to exclude past tickets in the event cost range.
 			 */
-			$exclude_past_tickets = apply_filters( 'event_tickets_exclude_past_tickets_from_cost_range', true );
+			$exclude_past_tickets = apply_filters( 'event_tickets_exclude_past_tickets_from_cost_range', false );
 
 			if ( ! $exclude_past_tickets ) {
 				return $costs;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2712,11 +2712,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			/**
 			 * Allow filtering of whether to exclude past tickets in the event cost range.
 			 *
-			 * @since 5.1.5
+			 * @since 5.1.4
 			 *
-			 * @param bool $exclude_past_tickets Whether to exclude past tickets in the event cost range.
+			 * @param bool  $exclude_past_tickets Whether to exclude past tickets in the event cost range.
+			 * @param array $costs                Which costs are going to be displayed.
+			 * @param int   $post_id              Which Event/Post we are dealign with.
 			 */
-			$exclude_past_tickets = apply_filters( 'event_tickets_exclude_past_tickets_from_cost_range', false );
+			$exclude_past_tickets = apply_filters( 'event_tickets_exclude_past_tickets_from_cost_range', false, $costs, $post_id );
 
 			if ( ! $exclude_past_tickets ) {
 				return $costs;


### PR DESCRIPTION
### 🎫 Ticket

[ET-1133] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Here we have a "Fix", since this is reverting a behavior we introduced on version 5.1.4, where we added a filter to exclude past items from the list of 

### 🎥 Artifacts <!-- if applicable-->
https://i.bordoni.me/qGu5gLKx

### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1133]: https://theeventscalendar.atlassian.net/browse/ET-1133