### PR TITLE
[ET-1349] Add duplicate ticket feature

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -211,10 +211,11 @@ class Tribe__Tickets__Assets {
 		];
 
 		$nonces = [
-			'add_ticket_nonce'    => wp_create_nonce( 'add_ticket_nonce' ),
-			'edit_ticket_nonce'   => wp_create_nonce( 'edit_ticket_nonce' ),
-			'remove_ticket_nonce' => wp_create_nonce( 'remove_ticket_nonce' ),
-			'ajaxurl'             => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
+			'add_ticket_nonce'       => wp_create_nonce( 'add_ticket_nonce' ),
+			'edit_ticket_nonce'      => wp_create_nonce( 'edit_ticket_nonce' ),
+			'remove_ticket_nonce'    => wp_create_nonce( 'remove_ticket_nonce' ),
+			'duplicate_ticket_nonce' => wp_create_nonce( 'duplicate_ticket_nonce' ),
+			'ajaxurl'                => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 		];
 
 		$ticket_js_deps = [ 'jquery-ui-datepicker', 'tribe-bumpdown', 'tribe-attrchange', 'tribe-moment', 'underscore', 'tribe-validation', 'event-tickets-admin-accordion-js', 'tribe-timepicker' ];

--- a/src/admin-views/editor/list-row.php
+++ b/src/admin-views/editor/list-row.php
@@ -109,6 +109,18 @@ if (
 	<td class="ticket_edit">
 		<?php
 		printf(
+			"<button data-provider='%s' data-ticket-id='%s' title='%s' class='ticket_duplicate'><span class='ticket_duplicate_text'>%s</span></a>",
+			esc_attr( $ticket->provider_class ),
+			esc_attr( $ticket->ID ),
+			esc_attr( sprintf(
+				_x( 'Duplicate %s ID: %d', 'ticket ID title attribute', 'event-tickets' ),
+				tribe_get_ticket_label_singular( 'ticket_id_title_attribute' ),
+				$ticket->ID
+			) ),
+			esc_html( $ticket->name )
+		);
+		
+		printf(
 			"<button data-provider='%s' data-ticket-id='%s' title='%s' class='ticket_edit_button'><span class='ticket_edit_text'>%s</span></a>",
 			esc_attr( $ticket->provider_class ),
 			esc_attr( $ticket->ID ),

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -695,6 +695,41 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 		);
 	} );
 
+	/* "Duplicate Ticket" link action */
+	$document.on( 'click', '.ticket_duplicate', function( event ) {
+		console.log('.ticket_duplicate clicked', event);
+		// Prevent Form Submit on button click
+		event.preventDefault();
+
+		// Where we clicked
+		var $button = $( this );
+
+		// Prep the Params for the Request
+		var params = {
+			action: 'tribe-ticket-duplicate',
+			post_id: $post_id.val(),
+			ticket_id: $button.data( 'ticketId' ),
+			nonce: TribeTickets.duplicate_ticket_nonce,
+			is_admin: $( 'body' ).hasClass( 'wp-admin' )
+		};
+
+		$.post(
+			ajaxurl,
+			params,
+			function( response ) {
+				if ( ! response.success ) {
+					return;
+				}
+
+				obj.refreshPanels( response.data );
+			},
+			'json'
+		);
+
+		// Make it safe that it wont submit
+		return false;
+	} );
+
 	/* Change global stock type if we've put a value in global_stock_cap */
 	$document.on( 'change', '.tribe-ticket-field-capacity', function( e ) {
 		var $this = $( this );

--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -119,12 +119,13 @@
 	}
 
 	.ticket_edit {
-		width: 60px;
+		width: 84px;
 	}
 
 	/* Edit button styles - separate for portability */
 	.ticket_edit_button,
 	.ticket_delete,
+	.ticket_duplicate,
 	.global_capacity_edit_button {
 		background: none;
 		border: 0;
@@ -138,7 +139,8 @@
 
 		.ticket_edit_text,
 		.global_capacity_edit_text,
-		.ticket_delete_text {
+		.ticket_delete_text,
+		.ticket_duplicate_text {
 			font-size: 0;
 
 			&:before {
@@ -154,6 +156,16 @@
 				content: '\f182';
 			}
 		}
+
+		.ticket_duplicate_text {
+			&:before {
+				content: '\f105';
+			}
+		}
+	}
+
+	.ticket_edit_button {
+		margin-left: 12px;
 	}
 
 	.ticket_delete {


### PR DESCRIPTION
### 🎫 Ticket

[ET-1349] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

Adds a way to duplicate a ticket in Classic Editor. It should duplicate the selected ticket and copy ticket meta to the newly created ticket.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://youtu.be/DnEZW84KpBY

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
