### PR TITLE
[ET-1089] enable multiline input for ticket rsvp titles in block editor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Fixed ticket total formatting when using custom thousands and decimal separators. [ET-1197]
+* Enhancement - When editing an RSVP or ticket in the block editor, allow title to wrap to multiple lines. [ET-1089]
 
 = [5.1.9] 2021-08-31 =
 

--- a/src/modules/blocks/rsvp/container-header/style.pcss
+++ b/src/modules/blocks/rsvp/container-header/style.pcss
@@ -29,6 +29,7 @@
 }
 
 .tribe-editor__rsvp-container-header__title-input-wrapper {
+	align-items: baseline;
 	display: flex;
 
 	svg {
@@ -42,36 +43,31 @@
 .tribe-editor__rsvp {
 
 	.tribe-editor__rsvp-container-header__title-input {
-		flex: none;
-		margin: 0;
-		padding-top: 3px;
+		background-color: transparent;
+		border: none;
+		color: #000000;
+		font-family: 'Helvetica Neue', Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
+		font-size: 21px;
+		font-weight: bold;
+		letter-spacing: 0.16px;
 		line-height: 25px;
+		margin: 3px 0 0;
+		padding: 0;
+		resize: none;
+		width: calc( 95% - 26px );
 
-		& > input {
-			background-color: transparent;
-			color: #000000;
-			margin: 0;
-			padding: 0;
-			border: none;
-			font-family: 'Helvetica Neue', Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
-			font-weight: bold;
-			font-size: 21px;
-			line-height: 25px;
-			letter-spacing: 0.16px;
+		&:hover,
+		&:focus {
+			background-color: #FFFFFF;
+		}
 
+		&:disabled {
+
+			&,
 			&:hover,
 			&:focus {
-				background-color: #FFFFFF;
-			}
-
-			&:disabled {
-
-				&,
-				&:hover,
-				&:focus {
-					background-color: transparent;
-					color: #AEB4BB;
-				}
+				background-color: transparent;
+				color: #AEB4BB;
 			}
 		}
 	}

--- a/src/modules/blocks/rsvp/container-header/style.pcss
+++ b/src/modules/blocks/rsvp/container-header/style.pcss
@@ -45,7 +45,7 @@
 	.tribe-editor__rsvp-container-header__title-input {
 		background-color: transparent;
 		border: none;
-		color: #000000;
+		color: #000;
 		font-family: 'Helvetica Neue', Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
 		font-size: 21px;
 		font-weight: bold;
@@ -54,11 +54,11 @@
 		margin: 3px 0 0;
 		padding: 0;
 		resize: none;
-		width: calc( 95% - 26px );
+		width: calc(95% - 26px);
 
 		&:hover,
 		&:focus {
-			background-color: #FFFFFF;
+			background-color: #fff;
 		}
 
 		&:disabled {
@@ -67,7 +67,7 @@
 			&:hover,
 			&:focus {
 				background-color: transparent;
-				color: #AEB4BB;
+				color: #aeb4bb;
 			}
 		}
 	}

--- a/src/modules/blocks/rsvp/container-header/template.js
+++ b/src/modules/blocks/rsvp/container-header/template.js
@@ -3,7 +3,6 @@
  */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import AutosizeInput from 'react-input-autosize';
 import TextareaAutosize from 'react-textarea-autosize';
 
 /**
@@ -42,7 +41,7 @@ const getTitle = (
 	isSelected
 		? (
 			<div className="tribe-editor__rsvp-container-header__title-input-wrapper">
-				<AutosizeInput
+				<TextareaAutosize
 					className="tribe-editor__rsvp-container-header__title-input"
 					value={ tempTitle }
 					placeholder={ __( 'RSVP Title', 'event-tickets' ) }

--- a/src/modules/blocks/ticket/container-header/title/style.pcss
+++ b/src/modules/blocks/ticket/container-header/title/style.pcss
@@ -54,7 +54,7 @@
 
 		background-color: transparent;
 		border: none;
-		color: #000000;
+		color: #000;
 		font-size: 21px;
 		font-weight: bold;
 		letter-spacing: 0.16px;
@@ -62,11 +62,11 @@
 		margin: 3px 0 0;
 		padding: 0;
 		resize: none;
-		width: calc( 95% - 26px );
+		width: calc(95% - 26px);
 
 		&:hover,
 		&:focus {
-			background-color: #FFFFFF;
+			background-color: #fff;
 		}
 
 		&:disabled {
@@ -75,7 +75,7 @@
 			&:hover,
 			&:focus {
 				background-color: transparent;
-				color: #AEB4BB;
+				color: #aeb4bb;
 			}
 		}
 	}

--- a/src/modules/blocks/ticket/container-header/title/style.pcss
+++ b/src/modules/blocks/ticket/container-header/title/style.pcss
@@ -1,4 +1,5 @@
 .tribe-editor__ticket__container-header-title {
+	align-items: baseline;
 	display: flex;
 
 	/* Clipboard tooltip */
@@ -50,27 +51,30 @@
 .tribe-editor__ticket {
 
 	.tribe-editor__ticket__container-header-title-input {
-		/* !important required to override styles from react-input-autosize */
-		display: flex !important;
-		margin: 0;
-		padding-top: 3px;
 
-		& > * {
-			flex: none;
+		background-color: transparent;
+		border: none;
+		color: #000000;
+		font-size: 21px;
+		font-weight: bold;
+		letter-spacing: 0.16px;
+		line-height: 25px;
+		margin: 3px 0 0;
+		padding: 0;
+		resize: none;
+		width: calc( 95% - 26px );
+
+		&:hover,
+		&:focus {
+			background-color: #FFFFFF;
 		}
 
-		& > input {
-			background-color: transparent;
-			color: #000000;
-			margin: 0;
-			padding: 0;
-			border: none;
-			font-weight: bold;
-			font-size: 21px;
-			line-height: 25px;
-			letter-spacing: 0.16px;
+		&:disabled {
 
-			&:disabled {
+			&,
+			&:hover,
+			&:focus {
+				background-color: transparent;
 				color: #AEB4BB;
 			}
 		}

--- a/src/modules/blocks/ticket/container-header/title/template.js
+++ b/src/modules/blocks/ticket/container-header/title/template.js
@@ -3,7 +3,7 @@
  */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import AutosizeInput from 'react-input-autosize';
+import TextareaAutosize from 'react-textarea-autosize';
 
 /**
  * Wordpress dependencies
@@ -42,7 +42,7 @@ const TicketContainerHeaderTitle = ( {
 				isSelected
 					? (
 						<Fragment>
-							<AutosizeInput
+							<TextareaAutosize
 								className="tribe-editor__ticket__container-header-title-input"
 								value={ tempTitle }
 								placeholder={ __( 'Ticket Type *', 'event-tickets' ) }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1089] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
When editing an RSVP or ticket in the block editor, we want to allow titles to wrap to multiple lines instead of stretching things out.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://youtu.be/aV-wDYw-TiQ

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1089]: https://theeventscalendar.atlassian.net/browse/ET-1089