### PR TITLE
Fixed loader cached issue for Firefox and Safari

### DIFF
--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -451,6 +451,13 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 
 		if ( ! $script.length ) {
 			$document.trigger( tribe.tickets.commerce.customEvents.hideLoader );
+		}
+
+		/**
+		 * If PayPal is loaded already then setup PayPal buttons.
+		 */
+		if ( typeof paypal !== 'undefined' ) {
+			obj.setupButtons( {}, $( tribe.tickets.commerce.selectors.checkoutContainer ) );
 			return;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1212] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* For Firefox and Safari browsers, if the PayPal script was cached then it was not firing the `window.onload` event causing the loader hide script to be skipped.
* We have now checked for the `paypal` variable and triggered the button loader immediately if `paypal` is available instead of using the onload event.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s) : https://d.pr/i/kE13ix

### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
