### PR TITLE
[ET-1349] Duplicate Ticket - remove duplicate button from CT

### DIFF
--- a/src/admin-views/editor/list-row.php
+++ b/src/admin-views/editor/list-row.php
@@ -1,14 +1,14 @@
 <?php
-$provider      = $ticket->provider_class;
-$provider_obj  = Tribe__Tickets__Tickets::get_ticket_provider_instance( $provider );
-$inventory     = $ticket->inventory();
-$available     = $ticket->available();
-$capacity      = $ticket->capacity();
-$stock         = $ticket->stock();
-$needs_warning = false;
-$stk_warning   = false;
-$mode          = $ticket->global_stock_mode();
-$event         = $ticket->get_event();
+$provider              = $ticket->provider_class;
+$provider_obj          = Tribe__Tickets__Tickets::get_ticket_provider_instance( $provider );
+$inventory             = $ticket->inventory();
+$available             = $ticket->available();
+$capacity              = $ticket->capacity();
+$stock                 = $ticket->stock();
+$needs_warning         = false;
+$stk_warning           = false;
+$mode                  = $ticket->global_stock_mode();
+$event                 = $ticket->get_event();
 $show_duplicate_button = is_admin();
 
 // If we don't have an event we shouldn't even continue

--- a/src/admin-views/editor/list-row.php
+++ b/src/admin-views/editor/list-row.php
@@ -9,6 +9,7 @@ $needs_warning = false;
 $stk_warning   = false;
 $mode          = $ticket->global_stock_mode();
 $event         = $ticket->get_event();
+$show_duplicate_button = is_admin();
 
 // If we don't have an event we shouldn't even continue
 if ( ! $event ) {
@@ -120,18 +121,20 @@ if (
 			esc_html( $ticket->name )
 		);
 
-		printf(
-			"<button data-provider='%s' data-ticket-id='%s' title='%s' class='ticket_duplicate'><span class='ticket_duplicate_text'>%s</span></a>",
-			esc_attr( $ticket->provider_class ),
-			esc_attr( $ticket->ID ),
-			esc_attr( sprintf(
-				// Translators: %s: dynamic "ticket" text, %d: ticket ID #.
-				_x( 'Duplicate %s ID: %d', 'ticket ID title attribute', 'event-tickets' ),
-				tribe_get_ticket_label_singular( 'ticket_id_title_attribute' ),
-				$ticket->ID
-			) ),
-			esc_html( $ticket->name )
-		);
+        if ( $show_duplicate_button ) {
+            printf(
+                "<button data-provider='%s' data-ticket-id='%s' title='%s' class='ticket_duplicate'><span class='ticket_duplicate_text'>%s</span></a>",
+                esc_attr($ticket->provider_class),
+                esc_attr($ticket->ID),
+                esc_attr(sprintf(
+                    // Translators: %s: dynamic "ticket" text, %d: ticket ID #.
+                    _x('Duplicate %s ID: %d', 'ticket ID title attribute', 'event-tickets'),
+                    tribe_get_ticket_label_singular('ticket_id_title_attribute'),
+                    $ticket->ID
+                )),
+                esc_html($ticket->name)
+            );
+        }
 		
 		printf(
 			"<button attr-provider='%s' attr-ticket-id='%s' title='%s' class='ticket_delete'><span class='ticket_delete_text'>%s</span></a>",


### PR DESCRIPTION
### 🎫 Ticket

[ET-1349] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
This PR makes sure that we're only showing the duplicate ticket button on an admin page. CT is using the same templates as the admin views for tickets.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1349]: https://theeventscalendar.atlassian.net/browse/ET-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ