### PR TITLE
Fix failing tests on the bucket branch `bucket/wp-inner-block-component-deprecation`

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -3,7 +3,7 @@
 Plugin Name: Event Tickets
 Plugin URI:  https://evnt.is/1acb
 Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
-Version: 5.2.3
+Version: 5.2.4
 Author: The Events Calendar
 Author URI: https://evnt.is/1aor
 License: GPLv2 or later

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "mt-a11y-dialog": "^5.1.1",
         "prop-types": "^15.6.2",
         "querystringify": "^2.0.0",
-        "react": "16.3.0",
+        "react": "16.3.1",
         "react-day-picker": "^7.2.4",
         "react-dom": "16.3.3",
         "react-input-autosize": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "mt-a11y-dialog": "^5.1.1",
     "prop-types": "^15.6.2",
     "querystringify": "^2.0.0",
-    "react": "16.3.0",
+    "react": "16.3.1",
     "react-day-picker": "^7.2.4",
     "react-dom": "16.3.3",
     "react-input-autosize": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-tickets",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "repository": "git@github.com:the-events-calendar/event-tickets.git",
   "_zipname": "event-tickets",
   "_zipfoldername": "event-tickets",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: theeventscalendar, brianjessee, camwynsp, paulkim, aguseo, bordoni
 Tags: tickets, registration, The Events Calendar, RSVP, ticket sales, attendee management
 Requires at least: 5.6
 Tested up to: 5.8.2
-Stable tag: 5.2.3
+Stable tag: 5.2.4
 Requires PHP: 7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -7,7 +7,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '5.2.3';
+	const VERSION = '5.2.4';
 
 	/**
 	 * Used to store the version history.


### PR DESCRIPTION
Fixes failing tests on the bucket branch i.e. [bucket/wp-inner-block-component-deprecation](https://github.com/the-events-calendar/event-tickets/tree/bucket/wp-inner-block-component-deprecation)

Original Ticket : https://theeventscalendar.atlassian.net/browse/ET-1367