### PR TITLE
[ET-1201] Disable free ticket for TicketCommerce and TribeCommerce

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Show warning while creating new tickets with `0` price for TribeCommerce. [ET-1201]
 * Tweak - Added a new filter `tribe_tickets_get_provider_query_slug` to allow customization of the provider URL variable name. [ET-543]
 * Tweak - Changed the `provider` URL variable name to `tickets_provider`. The filter `tribe_tickets_get_provider_query_slug` allows for customization. [ET-543]
 * Fix - Fixed text overlapping description in the ticket AR modal. [ET-1179]

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -222,10 +222,13 @@ class Tribe__Tickets__Editor extends Tribe__Editor {
 	 * @return string
 	 */
 	public function filter_get_price_fields( $post_id, $ticket_id ) {
-		$context = array(
+		$provider = Tribe__Tickets__Tickets::get_event_ticket_provider_object( $post_id );
+
+		$context = [
 			'post_id'   => $post_id,
 			'ticket_id' => $ticket_id,
-		);
+			'provider'  => $provider,
+		];
 
 		return tribe( 'tickets.admin.views' )->template( 'editor/fieldset/price', $context );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1201] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* We don't allow tickets with a $0 price for PayPal.
* Previously it was only showing errors for $0 price when the Event/Post was saved and not for new events.
* We have updated the `price` meta box template to show JS error for $0 price ticket on new events/posts.
* This applies for both TribeCommerce and TicketCommerce.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
 📷 screenshot(s): https://d.pr/i/6anTeX


### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1201]: https://theeventscalendar.atlassian.net/browse/ET-1201