### PR TITLE
[ET-1145] Feature/et 1145 add export button attendees title

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,7 +179,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 == Changelog ==
 
 = [5.2.1] TBD =
-6
+
 * Feature - Added export button next to the page title on the Attendees page. [ET-1145]
 * Tweak - Added `$attendees` parameter to the `tribe_report_page_after_text_label` action. [ET-1145]
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: theeventscalendar, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, bordoni, borkweb, GeoffBel, geoffgraham, jentheo, leahkoerper, lucatume, neillmcshea, patriciahillebrandt, vicskf, zbtirrell, juanfra
 Tags: tickets, registration, The Events Calendar, RSVP, ticket sales, attendee management
 Requires at least: 4.9.14
-Tested up to: 5.8.0
-Stable tag: 5.2.1
+Tested up to: 5.7.2
+Stable tag: 5.1.6
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -183,8 +183,6 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Feature - Added export button next to the page title on the Attendees page. [ET-1145]
 * Tweak - Added `$attendees` parameter to the `tribe_report_page_after_text_label` action. [ET-1145]
 
-* Language -
-
 = [5.1.6] 2021-07-07 =
 
 * Tweak - Added support for HTML in Ticket description field. [ET-1135]

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: theeventscalendar, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, bordoni, borkweb, GeoffBel, geoffgraham, jentheo, leahkoerper, lucatume, neillmcshea, patriciahillebrandt, vicskf, zbtirrell, juanfra
 Tags: tickets, registration, The Events Calendar, RSVP, ticket sales, attendee management
 Requires at least: 4.9.14
-Tested up to: 5.7.2
-Stable tag: 5.1.6
+Tested up to: 5.8.0
+Stable tag: 5.2.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -177,6 +177,13 @@ We've got a [ProductStash](https://app.productstash.io/the-events-calendar-suite
 Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on using, tweaking, and troubleshooting our plugins.
 
 == Changelog ==
+
+= [5.2.1] TBD =
+
+* Feature - Added export button next to the page title on the Attendees page. [ET-1145]
+* Tweak - Added `$attendees` parameter to the `tribe_report_page_after_text_label` action. [ET-1145]
+
+* Language -
 
 = [5.1.6] 2021-07-07 =
 

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -31,6 +31,7 @@ class Tribe__Tickets__Attendees {
 	public function hook() {
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 
+		add_action( 'tribe_report_page_after_text_label', [ $this, 'include_export_button_title' ], 25, 2 );
 		add_action( 'tribe_events_tickets_attendees_totals_top', array( $this, 'print_checkedin_totals' ), 0 );
 		add_action( 'tribe_tickets_attendees_event_details_list_top', array( $this, 'event_details_top' ), 20 );
 		add_action( 'tribe_tickets_plus_report_event_details_list_top', array( $this, 'event_details_top' ), 20 );
@@ -43,6 +44,8 @@ class Tribe__Tickets__Attendees {
 
 		add_filter( 'post_row_actions', array( $this, 'filter_admin_row_actions' ) );
 		add_filter( 'page_row_actions', array( $this, 'filter_admin_row_actions' ) );
+
+
 	}
 
 	/**
@@ -934,13 +937,22 @@ class Tribe__Tickets__Attendees {
 
 		return $provider->update_attendee( $attendee, $attendee_data );
 	}
-	//TODO add docbloc
+	//@TODO add docbloc
 	public function get_export_url (){
-		return add_query_arg(
+		return  add_query_arg(
 			[
 				'attendees_csv'       => true,
 				'attendees_csv_nonce' => wp_create_nonce( 'attendees_csv_nonce' ),
 			]
 		);
+	}
+	//@TODO add docbloc
+	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees ){
+		if ( ! $attendees->attendees_table->has_items() ) {
+			return false;
+		}
+
+		echo sprintf( '<a target="_blank" href="%s" class="export action page-title-action">%s</a>', esc_url( $export_url = $this->get_export_url() ), esc_html__( 'Export', 'event-tickets' ) ) ;
+
 	}
 }

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -934,5 +934,13 @@ class Tribe__Tickets__Attendees {
 
 		return $provider->update_attendee( $attendee, $attendee_data );
 	}
-
+	//TODO add docbloc
+	public function get_export_url (){
+		return add_query_arg(
+			[
+				'attendees_csv'       => true,
+				'attendees_csv_nonce' => wp_create_nonce( 'attendees_csv_nonce' ),
+			]
+		);
+	}
 }

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -977,7 +977,7 @@ class Tribe__Tickets__Attendees {
 		echo sprintf(
 			'<a target="_blank" href="%s" class="export action page-title-action" rel="noopener noreferrer">%s</a>',
 			esc_url( $export_url = $this->get_export_url() ),
-			esc_html__( 'Export', 'event-tickets' ) ) ;
-
+			esc_html__( 'Export', 'event-tickets' )
+		) ;
 	}
 }

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -44,8 +44,6 @@ class Tribe__Tickets__Attendees {
 
 		add_filter( 'post_row_actions', array( $this, 'filter_admin_row_actions' ) );
 		add_filter( 'page_row_actions', array( $this, 'filter_admin_row_actions' ) );
-
-
 	}
 
 	/**
@@ -939,14 +937,13 @@ class Tribe__Tickets__Attendees {
 	}
 
 	/**
-	 * Generate the export URL for exporting attendees
+	 * Generate the export URL for exporting attendees.
 	 *
 	 * @since TBD
 	 *
-	 *
 	 * @return string Relative URL for the export.
 	 */
-	public function get_export_url (){
+	public function get_export_url() {
 		return  add_query_arg(
 			[
 				'attendees_csv'       => true,
@@ -954,6 +951,7 @@ class Tribe__Tickets__Attendees {
 			]
 		);
 	}
+
 	/**
 	 * Echo the button for the export that appears next to the attendees page title.
 	 *
@@ -966,17 +964,20 @@ class Tribe__Tickets__Attendees {
 	 */
 	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees ){
 
-		// Bail early if there are no attendees
+		// Bail early if there are no attendees.
 		if ( ! $attendees->attendees_table->has_items() ) {
 			return;
 		}
 
-		// Bail early if user is not owner/have permissions
+		// Bail early if user is not owner/have permissions.
 		if ( ! $this->user_can_manage_attendees( 0, $event_id ) ) {
 			return;
 		}
 
-		echo sprintf( '<a target="_blank" href="%s" class="export action page-title-action">%s</a>', esc_url( $export_url = $this->get_export_url() ), esc_html__( 'Export', 'event-tickets' ) ) ;
+		echo sprintf(
+			'<a target="_blank" href="%s" class="export action page-title-action" rel="noopener noreferrer">%s</a>',
+			esc_url( $export_url = $this->get_export_url() ),
+			esc_html__( 'Export', 'event-tickets' ) ) ;
 
 	}
 }

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -957,8 +957,8 @@ class Tribe__Tickets__Attendees {
 	 *
 	 * @since TBD
 	 *
-	 * @param int $event_id
-	 * @param Tribe__Tickets__Attendees $attendees
+	 * @param int $event_id The Post ID of the event.
+	 * @param Tribe__Tickets__Attendees $attendees The attendees object.
 	 *
 	 * @return string Relative URL for the export.
 	 */

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -937,7 +937,15 @@ class Tribe__Tickets__Attendees {
 
 		return $provider->update_attendee( $attendee, $attendee_data );
 	}
-	//@TODO add docbloc
+
+	/**
+	 * Generate the export URL for exporting attendees
+	 *
+	 * @since TBD
+	 *
+	 *
+	 * @return string Relative URL for the export.
+	 */
 	public function get_export_url (){
 		return  add_query_arg(
 			[
@@ -946,10 +954,26 @@ class Tribe__Tickets__Attendees {
 			]
 		);
 	}
-	//@TODO add docbloc
+	/**
+	 * Echo the button for the export that appears next to the attendees page title.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $event_id
+	 * @param Tribe__Tickets__Attendees $attendees
+	 *
+	 * @return string Relative URL for the export.
+	 */
 	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees ){
+
+		// Bail early if there are no attendees
 		if ( ! $attendees->attendees_table->has_items() ) {
-			return false;
+			return;
+		}
+
+		// Bail early if user is not owner/have permissions
+		if ( ! $this->user_can_manage_attendees( 0, $event_id ) ) {
+			return;
 		}
 
 		echo sprintf( '<a target="_blank" href="%s" class="export action page-title-action">%s</a>', esc_url( $export_url = $this->get_export_url() ), esc_html__( 'Export', 'event-tickets' ) ) ;

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -551,8 +551,6 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			return;
 		}
 
-		$export_url = tribe( 'tickets.attendees' )->get_export_url();
-
 		/**
 		 * Include TB_iframe JS
 		 */
@@ -597,7 +595,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		$nav = [
 			'left' => [
 				'print'  => sprintf( '<input type="button" name="print" class="print button action" value="%s">', esc_attr__( 'Print', 'event-tickets' ) ),
-				'export' => sprintf( '<a target="_blank" href="%s" class="export button action">%s</a>', esc_url( $export_url ), esc_html__( 'Export', 'event-tickets' ) ),
+				'export' => sprintf( '<a target="_blank" href="%s" class="export button action">%s</a>', esc_url( tribe( 'tickets.attendees' )->get_export_url() ), esc_html__( 'Export', 'event-tickets' ) ),
 			],
 			'right' => [],
 		];

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -551,12 +551,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			return;
 		}
 
-		$export_url = add_query_arg(
-			[
-				'attendees_csv'       => true,
-				'attendees_csv_nonce' => wp_create_nonce( 'attendees_csv_nonce' ),
-			]
-		);
+		$export_url = tribe( 'tickets.attendees' )->get_export_url();
 
 		/**
 		 * Include TB_iframe JS

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -595,7 +595,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		$nav = [
 			'left' => [
 				'print'  => sprintf( '<input type="button" name="print" class="print button action" value="%s">', esc_attr__( 'Print', 'event-tickets' ) ),
-				'export' => sprintf( '<a target="_blank" href="%s" class="export button action">%s</a>', esc_url( tribe( 'tickets.attendees' )->get_export_url() ), esc_html__( 'Export', 'event-tickets' ) ),
+				'export' => sprintf( '<a target="_blank" href="%s" class="export button action" rel="noopener noreferrer">%s</a>', esc_url( tribe( 'tickets.attendees' )->get_export_url() ), esc_html__( 'Export', 'event-tickets' ) ),
 			],
 			'right' => [],
 		];

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -43,7 +43,7 @@ $export_url = tribe( 'tickets.attendees' )->get_export_url();
 			 * @since TBD Added the attendees information.
 			 *
 			 * @param int $event_id Post ID.
-			 * @param Tribe__Tickets__Attendees @attendees The attendees object.
+			 * @param Tribe__Tickets__Attendees $attendees The attendees object.
 			 */
 			do_action( 'tribe_report_page_after_text_label', $event_id, $attendees );
 

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -40,12 +40,13 @@ $export_url = tribe( 'tickets.attendees' )->get_export_url();
 			 * Add an action to render content after text title.
 			 *
 			 * @since 5.1.0
+			 * @since TBD Added the attendees information.
 			 *
 			 * @param int $event_id Post ID.
+			 * @param Tribe__Tickets__Attendees @attendees The attendees object.
 			 */
-			do_action( 'tribe_report_page_after_text_label', $event_id );
+			do_action( 'tribe_report_page_after_text_label', $event_id, $attendees );
 
-			echo sprintf( '<a target="_blank" href="%s" class="export action page-title-action">%s</a>', esc_url( $export_url ), esc_html__( 'Export', 'event-tickets' ) )
 			?>
 		</h1>
 	<?php endif; ?>

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -21,6 +21,7 @@ $singular = $pto->labels->singular_name;
  * @param Tribe__Tickets__Attendees $attendees  The attendees object.
  */
 $show_title = apply_filters( 'tribe_tickets_attendees_show_title', is_admin(), $attendees );
+$export_url = tribe( 'tickets.attendees' )->get_export_url();
 ?>
 
 <div class="wrap tribe-report-page">
@@ -43,6 +44,8 @@ $show_title = apply_filters( 'tribe_tickets_attendees_show_title', is_admin(), $
 			 * @param int $event_id Post ID.
 			 */
 			do_action( 'tribe_report_page_after_text_label', $event_id );
+
+			echo sprintf( '<a target="_blank" href="%s" class="export action page-title-action">%s</a>', esc_url( $export_url ), esc_html__( 'Export', 'event-tickets' ) )
 			?>
 		</h1>
 	<?php endif; ?>


### PR DESCRIPTION
### 🎫 Ticket

[ET-1145] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->

- Added the export button next to the page title on the Attendees page
- Updated the action `tribe_report_page_after_text_label` to include `$attendees` variable
- Moved the export button generating script to it's own function so it can be reused

<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Showing export button next to page title
![image](https://user-images.githubusercontent.com/12241059/126507583-1d93ad9d-1b0f-407a-a5a1-0fad8cea9892.png)
Showing export button on table
![image](https://user-images.githubusercontent.com/12241059/126507663-6edf7844-8e67-433b-a0c0-2ddc30a1f763.png)
Showing no export button with no attendees
![image](https://user-images.githubusercontent.com/12241059/126507883-40cf7aaa-700b-4617-b18c-06056b10f9b3.png)


### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1145]: https://theeventscalendar.atlassian.net/browse/ET-1145