### PR TITLE
[ETP-763] Add ability to filter ticket ids within the RSVP template block handler

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Enhancement - Allow for filtering of tickets within the RSVP template block handler. [ETP-763]
+
 = [5.2.1] 2021-11-17 =
 
 * Enhancement - Auto generate checkout page when enabling Tickets Commerce. [ET-1232]

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1144,10 +1144,11 @@ class Tribe__Tickets__Tickets_View {
 	 *
 	 * @param WP_Post|int $post The post object or ID.
 	 * @param boolean     $echo Whether to echo the output or not.
+	 * @param int[]       $include_tickets Array of ticket IDs to include, excluding all others.
 	 *
 	 * @return string The block HTML.
 	 */
-	public function get_rsvp_block( $post, $echo = true ) {
+	public function get_rsvp_block( $post, $echo = true, $include_tickets = [] ) {
 		if ( empty( $post ) ) {
 			return '';
 		}
@@ -1192,6 +1193,12 @@ class Tribe__Tickets__Tickets_View {
 		$tickets        = $blocks_rsvp->get_tickets( $post_id );
 		$active_tickets = $blocks_rsvp->get_active_tickets( $tickets );
 		$past_tickets   = $blocks_rsvp->get_all_tickets_past( $tickets );
+		
+		if( ! empty( $include_tickets ) ) {
+			$tickets        = Tribe__Tickets_Plus__Tickets::filter_tickets_by_ids( $tickets, $include_tickets );
+			$active_tickets = Tribe__Tickets_Plus__Tickets::filter_tickets_by_ids( $active_tickets, $include_tickets );
+			$past_tickets   = Tribe__Tickets_Plus__Tickets::filter_tickets_by_ids( $past_tickets, $include_tickets );
+		}
 
 		$args = [
 			'post_id'             => $post_id,

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1194,7 +1194,7 @@ class Tribe__Tickets__Tickets_View {
 		$active_tickets = $blocks_rsvp->get_active_tickets( $tickets );
 		$past_tickets   = $blocks_rsvp->get_all_tickets_past( $tickets );
 		
-		if( ! empty( $include_tickets ) ) {
+		if( class_exists( 'Tribe__Tickets_Plus__Main' ) && ! empty( $include_tickets ) ) {
 			$tickets        = Tribe__Tickets_Plus__Tickets::filter_tickets_by_ids( $tickets, $include_tickets );
 			$active_tickets = Tribe__Tickets_Plus__Tickets::filter_tickets_by_ids( $active_tickets, $include_tickets );
 			$past_tickets   = Tribe__Tickets_Plus__Tickets::filter_tickets_by_ids( $past_tickets, $include_tickets );


### PR DESCRIPTION
### 🎫 Ticket

[ETP-763] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We added the ability to filter by ticket id within the shortcodes for ETP. It required a tweak to the code in order to pass the tickets that needed to be filtered.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://youtu.be/rBs2xo3QIxc

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-763]: https://theeventscalendar.atlassian.net/browse/ETP-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ