### PR TITLE
workaround for empty emails_in_order when sending emails from a manua…

### DIFF
--- a/src/Tickets/Commerce/Flag_Actions/Send_Email.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email.php
@@ -34,6 +34,14 @@ class Send_Email extends Flag_Action_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function handle( Status_Interface $new_status, $old_status, \WP_Post $order ) {
+
+		// temporary fix for manual attendees first email
+		// @todo backend review this logic
+		if ( ! empty( $order->gateway ) && 'manual' === $order->gateway && empty( $order->events_in_order ) ) {
+			$order->events_in_order[] = $order;
+		}
+
+
 		if ( empty( $order->events_in_order ) || ! is_array( $order->events_in_order ) ) {
 			return;
 		}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1307] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Temporary workaround for empty array when sending emails to manual attendees

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1307]: https://theeventscalendar.atlassian.net/browse/ET-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ