### PR TITLE
Fix/etp 111 hook not passing ticket

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-
+* Fix - Exporting Attendees with HTML entities [ETP-730]
 = [5.1.5] TBD =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 == Changelog ==
-* Fix - Prevent Attendees with HTML entities from importing broken. [ETP-730]
+* Tweak - Added $ticket_id to 'tribe_events_tickets_metabox_edit_ajax_advanced'. [ETP-111]
+* Fix - Prevent Attendees with HTML entities from exporting broken. [ETP-730]
 = [5.1.5] TBD =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 == Changelog ==
 
-* Tweak - Added $ticket_id to 'tribe_events_tickets_metabox_edit_ajax_advanced'. [ETP-111]
+= [5.1.6] TBD =
+
+* Tweak - Added `$ticket_id` parameter to the `tribe_events_tickets_metabox_edit_ajax_advanced` filter. [ETP-111]
 
 = [5.1.5] TBD =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-* Fix - Exporting Attendees with HTML entities [ETP-730]
+* Fix - Prevent Attendees with HTML entities from importing broken. [ETP-730]
 = [5.1.5] TBD =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == Changelog ==
+
 * Tweak - Added $ticket_id to 'tribe_events_tickets_metabox_edit_ajax_advanced'. [ETP-111]
-* Fix - Prevent Attendees with HTML entities from exporting broken. [ETP-730]
+
 = [5.1.5] TBD =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]

--- a/readme.txt
+++ b/readme.txt
@@ -182,7 +182,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.6] TBD =
 
-
+* Tweak - Added $ticket_id to 'tribe_events_tickets_metabox_edit_ajax_advanced'. [ETP-111]
 
 = [5.1.5] 2021-06-09 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -182,7 +182,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.1.6] TBD =
 
-* Tweak - Added $ticket_id to 'tribe_events_tickets_metabox_edit_ajax_advanced'. [ETP-111]
+* Tweak - Added `$ticket_id` parameter to the `tribe_events_tickets_metabox_edit_ajax_advanced` filter. [ETP-111]
 
 = [5.1.5] 2021-06-09 =
 

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -643,7 +643,6 @@ class Tribe__Tickets__Attendees {
 
 		// Sanitize items for CSV usage.
 		$items = $this->sanitize_csv_rows( $items );
-
 		/**
 		 * Allow for filtering and modifying the list of attendees that will be exported via CSV for a given event.
 		 *

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -604,6 +604,7 @@ class Tribe__Tickets__Attendees {
 			// Prefix the value with a single quote to prevent formula from being processed.
 			$value = '\'' . $value;
 		}
+
 		return $value;
 	}
 
@@ -641,6 +642,7 @@ class Tribe__Tickets__Attendees {
 
 		// Sanitize items for CSV usage.
 		$items = $this->sanitize_csv_rows( $items );
+
 		/**
 		 * Allow for filtering and modifying the list of attendees that will be exported via CSV for a given event.
 		 *

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -558,6 +558,8 @@ class Tribe__Tickets__Attendees {
 
 				// Handle custom columns that might have names containing HTML tags
 				$row[ $column_id ] = wp_strip_all_tags( $row[ $column_id ] );
+				//Decode HTML Entities
+				$row[ $column_id] = html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');
 				// Remove line breaks (e.g. from multi-line text field) for valid CSV format. Double quotes necessary here.
 				$row[ $column_id ] = str_replace( array( "\r", "\n" ), ' ', $row[ $column_id ] );
 			}
@@ -604,7 +606,6 @@ class Tribe__Tickets__Attendees {
 			// Prefix the value with a single quote to prevent formula from being processed.
 			$value = '\'' . $value;
 		}
-
 		return $value;
 	}
 
@@ -642,6 +643,7 @@ class Tribe__Tickets__Attendees {
 
 		// Sanitize items for CSV usage.
 		$items = $this->sanitize_csv_rows( $items );
+
 
 		/**
 		 * Allow for filtering and modifying the list of attendees that will be exported via CSV for a given event.

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -644,7 +644,6 @@ class Tribe__Tickets__Attendees {
 		// Sanitize items for CSV usage.
 		$items = $this->sanitize_csv_rows( $items );
 
-
 		/**
 		 * Allow for filtering and modifying the list of attendees that will be exported via CSV for a given event.
 		 *

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -558,8 +558,8 @@ class Tribe__Tickets__Attendees {
 
 				// Handle custom columns that might have names containing HTML tags
 				$row[ $column_id ] = wp_strip_all_tags( $row[ $column_id ] );
-				//Decode HTML Entities
-				$row[ $column_id] = html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8');
+				// Decode HTML Entities.
+				$row[ $column_id] = html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8' );
 				// Remove line breaks (e.g. from multi-line text field) for valid CSV format. Double quotes necessary here.
 				$row[ $column_id ] = str_replace( array( "\r", "\n" ), ' ', $row[ $column_id ] );
 			}

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -558,8 +558,6 @@ class Tribe__Tickets__Attendees {
 
 				// Handle custom columns that might have names containing HTML tags
 				$row[ $column_id ] = wp_strip_all_tags( $row[ $column_id ] );
-				// Decode HTML Entities.
-				$row[ $column_id] = html_entity_decode( $row[ $column_id ] , ENT_QUOTES | ENT_XML1, 'UTF-8' );
 				// Remove line breaks (e.g. from multi-line text field) for valid CSV format. Double quotes necessary here.
 				$row[ $column_id ] = str_replace( array( "\r", "\n" ), ' ', $row[ $column_id ] );
 			}

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1806,7 +1806,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		 * @param string the provider class name
 		 * @param int $ticket_id The ticket ID.
 		 */
-		do_action( 'tribe_events_tickets_metabox_edit_ajax_advanced', $post_id, $provider, $ticket_id  );
+		do_action( 'tribe_events_tickets_metabox_edit_ajax_advanced', $post_id, $provider, $ticket_id );
 
 		echo '</div>';
 	}

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1804,8 +1804,9 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		 *
 		 * @param int Post ID
 		 * @param string the provider class name
+		 * @param int the  id of the ticket
 		 */
-		do_action( 'tribe_events_tickets_metabox_edit_ajax_advanced', $post_id, $provider );
+		do_action( 'tribe_events_tickets_metabox_edit_ajax_advanced', $post_id, $provider, $ticket_id  );
 
 		echo '</div>';
 	}

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1804,7 +1804,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		 *
 		 * @param int Post ID
 		 * @param string the provider class name
-		 * @param int the  id of the ticket
+		 * @param int $ticket_id The ticket ID.
 		 */
 		do_action( 'tribe_events_tickets_metabox_edit_ajax_advanced', $post_id, $provider, $ticket_id  );
 


### PR DESCRIPTION
### 🎫 Ticket

[ETP-111]<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This pull request coincides with one for ET+ (https://github.com/the-events-calendar/event-tickets-plus/pull/1226).

<!-- Please describe what you have changed or added -->
Updated the tribe_events_tickets_metabox_edit_ajax_advanced to have three parameters. 
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
New Feature
<!-- Include any important information for reviewers -->
To test add this code to your functions.php
```
add_action( 'tribe_events_tickets_metabox_edit_ajax_advanced', static function(){
    $args = func_get_args();
    var_dump($args);
},15,3 );
```

<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/12241059/122930020-94eba580-d339-11eb-8055-dad8af1cfe50.png)
Screenshot displays the var_dump from the above code snippet. The ticket ID is 15.

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-111]: https://theeventscalendar.atlassian.net/browse/ETP-111