### PR TITLE
TribeCommerce and Ticket Commerce parallel fixes.

### DIFF
--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -85,6 +85,7 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'tribe_attendee_registration_cart_provider', [ $this, 'filter_registration_cart_provider' ], 10, 2 );
 
 		add_filter( 'tribe_tickets_get_default_module', [ $this, 'filter_de_prioritize_module' ], 5, 2 );
+		add_filter( 'tribe_events_tickets_module_name', [ $this, 'set_displayed_module_name' ] );
 
 		add_filter( 'tribe_tickets_checkout_urls', [ $this, 'filter_js_include_checkout_url' ] );
 		add_filter( 'tribe_tickets_cart_urls', [ $this, 'filter_js_include_cart_url' ] );
@@ -416,4 +417,21 @@ class Hooks extends tad_DI52_ServiceProvider {
 		return $post_states;
 	}
 
+	/**
+	 * Show the legacy PayPal as not recommended.
+	 *
+	 * @since TBD
+	 *
+	 * @param $name string Name of the provider.
+	 *
+	 * @return string
+	 */
+	public function set_displayed_module_name( $name ) {
+
+		if ( $name === 'Tribe Commerce' ) {
+			return __( 'Tribe Commerce ( Legacy PayPal, not recommended )', 'event-tickets' );
+		}
+
+		return $name;
+	}
 }

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -87,6 +87,9 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'tribe_tickets_get_default_module', [ $this, 'filter_de_prioritize_module' ], 5, 2 );
 		add_filter( 'tribe_events_tickets_module_name', [ $this, 'set_displayed_module_name' ] );
 
+		// Disable TribeCommerce for new installations.
+		add_filter( 'tribe_tickets_commerce_paypal_is_active', 'tec_tribe_commerce_is_available' );
+
 		add_filter( 'tribe_tickets_checkout_urls', [ $this, 'filter_js_include_checkout_url' ] );
 		add_filter( 'tribe_tickets_cart_urls', [ $this, 'filter_js_include_cart_url' ] );
 

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -85,10 +85,6 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'tribe_attendee_registration_cart_provider', [ $this, 'filter_registration_cart_provider' ], 10, 2 );
 
 		add_filter( 'tribe_tickets_get_default_module', [ $this, 'filter_de_prioritize_module' ], 5, 2 );
-		add_filter( 'tribe_events_tickets_module_name', [ $this, 'set_displayed_module_name' ] );
-
-		// Disable TribeCommerce for new installations.
-		add_filter( 'tribe_tickets_commerce_paypal_is_active', 'tec_tribe_commerce_is_available' );
 
 		add_filter( 'tribe_tickets_checkout_urls', [ $this, 'filter_js_include_checkout_url' ] );
 		add_filter( 'tribe_tickets_cart_urls', [ $this, 'filter_js_include_cart_url' ] );
@@ -418,23 +414,5 @@ class Hooks extends tad_DI52_ServiceProvider {
 		$post_states = tribe( Success::class )->maybe_add_display_post_states( $post_states, $post );
 
 		return $post_states;
-	}
-
-	/**
-	 * Show the legacy PayPal as not recommended.
-	 *
-	 * @since TBD
-	 *
-	 * @param $name string Name of the provider.
-	 *
-	 * @return string
-	 */
-	public function set_displayed_module_name( $name ) {
-
-		if ( $name === 'Tribe Commerce' ) {
-			return __( 'Tribe Commerce ( Legacy PayPal, not recommended )', 'event-tickets' );
-		}
-
-		return $name;
 	}
 }

--- a/src/Tickets/Commerce/Legacy_Compat.php
+++ b/src/Tickets/Commerce/Legacy_Compat.php
@@ -26,7 +26,48 @@ class Legacy_Compat extends tad_DI52_ServiceProvider {
 	 * @since 5.1.6
 	 */
 	public function register() {
+//		$this->add_actions();
+		$this->add_filters();
+	}
 
+	/**
+	 * Adds the actions required to handle legacy compatibility.
+	 *
+	 * @since TBD
+	 */
+	protected function add_actions() {
+
+	}
+
+	/**
+	 * Adds the filters required to handle legacy compatibility.
+	 *
+	 * @since TBD
+	 */
+	protected function add_filters() {
+
+		add_filter( 'tribe_events_tickets_module_name', [ $this, 'set_legacy_module_name' ] );
+
+		// Disable TribeCommerce for new installations.
+		add_filter( 'tribe_tickets_commerce_paypal_is_active', 'tec_tribe_commerce_is_available' );
+	}
+
+	/**
+	 * Show the legacy PayPal as not recommended.
+	 *
+	 * @since TBD
+	 *
+	 * @param $name string Name of the provider.
+	 *
+	 * @return string
+	 */
+	public function set_legacy_module_name( $name ) {
+
+		if ( $name === 'Tribe Commerce' ) {
+			return __( 'Tribe Commerce ( Legacy PayPal, not recommended )', 'event-tickets' );
+		}
+
+		return $name;
 	}
 
 }

--- a/src/Tickets/Commerce/Legacy_Compat.php
+++ b/src/Tickets/Commerce/Legacy_Compat.php
@@ -62,12 +62,7 @@ class Legacy_Compat extends tad_DI52_ServiceProvider {
 	 * @return string
 	 */
 	public function set_legacy_module_name( $name ) {
-
-		if ( $name === 'Tribe Commerce' ) {
-			return __( 'Tribe Commerce ( Legacy PayPal, not recommended )', 'event-tickets' );
-		}
-
-		return $name;
+		return $name != 'Tribe Commerce' ? $name : __( 'Tribe Commerce ( Legacy PayPal, not recommended )', 'event-tickets' );
 	}
 
 }

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -71,8 +71,6 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 
 		$args = $this->get_template_vars();
 
-		// @todo @rafsutaskin @gustavo skip showing form for empty cart.
-
 		// Add the rendering attributes into global context.
 		$this->get_template()->add_template_globals( $args );
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -221,8 +221,6 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	 * @return bool
 	 */
 	public function is_active() {
-		$is_active = tec_tickets_commerce_is_enabled() ? false : null;
-
 		/**
 		 * Filters the check for the active status of the PayPal tickets module.
 		 *
@@ -233,7 +231,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		 * @param bool                                   $is_active Whether the provider is active.
 		 * @param Tribe__Tickets__Commerce__PayPal__Main $commerce  The Tickets Commerce provider.
 		 */
-		$is_active = apply_filters( 'tribe_tickets_commerce_paypal_is_active', $is_active, $this );
+		$is_active = apply_filters( 'tribe_tickets_commerce_paypal_is_active', true, $this );
 
 		if ( null !== $is_active ) {
 			return (bool) $is_active;

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -156,7 +156,15 @@ $ticket_fields_end = [
 	],
 ];
 
-$commerce_fields = include 'tribe-commerce-settings.php';
+$commerce_fields = [];
+
+/**
+ * Hide Legacy PayPal settings for new installations.
+ */
+if ( tec_tribe_commerce_is_available() ) {
+	$commerce_fields = include 'tribe-commerce-settings.php';
+}
+
 /**
  * Allows for the specific filtering of the commerce fields.
  *

--- a/src/functions/commerce/provider.php
+++ b/src/functions/commerce/provider.php
@@ -59,11 +59,11 @@ function tribe_tickets_commerce_is_test_mode() {
  */
 function tec_tribe_commerce_is_available() {
 
-	if ( defined( 'TEC_TRIBE_COMMERCE_ENABLED' ) ) {
-		return (bool) TEC_TRIBE_COMMERCE_ENABLED;
+	if ( defined( 'TEC_TRIBE_COMMERCE_AVAILABLE' ) ) {
+		return (bool) TEC_TRIBE_COMMERCE_AVAILABLE;
 	}
 
-	$env_var = getenv( 'TEC_TRIBE_COMMERCE_ENABLED' );
+	$env_var = getenv( 'TEC_TRIBE_COMMERCE_AVAILABLE' );
 
 	if ( false !== $env_var ) {
 		return (bool) $env_var;
@@ -77,7 +77,7 @@ function tec_tribe_commerce_is_available() {
 	 *
 	 * @since TBD
 	 *
-	 * @param $active boolean Should be active or not.
+	 * @param boolean $available should be available or not.
 	 */
-	return apply_filters( 'tec_tribe_commerce_is_available', $active );
+	return apply_filters( 'tec_tribe_commerce_is_available', $available );
 }

--- a/src/functions/commerce/provider.php
+++ b/src/functions/commerce/provider.php
@@ -69,8 +69,8 @@ function tec_tribe_commerce_is_available() {
 		return (bool) $env_var;
 	}
 
-	// Todo, @juanfra @rafsuntaskin decide the proper version.
-	$active = tribe_installed_before( 'Tribe__Tickets__Main', '5.1' );
+	// Available if PayPal was completely setup previously.
+	$available = tribe( 'tickets.commerce.paypal.handler.ipn' )->get_config_status( 'slug' ) === 'complete';
 
 	/**
 	 * Filter whether we should disable TribeCommerce PayPal or not.

--- a/src/functions/commerce/provider.php
+++ b/src/functions/commerce/provider.php
@@ -70,7 +70,15 @@ function tec_tribe_commerce_is_available() {
 	}
 
 	// Available if PayPal was completely setup previously.
-	$available = tribe( 'tickets.commerce.paypal.handler.ipn' )->get_config_status( 'slug' ) === 'complete';
+	$available = tribe()->offsetExists( 'tickets.commerce.paypal.handler.ipn' ) ? tribe( 'tickets.commerce.paypal.handler.ipn' )->get_config_status( 'slug' ) === 'complete' : null;
+
+	if ( is_null( $available ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			'tickets.commerce.paypal.handler.ipn - is not a registered callback.',
+			'TBD'
+		);
+	}
 
 	/**
 	 * Filter whether we should disable TribeCommerce PayPal or not.

--- a/src/functions/commerce/provider.php
+++ b/src/functions/commerce/provider.php
@@ -49,3 +49,35 @@ function tribe_tickets_commerce_is_test_mode() {
 	 */
 	return \TEC\Tickets\Commerce\Gateways\PayPal\Gateway::is_test_mode();
 }
+
+/**
+ * Determine whether the legacy TribeCommerce should be shown or not.
+ *
+ * @since TBD
+ *
+ * @return boolean
+ */
+function tec_tribe_commerce_is_available() {
+
+	if ( defined( 'TEC_TRIBE_COMMERCE_ENABLED' ) ) {
+		return (bool) TEC_TRIBE_COMMERCE_ENABLED;
+	}
+
+	$env_var = getenv( 'TEC_TRIBE_COMMERCE_ENABLED' );
+
+	if ( false !== $env_var ) {
+		return (bool) $env_var;
+	}
+
+	// Todo, @juanfra @rafsuntaskin decide the proper version.
+	$active = tribe_installed_before( 'Tribe__Tickets__Main', '5.1' );
+
+	/**
+	 * Filter whether we should disable TribeCommerce PayPal or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param $active boolean Should be active or not.
+	 */
+	return apply_filters( 'tec_tribe_commerce_is_available', $active );
+}


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Reverted disabling TribeCommerce while Ticket Commerce is enabled, as we need to allow users to show and manage existing Tickets with TribeCommerce.
* Added a label to highlight TribeCommerce as Not Recommended but didn't remove completely for older installs.
* For new installs TribeCommerce is fully disabled and only Ticket commerce is shown.

### Discovery

* I was able to use both TribeCommerce and TicketCommerce in parallel.
* Existing tickets from TribeCommerce are not affected by changes from Ticket Commerce.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screenshot:
https://d.pr/i/QtTnoW


### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
