### PR TITLE
avoid JS errors on default `obj.showNotice` calls

### DIFF
--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -509,7 +509,7 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * @param {string} content Notice message content.
 	 */
 	obj.showNotice = ( $container, title, content ) => {
-		if ( ! $container.length ) {
+		if ( ! $container || ! $container.length ) {
 			$container = $( tribe.tickets.commerce.selectors.checkoutContainer );
 		}
 		const notice = tribe.tickets.commerce.notice;


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

Slack: https://lw.slack.com/archives/C01T9UJGE2U/p1635885014370700

* I was able to replicate the loader stuck issue once and saw the JS error that causes it. This PR resolves that error.

### ✔️ Checklist
- [ ] I've included a changelog entry both in readme.txt and changelog.txt files. <!-- Confirm that it includes the ticket ID, and it is in both files. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
