### PR TITLE
[ET-1156] Fix the block_categories function - 5.8 broke it.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Add a new function to add "Tickets Blocks" category to the editor for WP >= 5.8. [TBD]
+
 = [5.1.6] TBD =
 
 * Tweak - Added `$ticket_id` parameter to the `tribe_events_tickets_metabox_edit_ajax_advanced` filter. [ETP-111]

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,13 +4,13 @@
 
 * Fix - Add a new function to add "Tickets Blocks" category to the editor for WP >= 5.8. [TBD]
 
-= [5.1.6] TBD =
+= [5.1.6] 2021-07-07 =
 
 * Tweak - Added `$ticket_id` parameter to the `tribe_events_tickets_metabox_edit_ajax_advanced` filter. [ETP-111]
 * Fix - Prevent Attendees with HTML entities from exporting broken. [ETP-730]
 * Fix - Prevent Tribe Commerce "Confirmation email sender name" from displaying improperly when a single quote is added. [ET-1134]
 
-= [5.1.5] TBD =
+= [5.1.5] 2021-06-09 =
 
 * Tweak - Move complete list of changelog entries from `readme.txt` to `changelog.txt`. [ET-1121]
 

--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Add a new function to add "Tickets Blocks" category to the editor for WP >= 5.8. [TBD]
+
 = [5.1.6] 2021-07-07 =
 
 * Tweak - Added support for HTML in Ticket description field. [ET-1135]

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -191,8 +191,9 @@ class Tribe__Tickets__Editor extends Tribe__Editor {
 	 *
 	 * @since 4.9
 	 *
-	 * @param $categories
-	 * @param $post
+	 * @param array<array<string|string>> $categories An array of categories each an array
+	 *                                                in the format property => value.
+	 *
 	 * @return array
 	 */
 	public function block_categories( $categories ) {

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -126,10 +126,20 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 			tribe_callback( 'tickets.editor.blocks.attendees', 'register' )
 		);
 
-		add_action(
-			'block_categories',
-			tribe_callback( 'tickets.editor', 'block_categories' )
-		);
+		global $wp_version;
+		if ( ! class_exists( 'WP_Block_Editor_Context' ) || version_compare( $wp_version, '5.8', '<' ) ) {
+			// WP < 5.8
+			add_action(
+				'block_categories',
+				tribe_callback( 'tickets.editor', 'block_categories' )
+			);
+		} else {
+			// WP >= 5.8
+			add_action(
+				'block_categories_all',
+				tribe_callback( 'tickets.editor', 'block_categories' )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket
[ET-1156]

### 🗒️ Description

Corrects an issue in WP 5.8 where the `block_categories` filter has been deprecated - and the new `block_categories_all` has a different signature. Both are covered without changes to the function itself.

### ✔️ Checklist
- [X] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [X] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [X] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
### Related
https://github.com/the-events-calendar/events-pro/pull/1801
https://github.com/the-events-calendar/the-events-calendar/pull/3592


[ET-1156]: https://theeventscalendar.atlassian.net/browse/ET-1156