### PR TITLE
Fix/et 1134 email from displays encoded html entities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-* Fix - Prevent Attendees with HTML entities from importing broken. [ETP-730]
+* Fix - Prevent Tribe Commerce 'Confirmation email sender name' from displaying improperly when a single quote is added. [ET-1134]
 = [5.1.5] TBD =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-* Fix - Prevent Tribe Commerce 'Confirmation email sender name' from displaying improperly when a single quote is added. [ET-1134]
+* Fix - Prevent Tribe Commerce "Confirmation email sender name" from displaying improperly when a single quote is added. [ET-1134]
 = [5.1.5] TBD =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/readme.txt
+++ b/readme.txt
@@ -181,7 +181,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 == Changelog ==
 
 = [5.1.6] TBD =
-* Fix - Prevent Tribe Commerce 'Confirmation email sender name' from displaying improperly when a single quote is added. [ET-1134]
+* Fix - Prevent Tribe Commerce "Confirmation email sender name" from displaying improperly when a single quote is added. [ET-1134]
 
 
 = [5.1.5] 2021-06-09 =

--- a/readme.txt
+++ b/readme.txt
@@ -181,7 +181,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 == Changelog ==
 
 = [5.1.6] TBD =
-
+* Fix - Prevent Tribe Commerce 'Confirmation email sender name' from displaying improperly when a single quote is added. [ET-1134]
 
 
 = [5.1.5] 2021-06-09 =

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -558,8 +558,6 @@ class Tribe__Tickets__Attendees {
 
 				// Handle custom columns that might have names containing HTML tags
 				$row[ $column_id ] = wp_strip_all_tags( $row[ $column_id ] );
-				// Decode HTML Entities.
-				$row[ $column_id] = html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8' );
 				// Remove line breaks (e.g. from multi-line text field) for valid CSV format. Double quotes necessary here.
 				$row[ $column_id ] = str_replace( array( "\r", "\n" ), ' ', $row[ $column_id ] );
 			}
@@ -606,6 +604,7 @@ class Tribe__Tickets__Attendees {
 			// Prefix the value with a single quote to prevent formula from being processed.
 			$value = '\'' . $value;
 		}
+
 		return $value;
 	}
 
@@ -643,6 +642,7 @@ class Tribe__Tickets__Attendees {
 
 		// Sanitize items for CSV usage.
 		$items = $this->sanitize_csv_rows( $items );
+
 		/**
 		 * Allow for filtering and modifying the list of attendees that will be exported via CSV for a given event.
 		 *

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2392,7 +2392,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 				$headers[] = sprintf(
 					'From: %1$s <%2$s>',
-					stripcslashes($from_name),
+					stripcslashes( $from_name ),
 					$from_email
 				);
 				//html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2392,9 +2392,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 				$headers[] = sprintf(
 					'From: %1$s <%2$s>',
-					html_entity_decode(
-						filter_var( $from_name, FILTER_SANITIZE_STRING )
-						, ENT_QUOTES | ENT_XML1, 'UTF-8')
+					html_entity_decode( $from_name, ENT_QUOTES | ENT_XML1, 'UTF-8')
 						,
 					$from_email
 				);

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2392,7 +2392,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 				$headers[] = sprintf(
 					'From: %1$s <%2$s>',
-					$from_name,
+					stripcslashes($from_name),
 					$from_email
 				);
 				//html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2395,8 +2395,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					stripcslashes( $from_name ),
 					$from_email
 				);
-				//html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');
-
 
 				$headers[] = sprintf(
 					'Reply-To: %s',

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2392,9 +2392,14 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 				$headers[] = sprintf(
 					'From: %1$s <%2$s>',
-					filter_var( $from_name, FILTER_SANITIZE_STRING ),
+					html_entity_decode(
+						filter_var( $from_name, FILTER_SANITIZE_STRING )
+						, ENT_QUOTES | ENT_XML1, 'UTF-8')
+						,
 					$from_email
 				);
+				//html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');
+
 
 				$headers[] = sprintf(
 					'Reply-To: %s',

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2392,8 +2392,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 				$headers[] = sprintf(
 					'From: %1$s <%2$s>',
-					html_entity_decode( $from_name, ENT_QUOTES | ENT_XML1, 'UTF-8')
-						,
+					$from_name,
 					$from_email
 				);
 				//html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');


### PR DESCRIPTION
### 🎫 Ticket

[ET-1134] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
Single quotes were being escaped. Gmail did not like this. I removed the escaping that was occurring on the persons name
<!-- What types of changes does your code introduce? -->
Bug Fix -

Single line change for TC sending emails for Paypal.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://user-images.githubusercontent.com/12241059/122456218-4e81f980-cf7b-11eb-86c5-d9eb7d700884.mp4

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt fi>
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge i>
- [x] My code has [proper inline documentation](https://the-events-calendar.g>





[ET-1134]: https://theeventscalendar.atlassian.net/browse/ET-1134