### PR TITLE
[ET-1205] Fix ticket settings update breaking provider meta data.

### DIFF
--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -440,7 +440,7 @@ class Hooks extends tad_DI52_ServiceProvider {
 		 */
 		$ticket_handler = tribe( 'tickets.handler' );
 
-		add_filter( "sanitize_post_meta_{$ticket_handler->key_provider_field}" , [ $this, 'filter_modify_sanitization_provider_meta' ], 10, 2 );
+		add_filter( "sanitize_post_meta_{$ticket_handler->key_provider_field}" , [ $this, 'filter_modify_sanitization_provider_meta' ] );
 	}
 
 	/**
@@ -448,12 +448,11 @@ class Hooks extends tad_DI52_ServiceProvider {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $meta_key   Metadata key.
 	 * @param mixed  $meta_value Metadata value.
 	 *
 	 * @return string
 	 */
-	public function filter_modify_sanitization_provider_meta( $meta_value, $meta_key ) {
-		return tribe( Settings::class )->skip_sanitization( $meta_value, $meta_key );
+	public function filter_modify_sanitization_provider_meta( $meta_value ) {
+		return tribe( Settings::class )->skip_sanitization( $meta_value );
 	}
 }

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -94,9 +94,9 @@ class Hooks extends tad_DI52_ServiceProvider {
 		// Add a post display state for special Event Tickets pages.
 		add_filter( 'display_post_states', [ $this, 'add_display_post_states' ], 10, 2 );
 
-		// Todo make the following filters dynamic.
-		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_tribe_events' , [ $this, 'skip_sanitization' ], 10, 2 );
-		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_post' , [ $this, 'skip_sanitization' ], 10, 2 );
+		// @todo make the following filters dynamic.
+		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_tribe_events' , [ $this, 'handle_provider_meta' ], 10, 2 );
+		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_post' , [ $this, 'handle_provider_meta' ], 10, 2 );
 	}
 
 	/**
@@ -420,12 +420,17 @@ class Hooks extends tad_DI52_ServiceProvider {
 		return $post_states;
 	}
 
-	public function skip_sanitization( $meta_value, $meta_key ) {
-
-		if ( $meta_value != wp_unslash( tribe( Module::class )->class_name ) ) {
-			return $meta_value;
-		}
-
-		return tribe( Module::class )->class_name;
+	/**
+	 * Handle saving of Ticket provider meta data.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $meta_key   Metadata key.
+	 * @param mixed  $meta_value Metadata value.
+	 *
+	 * @return string
+	 */
+	public function handle_provider_meta( $meta_value, $meta_key ) {
+		return tribe( Settings::class )->skip_sanitization( $meta_value, $meta_key );
 	}
 }

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -94,9 +94,7 @@ class Hooks extends tad_DI52_ServiceProvider {
 		// Add a post display state for special Event Tickets pages.
 		add_filter( 'display_post_states', [ $this, 'add_display_post_states' ], 10, 2 );
 
-		// @todo make the following filters dynamic.
-		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_tribe_events' , [ $this, 'filter_modify_sanitization_provider_meta' ], 10, 2 );
-		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_post' , [ $this, 'filter_modify_sanitization_provider_meta' ], 10, 2 );
+		$this->provider_meta_sanitization_filters();
 	}
 
 	/**
@@ -418,6 +416,31 @@ class Hooks extends tad_DI52_ServiceProvider {
 		$post_states = tribe( Success::class )->maybe_add_display_post_states( $post_states, $post );
 
 		return $post_states;
+	}
+
+	/**
+	 * Add the filter for provider meta sanitization.
+	 *
+	 * @since TBD
+	 */
+	public function provider_meta_sanitization_filters() {
+
+		if ( ! tribe()->offsetExists( 'tickets.handler' ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				'tickets.handler - is not registered.',
+				'TBD'
+			);
+
+			return;
+		}
+
+		/**
+		 * @var \Tribe__Tickets__Tickets_Handler $ticket_handler
+		 */
+		$ticket_handler = tribe( 'tickets.handler' );
+
+		add_filter( "sanitize_post_meta_{$ticket_handler->key_provider_field}" , [ $this, 'filter_modify_sanitization_provider_meta' ], 10, 2 );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -95,8 +95,8 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'display_post_states', [ $this, 'add_display_post_states' ], 10, 2 );
 
 		// @todo make the following filters dynamic.
-		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_tribe_events' , [ $this, 'handle_provider_meta' ], 10, 2 );
-		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_post' , [ $this, 'handle_provider_meta' ], 10, 2 );
+		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_tribe_events' , [ $this, 'filter_modify_sanitization_provider_meta' ], 10, 2 );
+		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_post' , [ $this, 'filter_modify_sanitization_provider_meta' ], 10, 2 );
 	}
 
 	/**
@@ -430,7 +430,7 @@ class Hooks extends tad_DI52_ServiceProvider {
 	 *
 	 * @return string
 	 */
-	public function handle_provider_meta( $meta_value, $meta_key ) {
+	public function filter_modify_sanitization_provider_meta( $meta_value, $meta_key ) {
 		return tribe( Settings::class )->skip_sanitization( $meta_value, $meta_key );
 	}
 }

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -93,6 +93,10 @@ class Hooks extends tad_DI52_ServiceProvider {
 
 		// Add a post display state for special Event Tickets pages.
 		add_filter( 'display_post_states', [ $this, 'add_display_post_states' ], 10, 2 );
+
+		// Todo make the following filters dynamic.
+		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_tribe_events' , [ $this, 'skip_sanitization' ], 10, 2 );
+		add_filter( 'sanitize_post_meta__tribe_default_ticket_provider_for_post' , [ $this, 'skip_sanitization' ], 10, 2 );
 	}
 
 	/**
@@ -416,4 +420,12 @@ class Hooks extends tad_DI52_ServiceProvider {
 		return $post_states;
 	}
 
+	public function skip_sanitization( $meta_value, $meta_key ) {
+
+		if ( $meta_value != wp_unslash( tribe( Module::class )->class_name ) ) {
+			return $meta_value;
+		}
+
+		return tribe( Module::class )->class_name;
+	}
 }

--- a/src/Tickets/Commerce/Legacy_Compat.php
+++ b/src/Tickets/Commerce/Legacy_Compat.php
@@ -45,7 +45,6 @@ class Legacy_Compat extends tad_DI52_ServiceProvider {
 	 * @since TBD
 	 */
 	protected function add_filters() {
-
 		add_filter( 'tribe_events_tickets_module_name', [ $this, 'set_legacy_module_name' ] );
 
 		// Disable TribeCommerce for new installations.

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -398,16 +398,15 @@ class Settings extends Abstract_Settings {
 	}
 
 	/**
-	 * If the provided meta value is from Ticket Commerce then un-slash the meta value.
+	 * If the provided meta value is from Ticket Commerce Module then re-slash the meta value.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $meta_key   Metadata key.
-	 * @param mixed  $meta_value Metadata value.
+	 * @param mixed $meta_value Metadata value.
 	 *
 	 * @return string
 	 */
-	public function skip_sanitization( $meta_value, $meta_key ) {
+	public function skip_sanitization( $meta_value ) {
 		if ( $meta_value === wp_unslash( Module::class ) ) {
 			return Module::class;
 		}

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -408,7 +408,6 @@ class Settings extends Abstract_Settings {
 	 * @return string
 	 */
 	public function skip_sanitization( $meta_value, $meta_key ) {
-
 		if ( $meta_value === wp_unslash( Module::class ) ) {
 			return Module::class;
 		}

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -397,4 +397,23 @@ class Settings extends Abstract_Settings {
 		return $settings;
 	}
 
+	/**
+	 * If the provided meta value is from Ticket Commerce then un-slash the meta value.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $meta_key   Metadata key.
+	 * @param mixed  $meta_value Metadata value.
+	 *
+	 * @return string
+	 */
+	public function skip_sanitization( $meta_value, $meta_key ) {
+
+		if ( $meta_value === wp_unslash( Module::class ) ) {
+			return Module::class;
+		}
+
+		return $meta_value;
+	}
+
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1205] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* When the Ticket Settings update is clicked we trigger the `save_form_settings` method that makes use of `update_post_meta` for saving the provider data.
* For the new Ticket Commerce our provider class is namespaced which should be saved like this as meta: `TEC\\Tickets\\Commerce\\Module` but as it is running through `wp_unslash` it's getting saved as `TECTicketsCommerceModule`.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://d.pr/v/kOMioC

### ✔️ Checklist
- [ ] ~~I've included a changelog entry both in readme.txt.~~ ( Not required )
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1205]: https://theeventscalendar.atlassian.net/browse/ET-1205