### PR TITLE
Remove deprecated wp.editor.InnerBlocks component in favor of wp.blockEditor.InnerBlocks [ET-1367]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Remove the `wp.editor.InnerBlocks` gutenberg component in favor of `wp.blockEditor.InnerBlocks` which was deprecated since version 5.3. [ET-1367]
+
 = [5.2.3] 2022-01-19 =
 
 * Feature - Allow duplicating a ticket when using the Classic Editor. [ET-1349]

--- a/src/modules/blocks/ticket/index.js
+++ b/src/modules/blocks/ticket/index.js
@@ -7,7 +7,7 @@ import React from 'react';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/editor';
+const { InnerBlocks } = wp.blockEditor;
 
 /**
  * Internal dependencies

--- a/src/modules/blocks/tickets/container/template.js
+++ b/src/modules/blocks/tickets/container/template.js
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 /**
  * Wordpress dependencies
  */
-import { InnerBlocks } from '@wordpress/editor';
+const { InnerBlocks } = wp.blockEditor;
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/src/modules/blocks/tickets/index.js
+++ b/src/modules/blocks/tickets/index.js
@@ -7,7 +7,7 @@ import React from 'react';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/editor';
+const { InnerBlocks } = wp.blockEditor;
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Remove the `wp.editor.InnerBlocks` gutenberg component in the ticket block in favor of `wp.blockEditor.InnerBlocks` which was deprecated since version 5.3. 

Ticket : [[ET-1367]](https://theeventscalendar.atlassian.net/browse/ET-1367)
![149913028-7a4b6e95-36f3-4db3-9762-b573e9aa15df](https://user-images.githubusercontent.com/22029087/150557762-c0c14c7a-1485-4e3b-b883-d8aa7769cc0c.png)



[ET-1367]: https://theeventscalendar.atlassian.net/browse/ET-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
https://www.loom.com/share/47487d027fce416789d024163ac58ddc