### PR TITLE
RadioControl needs to be type='radio' shockingly... not type='text'

### DIFF
--- a/src/modules/blocks/ticket/container-content/attendee-collection/iac-setting/template.js
+++ b/src/modules/blocks/ticket/container-content/attendee-collection/iac-setting/template.js
@@ -48,7 +48,7 @@ class IACSetting extends PureComponent {
 					<RadioControl
 						className="tribe-editor__ticket__iac-setting-input"
 						id={ this.id }
-						type="text"
+						type="radio"
 						selected={ iac }
 						onChange={ onChange }
 						disabled={ isDisabled }


### PR DESCRIPTION

### 🎫 Ticket

[ETP-739] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->

<img width="856" alt="Screen Shot 2021-07-28 at 6 39 26 PM" src="https://user-images.githubusercontent.com/236579/127405228-c841439e-abfc-422b-8476-09924c84ea4c.png">

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-739]: https://theeventscalendar.atlassian.net/browse/ETP-739