### PR TITLE
Fix failing tests on the bucket branch `bucket/wp-inner-block-component-deprecation`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "mt-a11y-dialog": "^5.1.1",
         "prop-types": "^15.6.2",
         "querystringify": "^2.0.0",
-        "react": "16.3.0",
+        "react": "16.3.1",
         "react-day-picker": "^7.2.4",
         "react-dom": "16.3.3",
         "react-input-autosize": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "mt-a11y-dialog": "^5.1.1",
     "prop-types": "^15.6.2",
     "querystringify": "^2.0.0",
-    "react": "16.3.0",
+    "react": "16.3.1",
     "react-day-picker": "^7.2.4",
     "react-dom": "16.3.3",
     "react-input-autosize": "^2.2.1",


### PR DESCRIPTION
Fixes failing tests on the bucket branch i.e. [bucket/wp-inner-block-component-deprecation](https://github.com/the-events-calendar/event-tickets/tree/bucket/wp-inner-block-component-deprecation)

Note : I'm bumping up the version of react we use in order to fix the failing tests. It turns out that the tests were failing due to a bug in @16.3.0 that was fixed in @16.3.1.

Original Ticket : https://theeventscalendar.atlassian.net/browse/ET-1367