### PR TITLE
[ET-1107] Add delete functionality for the tickets area in the classic editor.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.2.1] TBD =
 
+* Tweak - Added "Delete" functionality for the tickets area in the classic editor. [ET-1107]
 * Language -
 
 = [5.1.6] 2021-07-07 =

--- a/src/admin-views/editor/list-row.php
+++ b/src/admin-views/editor/list-row.php
@@ -119,6 +119,18 @@ if (
 			) ),
 			esc_html( $ticket->name )
 		);
+
+		printf(
+			"<button attr-provider='%s' attr-ticket-id='%s' title='%s' class='ticket_delete'><span class='ticket_delete_text'>%s</span></a>",
+			esc_attr( $ticket->provider_class ),
+			esc_attr( $ticket->ID ),
+			esc_attr( sprintf(
+				_x( 'Delete %s ID: %d', 'ticket ID title attribute', 'event-tickets' ),
+				tribe_get_ticket_label_singular( 'ticket_id_title_attribute' ),
+				$ticket->ID
+			) ),
+			esc_html( $ticket->name )
+		);
 		?>
 	</td>
 </tr>

--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -123,11 +123,12 @@
 	}
 
 	.ticket_edit {
-		width: 30px;
+		width: 55px;
 	}
 
 	/* Edit button styles - separate for portability */
 	.ticket_edit_button,
+	.ticket_delete,
 	.global_capacity_edit_button {
 		background: none;
 		border: 0;
@@ -136,20 +137,33 @@
 		padding: 0;
 
 		&:hover {
-			color: #00a0d2;
+			color: #727272;
 		}
 
 		.ticket_edit_text,
-		.global_capacity_edit_text {
+		.global_capacity_edit_text,
+		.ticket_delete_text {
 			font-size: 0;
 
 			&::before {
 				content: '\f464';
 				font-family: 'dashicons';
-				font-size: x-large;
+				font-size: 20px;
 				vertical-align: top;
 			}
 		}
+
+		.ticket_delete_text {
+			font-size: 0;
+
+			&::before {
+				content: "\f182";
+			}
+		}
+	}
+
+	.ticket_delete {
+		margin-left: 12px;
 	}
 
 	.global_capacity_edit_button {

--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -145,7 +145,7 @@
 		.ticket_delete_text {
 			font-size: 0;
 
-			&::before {
+			&:before {
 				content: '\f464';
 				font-family: 'dashicons';
 				font-size: 20px;
@@ -154,7 +154,7 @@
 		}
 
 		.ticket_delete_text {
-			&::before {
+			&:before {
 				content: '\f182';
 			}
 		}

--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -154,10 +154,8 @@
 		}
 
 		.ticket_delete_text {
-			font-size: 0;
-
 			&::before {
-				content: "\f182";
+				content: '\f182';
 			}
 		}
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1107] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Adding the delete functionality for the list of tickets in the classic editor.
- Hooking onto existing functionality, keeping the classes and such so the JS works out of the box. We could possibly improve this in the future.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/1601bd8ecf75476e8b64a7972c4d4b01

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1107]: https://theeventscalendar.atlassian.net/browse/ET-1107