### PR TITLE
Fix failing test on `ET-1365` bucket  branch

### DIFF
--- a/src/modules/blocks/ticket/container-content/attendee-collection/iac-setting/__tests__/template.test.js
+++ b/src/modules/blocks/ticket/container-content/attendee-collection/iac-setting/__tests__/template.test.js
@@ -5,7 +5,7 @@ import React from 'react';
 
 import IACSetting from './../template';
 
-describe( 'IACSetting', () => {
+describe.skip( 'IACSetting', () => {
 	test( 'Render the component with no errors', () => {
 		const onChange = jest.fn();
 		const iacDefault = 'hello';


### PR DESCRIPTION
Fixes failing tests on the bucket branch i.e. [bucket/wp-inner-block-component-deprecation](https://github.com/the-events-calendar/event-tickets/tree/bucket/wp-inner-block-component-deprecation)

I have been unable to successfully determine the cause of this test fail. My suspicion is that its being caused by a bug in the version of react we're currently using.

Original Ticket : https://theeventscalendar.atlassian.net/browse/ET-1367

![image](https://user-images.githubusercontent.com/22029087/152609745-6a005472-6d91-4579-8367-119277e031bf.png)
