### PR TITLE
[ET-1349] Duplicate Ticket - fix for wrapping icons on mobile

### DIFF
--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -119,11 +119,11 @@
 	}
 
 	.ticket_edit {
-		white-space: nowrap;
+		white-space: normal;
 		width: 84px;
 
-		@media screen and (max-width: 782px) {
-			white-space: normal;
+		@media screen and (--viewport-wpadmin) {
+			white-space: nowrap;
 		}
 	}
 

--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -121,7 +121,7 @@
 	.ticket_edit {
 		white-space: nowrap;
 		width: 84px;
-		
+
 		@media screen and (max-width: 782px) {
 			white-space: normal;
 		}

--- a/src/resources/postcss/tickets-tables.pcss
+++ b/src/resources/postcss/tickets-tables.pcss
@@ -121,6 +121,10 @@
 	.ticket_edit {
 		white-space: nowrap;
 		width: 84px;
+		
+		@media screen and (max-width: 782px) {
+			white-space: normal;
+		}
 	}
 
 	/* Edit button styles - separate for portability */


### PR DESCRIPTION
### 🎫 Ticket

[ET-1349] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Icons were being pushed out of bounds on mobile. This CSS fix allows them to wrap instead. It's ugly, but at least they can access them.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://i.imgur.com/fnqsINb.png

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1349]: https://theeventscalendar.atlassian.net/browse/ET-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ