### PR TITLE
[ET-1177] Success/order page

### DIFF
--- a/src/Tickets/Commerce/Gateways/PayPal/Client.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Client.php
@@ -125,7 +125,7 @@ class Client {
 	public function request( $method, $url, array $query_args = [], array $request_arguments = [], $raw = false ) {
 		$method = strtoupper( $method );
 
-		// If the endpoint passed is a full URL dont try to append anything.
+		// If the endpoint passed is a full URL don't try to append anything.
 		$url = 0 !== strpos( 'https://', $url )
 			? $this->get_api_url( $url, $query_args )
 			: add_query_arg( $query_args, $url );

--- a/src/Tickets/Commerce/Gateways/PayPal/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/WhoDat.php
@@ -27,7 +27,6 @@ class WhoDat {
 	 *
 	 * @since 5.1.9
 	 *
-	 *
 	 * @param string $endpoint   The endpoint path.
 	 * @param array  $query_args Query args appended to the URL.
 	 *
@@ -72,7 +71,7 @@ class WhoDat {
 	public function get_seller_referral_data( $url ) {
 		$query_args = [
 			'mode' => tribe( Merchant::class )->get_mode(),
-			'url'  => $url
+			'url'  => $url,
 		];
 
 		return $this->get( 'seller/referral-data', $query_args );
@@ -90,7 +89,7 @@ class WhoDat {
 	public function get_seller_status( $saved_merchant_id ) {
 		$query_args = [
 			'mode'        => tribe( Merchant::class )->get_mode(),
-			'merchant_id' => $saved_merchant_id
+			'merchant_id' => $saved_merchant_id,
 		];
 
 		return $this->post( 'seller/status', $query_args );

--- a/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
@@ -40,10 +40,11 @@ class Success_Shortcode extends Shortcode_Abstract {
 		] )->first();
 
 		$args = [
-			'provider_id' => Module::class,
-			'provider'    => tribe( Module::class ),
-			'order_id'    => $order_id,
-			'order'       => $order,
+			'provider_id'   => Module::class,
+			'provider'      => tribe( Module::class ),
+			'order_id'      => $order_id,
+			'order'         => $order,
+			'is_tec_active' => defined( 'TRIBE_EVENTS_FILE' ) && class_exists( 'Tribe__Events__Main' ),
 		];
 
 		$this->template_vars = $args;

--- a/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
@@ -68,7 +68,7 @@ class Success_Shortcode extends Shortcode_Abstract {
 		$html = $this->get_template()->template( 'success', $args, false );
 
 		// Enqueue assets.
-		tribe_asset_enqueue_group( 'tec-tickets-commerce-success' );
+		tribe_asset_enqueue_group( 'tec-tickets-commerce' );
 
 		return $html;
 	}

--- a/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
@@ -68,7 +68,7 @@ class Success_Shortcode extends Shortcode_Abstract {
 		$html = $this->get_template()->template( 'success', $args, false );
 
 		// Enqueue assets.
-		tribe_asset_enqueue_group( 'tec-tickets-commerce' );
+		tribe_asset_enqueue_group( 'tribe-tickets-commerce' );
 
 		return $html;
 	}

--- a/src/resources/postcss/tickets-commerce/_all.pcss
+++ b/src/resources/postcss/tickets-commerce/_all.pcss
@@ -5,3 +5,4 @@
  */
 
 @import "_checkout.pcss";
+@import "_success.pcss";

--- a/src/resources/postcss/tickets-commerce/_success.pcss
+++ b/src/resources/postcss/tickets-commerce/_success.pcss
@@ -1,0 +1,69 @@
+/**
+ * Event Tickets - Tickets Commerce - Success/Order
+ *
+ * @since TBD
+ */
+
+.event-tickets {
+
+	.tribe-tickets__commerce-order {
+		max-width: 600px;
+		position: relative;
+		width: 100%;
+	}
+
+	.tribe-tickets__commerce-order-description,
+	.tribe-tickets__commerce-order-details,
+	.tribe-tickets__commerce-order-footer {
+		margin-top: var(--tec-spacer-7);
+	}
+
+	.tribe-tickets__commerce-order-details-row {
+		display: flex;
+		margin: var(--tec-spacer-0) 0;
+		text-align: left;
+	}
+
+	.tribe-tickets__commerce-order-details-col1 {
+		flex-basis: 25%;
+		min-width: 160px;
+	}
+
+	.tribe-tickets__commerce-order-details-col2 {
+		flex-basis: 75%;
+		font-weight: bold;
+	}
+
+
+	.tribe-tickets__commerce-order-footer-link:not(:first-of-type) {
+		margin-left: var(--tec-spacer-2);
+	}
+
+	.tribe-tickets__commerce-order-footer-link {
+
+		&,
+		&:focus,
+		&:hover,
+		&:visited {
+			color: var(--tec-color-accent-primary);
+		}
+	}
+
+	/* -------------------------------------------------------------------------
+	 * Theme Overrides - Twenty Twenty
+	 * ------------------------------------------------------------------------- */
+
+	.tribe-theme-twentytwenty .entry-content & {
+
+		h1,
+		h2,
+		h3,
+		h4 {
+			margin: initial;
+		}
+
+		&.tribe-tickets__commerce-order {
+			padding: initial;
+		}
+	}
+}

--- a/src/resources/postcss/tickets-commerce/_success.pcss
+++ b/src/resources/postcss/tickets-commerce/_success.pcss
@@ -34,7 +34,6 @@
 		font-weight: bold;
 	}
 
-
 	.tribe-tickets__commerce-order-footer-link:not(:first-of-type) {
 		margin-left: var(--tec-spacer-2);
 	}

--- a/src/views/v2/commerce/checkout/footer.php
+++ b/src/views/v2/commerce/checkout/footer.php
@@ -21,4 +21,5 @@
  * @var bool             $must_login            [Global] Whether login is required to buy tickets or not.
  * @var string           $login_url             [Global] The site's login URL.
  * @var string           $registration_url      [Global] The site's registration URL.
+ * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */

--- a/src/views/v2/commerce/checkout/header/links/back.php
+++ b/src/views/v2/commerce/checkout/header/links/back.php
@@ -29,7 +29,13 @@ if ( empty( $items ) ) {
 	return;
 }
 
-$anchor_text = $is_tec_active ? __( 'back to event', 'event-tickets' ) : __( 'back', 'event-tickets' );
+$anchor_text = $is_tec_active ?
+	sprintf(
+		// Translators: %1$s: Singular `event` in lowercase.
+		__( 'back to %1$s', 'event-tickets' ),
+		tribe_get_event_label_singular_lowercase( 'tickets_commerce_checkout_header_link' )
+	)
+	: __( 'back', 'event-tickets' );
 ?>
 
 <a

--- a/src/views/v2/commerce/checkout/header/title.php
+++ b/src/views/v2/commerce/checkout/header/title.php
@@ -25,7 +25,12 @@
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
+$the_title = sprintf(
+	// Translators: %1$s: Plural `Tickets` label.
+	__( 'Purchase %1$s', 'event-tickets' ),
+	tribe_get_ticket_label_plural( 'tickets_commerce_checkout_title' ) // phpcs:ignore
+);
 ?>
 <h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	<?php esc_html_e( 'Purchase Tickets', 'event-tickets' ); ?>
+	<?php echo esc_html( $the_title ); ?>
 </h3>

--- a/src/views/v2/commerce/order/description.php
+++ b/src/views/v2/commerce/order/description.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/description.php
+++ b/src/views/v2/commerce/order/description.php
@@ -21,5 +21,11 @@
 
 ?>
 <div class="tribe-common-b1 tribe-tickets__commerce-order-description">
-	<?php esc_html_e( 'Thank you. Your order has been received. A receipt for purchase and any digital tickets ordered will be emailed to you shortly.', 'event-tickets' ); ?>
+	<?php
+	printf(
+		// Translators: %1$s: Plural `tickets` in lowercase.
+		esc_html__( 'Thank you. Your order has been received. A receipt for purchase and any digital %1$s ordered will be emailed to you shortly.', 'event-tickets' ),
+		tribe_get_ticket_label_plural_lowercase( 'tickets_commerce_order_description' ) // phpcs:ignore
+	);
+	?>
 </div>

--- a/src/views/v2/commerce/order/description.php
+++ b/src/views/v2/commerce/order/description.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Description
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/description.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,6 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-common-b1 tribe-tickets__commerce-order-description">
+	<?php esc_html_e( 'Thank you. Your order has been received. A receipt for purchase and any digital tickets ordered will be emailed to you shortly.', 'event-tickets' ); ?>
+</div>

--- a/src/views/v2/commerce/order/details.php
+++ b/src/views/v2/commerce/order/details.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/details.php
+++ b/src/views/v2/commerce/order/details.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Details
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/details.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,10 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-common-b1 tribe-tickets__commerce-order-details">
+	<?php $this->template( 'order/details/order-number' ); ?>
+	<?php $this->template( 'order/details/date' ); ?>
+	<?php $this->template( 'order/details/email' ); ?>
+	<?php $this->template( 'order/details/total' ); ?>
+	<?php $this->template( 'order/details/payment-method' ); ?>
+</div>

--- a/src/views/v2/commerce/order/details/date.php
+++ b/src/views/v2/commerce/order/details/date.php
@@ -25,6 +25,6 @@
 		<?php esc_html_e( 'Date:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		August 30, 2021
+		<?php the_date( '', $order->ID ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/date.php
+++ b/src/views/v2/commerce/order/details/date.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/details/date.php
+++ b/src/views/v2/commerce/order/details/date.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Details > Date
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/details/date.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,11 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-tickets__commerce-order-details-row">
+	<div class="tribe-tickets__commerce-order-details-col1">
+		<?php esc_html_e( 'Date:', 'event-tickets' ); ?>
+	</div>
+	<div class="tribe-tickets__commerce-order-details-col2">
+		August 30, 2021
+	</div>
+</div>

--- a/src/views/v2/commerce/order/details/date.php
+++ b/src/views/v2/commerce/order/details/date.php
@@ -25,6 +25,6 @@
 		<?php esc_html_e( 'Date:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		<?php the_date( '', $order->ID ); ?>
+		<?php echo esc_html( get_the_date( get_option( 'date_format' ), $order->ID ) ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/email.php
+++ b/src/views/v2/commerce/order/details/email.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Details > Email
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/details/email.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,11 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-tickets__commerce-order-details-row">
+	<div class="tribe-tickets__commerce-order-details-col1">
+		<?php esc_html_e( 'Email:', 'event-tickets' ); ?>
+	</div>
+	<div class="tribe-tickets__commerce-order-details-col2">
+		john@doe.com
+	</div>
+</div>

--- a/src/views/v2/commerce/order/details/email.php
+++ b/src/views/v2/commerce/order/details/email.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/details/email.php
+++ b/src/views/v2/commerce/order/details/email.php
@@ -19,12 +19,16 @@
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
+if ( empty( $order->purchaser['email'] ) ) {
+	return;
+}
+
 ?>
 <div class="tribe-tickets__commerce-order-details-row">
 	<div class="tribe-tickets__commerce-order-details-col1">
 		<?php esc_html_e( 'Email:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		john@doe.com
+		<?php echo esc_html( $order->purchaser['email'] ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/order-number.php
+++ b/src/views/v2/commerce/order/details/order-number.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Details > Order number
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/details/order-number.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,11 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-tickets__commerce-order-details-row">
+	<div class="tribe-tickets__commerce-order-details-col1">
+		<?php esc_html_e( 'Order number:', 'event-tickets' ); ?>
+	</div>
+	<div class="tribe-tickets__commerce-order-details-col2">
+		001
+	</div>
+</div>

--- a/src/views/v2/commerce/order/details/order-number.php
+++ b/src/views/v2/commerce/order/details/order-number.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/details/order-number.php
+++ b/src/views/v2/commerce/order/details/order-number.php
@@ -19,12 +19,16 @@
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
+if ( empty( $order->gateway_order_id ) ) {
+	return;
+}
+
 ?>
 <div class="tribe-tickets__commerce-order-details-row">
 	<div class="tribe-tickets__commerce-order-details-col1">
 		<?php esc_html_e( 'Order number:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		001
+		<?php echo esc_html( $order->gateway_order_id ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/payment-method.php
+++ b/src/views/v2/commerce/order/details/payment-method.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/details/payment-method.php
+++ b/src/views/v2/commerce/order/details/payment-method.php
@@ -19,12 +19,16 @@
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
+if ( empty( $order->gateway ) ) {
+	return;
+}
+
 ?>
 <div class="tribe-tickets__commerce-order-details-row">
 	<div class="tribe-tickets__commerce-order-details-col1">
 		<?php esc_html_e( 'Payment method:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		PayPal
+		<?php echo esc_html( $order->gateway ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/payment-method.php
+++ b/src/views/v2/commerce/order/details/payment-method.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Details > Payment Method
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/details/payment-method.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,11 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-tickets__commerce-order-details-row">
+	<div class="tribe-tickets__commerce-order-details-col1">
+		<?php esc_html_e( 'Payment method:', 'event-tickets' ); ?>
+	</div>
+	<div class="tribe-tickets__commerce-order-details-col2">
+		PayPal
+	</div>
+</div>

--- a/src/views/v2/commerce/order/details/total.php
+++ b/src/views/v2/commerce/order/details/total.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Details > Total
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/details/total.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,11 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-tickets__commerce-order-details-row">
+	<div class="tribe-tickets__commerce-order-details-col1">
+		<?php esc_html_e( 'Total:', 'event-tickets' ); ?>
+	</div>
+	<div class="tribe-tickets__commerce-order-details-col2">
+		$25
+	</div>
+</div>

--- a/src/views/v2/commerce/order/details/total.php
+++ b/src/views/v2/commerce/order/details/total.php
@@ -19,12 +19,16 @@
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
+if ( empty( $order->total_value ) ) {
+	return;
+}
+
 ?>
 <div class="tribe-tickets__commerce-order-details-row">
 	<div class="tribe-tickets__commerce-order-details-col1">
 		<?php esc_html_e( 'Total:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		$25
+		<?php echo esc_html( $order->$total_value ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/total.php
+++ b/src/views/v2/commerce/order/details/total.php
@@ -29,6 +29,6 @@ if ( empty( $order->total_value ) ) {
 		<?php esc_html_e( 'Total:', 'event-tickets' ); ?>
 	</div>
 	<div class="tribe-tickets__commerce-order-details-col2">
-		<?php echo esc_html( $order->$total_value ); ?>
+		<?php echo esc_html( $order->total_value ); ?>
 	</div>
 </div>

--- a/src/views/v2/commerce/order/details/total.php
+++ b/src/views/v2/commerce/order/details/total.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/footer.php
+++ b/src/views/v2/commerce/order/footer.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Footer
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/footer.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,6 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<footer class="tribe-tickets__commerce-order-footer">
+	<?php $this->template( 'order/footer/links' ); ?>
+</footer>

--- a/src/views/v2/commerce/order/footer.php
+++ b/src/views/v2/commerce/order/footer.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/footer/links.php
+++ b/src/views/v2/commerce/order/footer/links.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/footer/links.php
+++ b/src/views/v2/commerce/order/footer/links.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Footer Links
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/footer/links.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,7 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<div class="tribe-common-b2 tribe-tickets__commerce-order-footer-links">
+	<?php $this->template( 'order/footer/links/browse-events' ); ?>
+	<?php $this->template( 'order/footer/links/back-home' ); ?>
+</div>

--- a/src/views/v2/commerce/order/footer/links/back-home.php
+++ b/src/views/v2/commerce/order/footer/links/back-home.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/footer/links/back-home.php
+++ b/src/views/v2/commerce/order/footer/links/back-home.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Footer Links > Back home.
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/footer/links/back-home.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,8 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<a
+	class="tribe-common-anchor-alt tribe-tickets__commerce-order-footer-link tribe-tickets__commerce-order-footer-link--back-home"
+	href="<?php echo esc_url( home_url() ); ?>">
+	<?php esc_html_e( 'back home', 'event-tickets' ); ?>
+</a>

--- a/src/views/v2/commerce/order/footer/links/browse-events.php
+++ b/src/views/v2/commerce/order/footer/links/browse-events.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Footer Links > Browse events.
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/footer/links/browse-events.php
  *
  * See more documentation about our views templating system.
  *
@@ -19,10 +19,19 @@
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
+if ( empty( $is_tec_active ) ) {
+	return;
+}
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+<a
+	class="tribe-common-anchor-alt tribe-tickets__commerce-order-footer-link tribe-tickets__commerce-order-footer-link--browse-events"
+	href="<?php echo tribe_events_get_url(); // phpcs:ignore ?>"
+>
+	<?php
+		printf(
+			// Translators: %1$s: Plural `events` in lowercase.
+			esc_html__( 'browse more %1$s', 'event-tickets' ),
+			tribe_get_event_label_plural_lowercase( 'tickets_commerce_order_footer_link' ) // phpcs:ignore
+		);
+		?>
+</a>

--- a/src/views/v2/commerce/order/footer/links/browse-events.php
+++ b/src/views/v2/commerce/order/footer/links/browse-events.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 

--- a/src/views/v2/commerce/order/header.php
+++ b/src/views/v2/commerce/order/header.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tickets Commerce: Success Order Page
+ * Tickets Commerce: Success Order Page Header
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/v2/commerce/success.php
+ * [your-theme]/tribe/tickets/v2/commerce/order/header.php
  *
  * See more documentation about our views templating system.
  *
@@ -20,9 +20,9 @@
  */
 
 ?>
-<section class="tribe-common event-tickets tribe-tickets__commerce-order">
-	<?php $this->template( 'order/header' ); ?>
-	<?php $this->template( 'order/description' ); ?>
-	<?php $this->template( 'order/details' ); ?>
-	<?php $this->template( 'order/footer' ); ?>
-</section>
+
+<header class="tribe-tickets__commerce-order-header">
+	<h3 class="tribe-common-h2 tribe-tickets__commerce-order-header-title">
+		<?php esc_html_e( 'Order Received!', 'event-tickets' ); ?>
+	</h3>
+</header>

--- a/src/views/v2/commerce/order/header.php
+++ b/src/views/v2/commerce/order/header.php
@@ -16,11 +16,12 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 
 ?>
-
 <header class="tribe-tickets__commerce-order-header">
 	<h3 class="tribe-common-h2 tribe-tickets__commerce-order-header-title">
 		<?php esc_html_e( 'Order Received!', 'event-tickets' ); ?>

--- a/src/views/v2/commerce/success.php
+++ b/src/views/v2/commerce/success.php
@@ -16,6 +16,8 @@
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.
  * @var string           $provider_id           [Global] The tickets provider class name.
+ * @var \WP_Post         $order                 [Global] The order object.
+ * @var int              $order_id              [Global] The order ID.
  * @var bool             $is_tec_active         [Global] Whether `The Events Calendar` is active or not.
  */
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1177] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Adding templates and styles for the success/order page.
- Adding implementation so that we can demo the complete flow.
- I couldn't set up TC w/Paypal locally, so I ended up working on this like the old days, assuming, pushing to the sandbox, and updating a few items via sFTP.

**Things that we need to revisit**

- After strategy we need to check the naming here, to see if we keep with "success" for the shortcode or we do something more oriented to "order".
- Snapshot tests will come in a later PR.
- See if we can abstract order methods to use them directly (like for method, or total which is not including the currency symbol right now).

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img src="https://cldup.com/X8ERfj4dai.png">

### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1177]: https://theeventscalendar.atlassian.net/browse/ET-1177