### PR TITLE
[ET-1169] ensure arrow shows if set by theme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -182,7 +182,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Fixed ticket total formatting when using custom thousands and decimal separators. [ET-1197]
 * Enhancement - When editing an RSVP or ticket in the block editor, allow title to wrap to multiple lines. [ET-1089]
-* Enhancement - Ensure that text for the RSVP going/not going dropdown on front end isn't cut off. [ET-1169]
+* Enhancement - Ensure that text for the RSVP going/not going dropdown on front end isn't cut off and arrows aren't hidden. [ET-1169]
 
 = [5.1.9.1] 2021-09-08 =
 

--- a/src/resources/postcss/rsvp-v1.pcss
+++ b/src/resources/postcss/rsvp-v1.pcss
@@ -125,7 +125,7 @@
 	}
 
 	select {
-		background: white;
+		background-color: white;
 		border: 1px solid #ddd;
 		height: 30px;
 		line-height: 1;


### PR DESCRIPTION
### 🎫 Ticket

[ET-1169] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We've added a fix within ticket ET-1169 to also keep the background image (if theme sets one) from being hidden.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://youtu.be/Yt_-7MIJxKI

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1169]: https://theeventscalendar.atlassian.net/browse/ET-1169