### PR TITLE
[ET-1400] Remove usd from klarna

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Settings.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Settings.php
@@ -337,7 +337,7 @@ class Settings extends Abstract_Settings {
 				'label'      => esc_html__( 'Giropay', 'event-tickets' ),
 			],
 			'klarna'            => [
-				'currencies' => [ 'DKK', 'EUR', 'GBP', 'NOK', 'SEK', 'USD' ],
+				'currencies' => [ 'DKK', 'EUR', 'GBP', 'NOK', 'SEK' ],
 				'label'      => esc_html__( 'Klarna', 'event-tickets' ),
 			],
 			'acss_debit'        => [


### PR DESCRIPTION
### 🎫 Ticket

[ET-1400] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- [Stripe's documentation](https://stripe.com/docs/payments/payment-methods/integration-options) is wrong. They're listing that klarna is available for USD, but when testing we faced the following error: 

![Screenshot on 2022-02-08 at 11-07-13](https://user-images.githubusercontent.com/252415/153200572-ab20a864-1f50-4d43-9019-c62f66201cd0.png)

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

N/A

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1400]: https://theeventscalendar.atlassian.net/browse/ET-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ