### PR TITLE
[ET-1238] Add central method to get ticket prices

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Enhancement - Add getPrice method to utilities JS object to centralize the way we get ticket prices. [ET-1238]
+
 = [5.1.10] 2021-09-27 =
 
 * Enhancement - When editing an RSVP or ticket in the block editor, allow title to wrap to multiple lines. [ET-1089]

--- a/src/resources/js/v2/tickets-utils.js
+++ b/src/resources/js/v2/tickets-utils.js
@@ -225,4 +225,24 @@ tribe.tickets.utils = {};
 		// Return the post id for the first ticket block.
 		return $ticketsBlock.getAttribute( 'data-post-id' ) || false;
 	};
+
+	/**
+	 * Get the price of the ticket from the ticket item element
+	 *
+	 * @since TBD
+	 *
+	 * @return {float|int} The ticket price.
+	 */
+	obj.getPrice = function( $ticketItem, provider ) {
+		if ( $ticketItem ) {
+			const realPrice = $ticketItem.data( 'ticket-price' );
+			const formattedPrice = $ticketItem.find( '.tribe-tickets__tickets-sale-price .tribe-amount' ).text();
+			const priceString = isNaN( realPrice ) 
+				? obj.cleanNumber( formattedPrice, provider ) 
+				: realPrice;
+				return parseFloat( priceString );
+		}
+		return 0;
+	};
+
 } )( jQuery, tribe.tickets.utils );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1238] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
In order to consolidate code and simplify things, we're consolidating the way we get the ticket price (both on ET and ET+).

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Not applicable

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
