### PR TITLE
Flush transients whens saving plugin options

### DIFF
--- a/src/Tickets/Commerce/Gateways/PayPal/Hooks.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Hooks.php
@@ -79,7 +79,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tec_tickets_commerce_success_shortcode_checkout_page_paypal_template_vars', [ $this, 'include_checkout_page_vars' ], 10, 2 );
 		add_filter( 'tec_tickets_commerce_success_shortcode_success_page_paypal_template_vars', [ $this, 'include_success_page_vars' ], 10, 2 );
 		add_filter( 'tec_tickets_commerce_notice_messages', [ $this, 'include_admin_notices' ] );
-		add_filter( 'tribe-events-save-options', [ tribe( Signup::class ), 'flush_transients_when_toggling_sandbox_mode' ] );
+		add_filter( 'tribe-events-save-options', [ $this, 'flush_transients_when_toggling_sandbox_mode' ] );
 	}
 
 	/**
@@ -355,5 +355,18 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		}
 
 		$template->template( 'gateway/paypal/order/details/capture-id', [ 'capture_id' => $capture_id ] );
+	}
+
+	/**
+	 * Checks if the transient data needs to be flushed when saving options and deletes it if appropriate
+	 *
+	 * @since TBD
+	 *
+	 * @param array $options the list of plugin options set for saving
+	 *
+	 * @return array
+	 */
+	public function flush_transients_when_toggling_sandbox_mode( $options ) {
+		return $this->container->make( Signup::class )->maybe_delete_transient_data( $options );
 	}
 }

--- a/src/Tickets/Commerce/Gateways/PayPal/Hooks.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Hooks.php
@@ -67,7 +67,6 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_action( 'admin_init', [ $this, 'render_ssl_notice' ] );
 
 		add_action( 'tribe_template_after_include:tickets/v2/commerce/order/details/order-number', [ $this, 'include_capture_id_success_page' ], 10, 3 );
-		add_filter( 'tribe-events-save-options', [ $this, 'flush_transients_when_toggling_sandbox_mode' ] );
 	}
 
 	/**
@@ -80,6 +79,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tec_tickets_commerce_success_shortcode_checkout_page_paypal_template_vars', [ $this, 'include_checkout_page_vars' ], 10, 2 );
 		add_filter( 'tec_tickets_commerce_success_shortcode_success_page_paypal_template_vars', [ $this, 'include_success_page_vars' ], 10, 2 );
 		add_filter( 'tec_tickets_commerce_notice_messages', [ $this, 'include_admin_notices' ] );
+		add_filter( 'tribe-events-save-options', [ tribe( Signup::class ), 'flush_transients_when_toggling_sandbox_mode' ] );
 	}
 
 	/**
@@ -355,31 +355,5 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		}
 
 		$template->template( 'gateway/paypal/order/details/capture-id', [ 'capture_id' => $capture_id ] );
-	}
-
-	/**
-	 * When toggling between PayPal test mode and live mode, we need to re-generate
-	 * the transients to make sure the proper URLs are used.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $options the list of plugin options set for saving
-	 *
-	 * @return array
-	 */
-	public function flush_transients_when_toggling_sandbox_mode( $options ) {
-
-		if ( ! isset( $options[ Settings::$option_sandbox ] ) ) {
-			return $options;
-		}
-
-		if ( tec_tickets_commerce_is_sandbox_mode() === $options[ Settings::$option_sandbox ] ) {
-			return $options;
-		}
-
-		$signup = tribe( Signup::class );
-		$signup->delete_transient_data();
-
-		return $options;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/PayPal/Signup.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Signup.php
@@ -4,6 +4,7 @@ namespace TEC\Tickets\Commerce\Gateways\PayPal;
 
 use TEC\Tickets\Commerce\Gateways\PayPal\Location\Country;
 use TEC\Tickets\Commerce\Gateways\PayPal\REST\On_Boarding_Endpoint;
+use TEC\Tickets\Commerce\Settings;
 use Tribe__Utils__Array as Arr;
 
 /**
@@ -358,5 +359,30 @@ class Signup {
 
 		// If there were errors then redirect the user with notices
 		return $error_messages;
+	}
+
+	/**
+	 * When toggling between PayPal test mode and live mode, we need to re-generate
+	 * the transients to make sure the proper URLs are used.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $options the list of plugin options set for saving
+	 *
+	 * @return array
+	 */
+	public function flush_transients_when_toggling_sandbox_mode( $options ) {
+
+		if ( ! isset( $options[ Settings::$option_sandbox ] ) ) {
+			return $options;
+		}
+
+		if ( tec_tickets_commerce_is_sandbox_mode() === $options[ Settings::$option_sandbox ] ) {
+			return $options;
+		}
+
+		$this->delete_transient_data();
+
+		return $options;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/PayPal/Signup.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Signup.php
@@ -371,7 +371,7 @@ class Signup {
 	 *
 	 * @return array
 	 */
-	public function flush_transients_when_toggling_sandbox_mode( $options ) {
+	public function maybe_delete_transient_data( $options ) {
 
 		if ( ! isset( $options[ Settings::$option_sandbox ] ) ) {
 			return $options;

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -122,7 +122,6 @@ class Hooks extends tad_DI52_ServiceProvider {
 
 		add_filter( 'tec_tickets_commerce_payments_tab_settings', [ $this, 'filter_payments_tab_settings' ] );
 
-		add_filter( 'tribe-events-save-options', [ $this, 'flush_transients_when_toggling_sandbox_mode' ] );
 	}
 
 	/**
@@ -704,25 +703,4 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'wp_redirect', [ tribe( Compatibility\Events::class ), 'prevent_filter_redirect_canonical' ], 1, 2 );
 	}
 
-	/**
-	 * When toggling between PayPal test mode and live mode, we need to re-generate
-	 * the transients to make sure the proper URLs are used.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $options the list of plugin options set for saving
-	 *
-	 * @return array
-	 */
-	public function flush_transients_when_toggling_sandbox_mode( $options ) {
-
-		if ( isset( $options[ Settings::$option_sandbox ] ) &&
-			 tec_tickets_commerce_is_sandbox_mode() !== $options[ Settings::$option_sandbox ]
-		) {
-			$signup = tribe( Base_Commerce\Gateways\PayPal\Signup::class );
-			$signup->delete_transient_data();
-		}
-
-		return $options;
-	}
 }

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -121,6 +121,8 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'tribe_template_context:tickets-plus/v2/tickets/submit/button-modal', [ $this, 'filter_showing_cart_button' ] );
 
 		add_filter( 'tec_tickets_commerce_payments_tab_settings', [ $this, 'filter_payments_tab_settings' ] );
+
+		add_filter( 'tribe-events-save-options', [ $this, 'flush_transients_when_toggling_sandbox_mode' ] );
 	}
 
 	/**
@@ -700,5 +702,27 @@ class Hooks extends tad_DI52_ServiceProvider {
 		}
 
 		add_filter( 'wp_redirect', [ tribe( Compatibility\Events::class ), 'prevent_filter_redirect_canonical' ], 1, 2 );
+	}
+
+	/**
+	 * When toggling between PayPal test mode and live mode, we need to re-generate
+	 * the transients to make sure the proper URLs are used.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $options the list of plugin options set for saving
+	 *
+	 * @return array
+	 */
+	public function flush_transients_when_toggling_sandbox_mode( $options ) {
+
+		if ( isset( $options[ Settings::$option_sandbox ] ) &&
+			 tec_tickets_commerce_is_sandbox_mode() !== $options[ Settings::$option_sandbox ]
+		) {
+			$signup = tribe( Base_Commerce\Gateways\PayPal\Signup::class );
+			$signup->delete_transient_data();
+		}
+
+		return $options;
 	}
 }

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -121,7 +121,6 @@ class Hooks extends tad_DI52_ServiceProvider {
 		add_filter( 'tribe_template_context:tickets-plus/v2/tickets/submit/button-modal', [ $this, 'filter_showing_cart_button' ] );
 
 		add_filter( 'tec_tickets_commerce_payments_tab_settings', [ $this, 'filter_payments_tab_settings' ] );
-
 	}
 
 	/**
@@ -702,5 +701,4 @@ class Hooks extends tad_DI52_ServiceProvider {
 
 		add_filter( 'wp_redirect', [ tribe( Compatibility\Events::class ), 'prevent_filter_redirect_canonical' ], 1, 2 );
 	}
-
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1287] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Flushes the transients whenever the Sandbox option is toggled on/off.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

![Peek 2021-11-01 17-41](https://user-images.githubusercontent.com/1174547/139739285-ca4a3e4f-de06-4f4a-93f6-6ead1904ad3e.gif)




### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1287]: https://theeventscalendar.atlassian.net/browse/ET-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ