### PR TITLE
[ET-1216] Price formatting issues on ticket row totals in AR modal

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fixed ticket total formatting within the attendee registration modal when using custom thousands and decimal separators. [ET-1216]
+
 = [5.1.10] 2021-09-27 =
 
 * Enhancement - When editing an RSVP or ticket in the block editor, allow title to wrap to multiple lines. [ET-1089]

--- a/src/resources/js/v2/tickets-block.js
+++ b/src/resources/js/v2/tickets-block.js
@@ -207,16 +207,10 @@ tribe.tickets.block = {
 				return;
 			}
 
-			const $price = $input.closest( obj.selectors.item ).find( obj.selectors.itemPrice ).first();
-			const realPrice = $input.closest( obj.selectors.item ).data( 'ticket-price' );
 			let quantity = parseInt( $input.val(), 10 );
 			quantity = isNaN( quantity ) ? 0 : quantity;
-
-			// Only use tribe.tickets.utils.cleanNumber() if getting price from text block.
-			const ticketPrice = isNaN( realPrice ) 
-				? tribe.tickets.utils.cleanNumber( $price.text(), provider )
-				: realPrice.toString();
-
+			const $ticketItem = $input.closest( obj.selectors.item );
+			const ticketPrice = obj.getPrice( $ticketItem, provider );
 			const cost = ticketPrice * quantity;
 			footerAmount += cost;
 		} );
@@ -465,21 +459,12 @@ tribe.tickets.block = {
 	 *
 	 * @since 5.0.3
 	 *
-	 * @param {jQuery} $cartItem The jQuery object of the cart item to update.
-	 *
+	 * @param {jQuery} $item The jQuery object of the ticket item to update.
+	 * 
 	 * @returns {number} The item price.
 	 */
-	obj.getPrice = function( $cartItem ) {
-		const $form = $cartItem.closest( 'form' );
-		const provider = obj.getTicketsBlockProvider( $form );
-
-		const $price = $cartItem.find( obj.selectors.itemPrice ).first();
-		const realPrice = $cartItem.closest( obj.selectors.item ).data( 'ticket-price' );
-		const text = isNaN( realPrice ) ? $price.text() : realPrice.toString();
-
-		const price = tribe.tickets.utils.cleanNumber( text, provider );
-
-		return isNaN( price ) ? 0 : price;
+	obj.getPrice = function( $item ) {
+		return tribe.tickets.utils.getPrice( $item, obj.tribe_tickets_provider );
 	};
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[ET-1216] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Within the AR Modal, there are totals for each individual row of tickets. They were adding up incorrectly when using a comma for the decimal separator.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Screenshot showing the incorrect totals: https://d.pr/i/n1I8vA
Video showing issue and fix: https://youtu.be/hN-3p2z58ss

### ✔️ Checklist
- [x] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
