### PR TITLE
[ET-1143] Update wp org screenshots.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -114,15 +114,13 @@ Event Tickets is translated into multiple languages, including German, Danish, a
 
 == Screenshots ==
 
-1. RSVP and ticket on event
-2. Front-end ticket in page
-3. PayPal checkout
-4. Attendee report
-5. Emailed ticket
-6. Ticket confirmation
-7. Event settings
-8. Add new ticket
-9. Configure PayPal
+1. RSVP on event.
+2. Front-end ticket in page.
+3. PayPal checkout.
+4. Attendee report.
+5. Emailed ticket.
+6. Tickets settings.
+7. Add new ticket.
 
 == Frequently Asked Questions ==
 
@@ -184,6 +182,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Tweak - Added support for HTML in Ticket description field. [ET-1135]
 * Tweak - Added `$ticket_id` parameter to the `tribe_events_tickets_metabox_edit_ajax_advanced` filter. [ETP-111]
+* Tweak - Update the plugin screenshots on the WordPress.org page. [ET-1143]
 * Fix - Fixed the ticket block allowing to add more tickets than available when using shared capacity. [ET-1137]
 * Fix - Sync WooCommerce decimal separator with in Ticket edit form. [ETP-725]
 * Fix - Prevent Tribe Commerce "Confirmation email sender name" from displaying improperly when a single quote is added. [ET-1134]


### PR DESCRIPTION
### 🎫 Ticket

[ET-1143] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- We are including new, revamped screenshots for our WP.org page 🎉 
- We needed a small adjustment on the list of screenshots before we push them.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1143]: https://theeventscalendar.atlassian.net/browse/ET-1143