### PR TITLE
[ET-1214] AR Fields are not being saved with Ticket Commerce tickets.

### DIFF
--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -630,16 +630,16 @@ class Ticket {
 		do_action( "tec_tickets_commerce_after_{$save_type}_ticket", $post_id, $ticket, $raw_data, static::class );
 
 		/**
-		 * Generic action fired after saving a ticket
+		 * Generic action fired after saving a ticket.
 		 *
-		 * @since 4.7
+		 * @since TBD
 		 *
 		 * @param int                            $post_id  Post ID of post the ticket is tied to
 		 * @param \Tribe__Tickets__Ticket_Object $ticket   Ticket that was just saved
 		 * @param array                          $raw_data Ticket data
 		 * @param string                         $class    Commerce engine class
 		 */
-		do_action( 'tec_tickets_commerce_after_save_ticket', $post_id, $ticket, $raw_data, static::class );
+		do_action( 'event_tickets_after_save_ticket', $post_id, $ticket, $raw_data, static::class );
 
 		return $ticket->ID;
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1214] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* We were not using the proper action hook for saving ticket data that triggers the saving of Ticket Plus Meta.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast: https://d.pr/i/Z7lrJb


### ✔️ Checklist
- [ ] ~~I've included a changelog entry both in readme.txt and changelog.txt files.~~ <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1214]: https://theeventscalendar.atlassian.net/browse/ET-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ