### PR TITLE
Added a new action for `tribe_tabbed_view_heading_after_text_label`. …

### DIFF
--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -32,6 +32,7 @@ class Tribe__Tickets__Attendees {
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 
 		add_action( 'tribe_report_page_after_text_label', [ $this, 'include_export_button_title' ], 25, 2 );
+		add_action( 'tribe_tabbed_view_heading_after_text_label', [ $this, 'include_export_button_title' ], 25, 2 );
 		add_action( 'tribe_events_tickets_attendees_totals_top', array( $this, 'print_checkedin_totals' ), 0 );
 		add_action( 'tribe_tickets_attendees_event_details_list_top', array( $this, 'event_details_top' ), 20 );
 		add_action( 'tribe_tickets_plus_report_event_details_list_top', array( $this, 'event_details_top' ), 20 );
@@ -962,10 +963,26 @@ class Tribe__Tickets__Attendees {
 	 *
 	 * @return string Relative URL for the export.
 	 */
-	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees ){
+	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees = NULL ){
+
+		// Bail if not on the Attendees page.
+		if ( 'tickets-attendees' !== tribe_get_request_var( 'page' ) ) {
+			return;
+		}
+
+		// If this function is called from the tabbed-view.php file it does not send over $event_id or $attendees.
+		// If the $event_id is not an integer we can get the information from the get scope and find the data.
+		if ( ! is_int( $event_id ) &&
+		     ! empty( tribe_get_request_var( 'event_id' ) )
+		) {
+			$event_id = tribe_get_request_var( 'event_id' );
+			$attendees = tribe( 'tickets.attendees' );
+			$attendees->attendees_table->prepare_items();
+		}
 
 		// Bail early if there are no attendees.
-		if ( ! $attendees->attendees_table->has_items() ) {
+		if ( empty( $attendees ) ||
+		     ! $attendees->attendees_table->has_items() ) {
 			return;
 		}
 

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -982,7 +982,8 @@ class Tribe__Tickets__Attendees {
 
 		// Bail early if there are no attendees.
 		if ( empty( $attendees ) ||
-		     ! $attendees->attendees_table->has_items() ) {
+		     ! $attendees->attendees_table->has_items()
+		) {
 			return;
 		}
 

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -963,7 +963,7 @@ class Tribe__Tickets__Attendees {
 	 *
 	 * @return string Relative URL for the export.
 	 */
-	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees = NULL ){
+	public function include_export_button_title( $event_id, Tribe__Tickets__Attendees $attendees = null ){
 
 		// Bail if not on the Attendees page.
 		if ( 'tickets-attendees' !== tribe_get_request_var( 'page' ) ) {


### PR DESCRIPTION
### 🎫 Ticket

[ET-1145] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
The export button was not displaying correct when ET+ was enabled. The heading is powered by a different template when that is enabled. I added another action to the hook `tribe_tabbed_view_heading_after_text_label`.

`tribe_tabbed_view_heading_after_text_label` Does not send the correct variables to the function. If `$event_id` is not an integer then I look up the event based off of the GET scope and get everything I need.

<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/12241059/127167434-20780c75-6be0-42c7-95f8-7ab754b3decd.png)

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1145]: https://theeventscalendar.atlassian.net/browse/ET-1145