### PR TITLE
[ETP-763] RSVP ARI needs tribe common dependency

### DIFF
--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -233,7 +233,7 @@ class Tribe__Tickets__Editor__Blocks__Rsvp extends Tribe__Editor__Blocks__Abstra
 			$plugin,
 			'tribe-tickets-rsvp-ari',
 			'v2/rsvp-ari.js',
-			[ 'jquery', 'wp-util' ],
+			[ 'jquery', 'wp-util', 'tribe-common' ],
 			null,
 			[
 				'groups'       => 'tribe-tickets-rsvp',


### PR DESCRIPTION
### 🎫 Ticket

[ETP-763] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We found that in some instances, the `tribe` object wasn't being initialized until after the rsvp-ari js script. It causes errors when this happens. Adding `tribe-common` as a dependency will prevent this from happening.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://i.imgur.com/BzRhnaY.png

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-763]: https://theeventscalendar.atlassian.net/browse/ETP-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ