### PR TITLE
[ETP-703] Cancelled Tickets checkbox not hiding from manual attendee editing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Added `allow_resending_email` method which can be used to enable or disable resending email. [ETP-703]
+* Enhancement - Added filter `tribe_tickets_manual_attendee_allow_email_resend` to allow customization of email resending via Manual Attendees depending on status. [ETP-703]
 * Enhancement - Add `getPrice` method to utilities JS object to centralize the way we get ticket prices. [ET-1238]
 * Fix - Fixed ticket total formatting within the attendee registration modal when using custom thousands and decimal separators. [ET-1216]
 * Bug - Searching Ticket Holder Email / Ticket Holder Name through the Attendee page now functions as expected. [ET-1171]

--- a/readme.txt
+++ b/readme.txt
@@ -180,13 +180,13 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Fix - Added `allow_resending_email` method which can be used to enable or disable resending email. [ETP-703]
 * Enhancement - Added filter `tribe_tickets_manual_attendee_allow_email_resend` to allow customization of email resending via Manual Attendees depending on status. [ETP-703]
 * Enhancement - Add `getPrice` method to utilities JS object to centralize the way we get ticket prices. [ET-1238]
+* Fix - Added `allow_resending_email` method which can be used to enable or disable resending email. [ETP-703]
 * Fix - Fixed ticket total formatting within the attendee registration modal when using custom thousands and decimal separators. [ET-1216]
-* Bug - Searching Ticket Holder Email / Ticket Holder Name through the Attendee page now functions as expected. [ET-1171]
 * Fix - QR Code API generation settings not working if `The Events Calendar` plugin was not active. [ETP-754]
 * Fix - Fixed the event cost formatting issues showing the wrong currency symbol, symbol location and separators. [ET-1251]
+* Bug - Searching Ticket Holder Email / Ticket Holder Name through the Attendee page now functions as expected. [ET-1171]
 
 = [5.1.10] 2021-09-27 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Added `allow_resending_email` method which can be used to enable or disable resending email. [ETP-703]
 * Enhancement - Add `getPrice` method to utilities JS object to centralize the way we get ticket prices. [ET-1238]
 * Fix - Fixed ticket total formatting within the attendee registration modal when using custom thousands and decimal separators. [ET-1216]
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1014,7 +1014,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 * @return bool Whether to allow email resending.
 			 *
 			 */
-			return (bool)apply_filters('tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, $ticket, $attendee);
+			return (bool) apply_filters( 'tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, $ticket, $attendee );
 		}
 
 		/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -996,8 +996,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param WP_Post|null $ticket                The ticket post object if available, otherwise null.
-		 * @param array|null   $attendee              The attendee information if available, otherwise null.
+		 * @param WP_Post|null $ticket   The ticket post object if available, otherwise null.
+		 * @param array|null   $attendee The attendee information if available, otherwise null.
 		 *
 		 *  @return boolean
 		 */

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1001,7 +1001,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 *  @return boolean
 		 */
-		public function allow_resending_email($ticket = null, $attendee = null) {
+		public function allow_resending_email( $ticket = null, $attendee = null ) {
 			/**
 			 *
 			 * Shared filter between Woo, EDD, and the default logic.

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -998,6 +998,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @param WP_Post|null $ticket                The ticket post object if available, otherwise null.
 		 * @param array|null   $attendee              The attendee information if available, otherwise null.
+		 *
+		 *  @return boolean
 		 */
 		public function allow_resending_email($ticket = null, $attendee = null) {
 			/**
@@ -1010,8 +1012,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 *
 			 * @param WP_Post|null $ticket The ticket post object if available, otherwise null.
 			 * @param array|null $attendee The attendee information if available, otherwise null.
-			 *
-			 * @return bool Whether to allow email resending.
 			 *
 			 */
 			return (bool) apply_filters( 'tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, $ticket, $attendee );

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -999,9 +999,21 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param WP_Post|null $ticket                The ticket post object if available, otherwise null.
 		 * @param array|null   $attendee              The attendee information if available, otherwise null.
 		 */
-		public function allow_resending_email( $ticket = null, $attendee = null ) {
-			// Fallback logic, function should return true.
-			return true;
+		public function allow_resending_email($ticket = null, $attendee = null) {
+			/**
+			 *
+			 * Shared filter between Woo, EDD, and the default logic.
+			 * This filter allows the admin to control the re-send email option when an attendee's email is updated per a payment type (EDD, Woo, etc).
+			 * True means allow email resend, false means disallow email resend.
+			 *
+			 * @param bool $allow_resending_email Whether to allow email resending.
+			 * @param WP_Post|null $ticket The ticket post object if available, otherwise null.
+			 * @param array|null $attendee The attendee information if available, otherwise null.
+			 * @since 5.1.0
+			 *
+			 * @since TBD - Added $allow_resending_email variable to check if provider allows emailing to occur.
+			 */
+			return (bool)apply_filters('tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, $ticket, $attendee);
 		}
 
 		/**
@@ -2687,7 +2699,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @param  float|string $cost
 		 * @param  int   		$post_id
-		 * 
+		 *
 		 * @return string
 		 */
 		public function maybe_format_event_cost( $cost, $post_id ) {

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1008,9 +1008,10 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 *
 			 * @since TBD
 			 *
-			 * @param bool $allow_resending_email Whether to allow email resending.
 			 * @param WP_Post|null $ticket The ticket post object if available, otherwise null.
 			 * @param array|null $attendee The attendee information if available, otherwise null.
+			 *
+			 * @return bool Whether to allow email resending.
 			 *
 			 */
 			return (bool)apply_filters('tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, $ticket, $attendee);

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1006,12 +1006,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 * This filter allows the admin to control the re-send email option when an attendee's email is updated per a payment type (EDD, Woo, etc).
 			 * True means allow email resend, false means disallow email resend.
 			 *
+			 * @since TBD
+			 *
 			 * @param bool $allow_resending_email Whether to allow email resending.
 			 * @param WP_Post|null $ticket The ticket post object if available, otherwise null.
 			 * @param array|null $attendee The attendee information if available, otherwise null.
-			 * @since 5.1.0
 			 *
-			 * @since TBD - Added $allow_resending_email variable to check if provider allows emailing to occur.
 			 */
 			return (bool)apply_filters('tribe_tickets_my_tickets_allow_email_resend_on_attendee_email_update', true, $ticket, $attendee);
 		}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -992,6 +992,19 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		/**
+		 * Handles if email sending is allowed.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_Post|null $ticket                The ticket post object if available, otherwise null.
+		 * @param array|null   $attendee              The attendee information if available, otherwise null.
+		 */
+		public function allow_resending_email( $ticket = null, $attendee = null ) {
+			// Fallback logic, function should return true.
+			return true;
+		}
+
+		/**
 		 * Mark an attendee as checked in
 		 *
 		 * @abstract

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Admin/PayPal/Connect/__snapshots__/InactiveTest__test_should_render__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Admin/PayPal/Connect/__snapshots__/InactiveTest__test_should_render__1.php
@@ -26,7 +26,7 @@
 	<a
 		target="_blank"
 		data-paypal-onboard-complete="onboardedCallback"
-		href="&displayMode=minibrowser"
+		href="http://thepaypalsandboxlink.tec.com/hash&displayMode=minibrowser"
 		data-paypal-button="true"
 		id="connect_to_paypal"
 		class="tec-tickets__admin-settings-tickets-commerce-paypal-connect-button-link"


### PR DESCRIPTION
### 🎫 Ticket

[ETP-703] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**This ticket is part of https://github.com/the-events-calendar/event-tickets-plus/pull/1271 and must be merged together to function.**

<!-- Please describe what you have changed or added -->
This PR incorporates a bunch of changes to the logic behind the scenes. As well  as adds a new function `allow_resending_email` into WooCommerce/EDD for cancelled or refunded orders.

This logic will most likely need to be added into Paypal as well.
    
Added a new filter  called `tribe_tickets_manual_attendee_allow_email_resend`. This filter will allow uses to alter the logic for allowing emails to send.
    
```function tec_customize_manual_attendee_email_by_status($allow_email, $ticket, $attendee)
    {
        //Logic here based off of $attendee['order_status'].
        //For testing return either true (to allow) or false (to disable).
        return false;
    }

add_filter('tribe_tickets_manual_attendee_allow_email_resend', 'tec_customize_manual_attendee_email_by_status', 10, 3);
```
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
When an order is cancelled/refunded and the email is updated the "resend email" button will no longer appear 
![image](https://user-images.githubusercontent.com/12241059/133818364-4c0c6bad-bab2-41ac-9913-97065c040e20.png)

when an order is not cancelled/not refunded and the email is updated the "resend email" button will still appear
![image](https://user-images.githubusercontent.com/12241059/133818399-1fd473c8-76ad-4405-96ee-efae686ce9c3.png)


### ✔️ Checklist
- [x] I've included a readme.txt Changelog entry. <!-- Confirm that it includes the ticket ID -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-703]: https://theeventscalendar.atlassian.net/browse/ETP-703