### PR TITLE
[ET-1169] tweak padding for going dropdown

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -182,6 +182,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Fixed ticket total formatting when using custom thousands and decimal separators. [ET-1197]
 * Enhancement - When editing an RSVP or ticket in the block editor, allow title to wrap to multiple lines. [ET-1089]
+* Enhancement - Ensure that text for the RSVP going/not going dropdown on front end isn't cut off. [ET-1169]
 
 = [5.1.9.1] 2021-09-08 =
 

--- a/src/resources/postcss/rsvp-v1.pcss
+++ b/src/resources/postcss/rsvp-v1.pcss
@@ -130,6 +130,7 @@
 		height: 30px;
 		line-height: 1;
 		margin-left: 5px;
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1169] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
In the Twenty Twenty One theme, when users go to view their RSVPs on the front end, the "Going/Not Going" dropdown isn't sized appropriately to show all of the text. It gets cut-off. This PR fixes it by removing the padding that Twenty Twenty One adds to all select boxes.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://youtu.be/X7ieTyXy0bU

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1169]: https://theeventscalendar.atlassian.net/browse/ET-1169