### PR TITLE
[ET-1379] Remove anonymous purchase notice after ET-1378 was implemented.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -182,6 +182,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.3.0] TBD =
 
 * Feature - Collect puchaser name and email for anonymous purchases using Tickets Commerce. [ET-1378]
+* Fix - Remove anonymous purchase notice for Tickets Commerce after ET-1378 was implemented. [ET-1379]
 
 = [5.2.3] 2022-01-19 =
 

--- a/src/Tickets/Commerce/Admin/Notices.php
+++ b/src/Tickets/Commerce/Admin/Notices.php
@@ -6,7 +6,6 @@ use \tad_DI52_ServiceProvider;
 use TEC\Tickets\Commerce\Checkout;
 use TEC\Tickets\Commerce\Success;
 use \Tribe__Settings;
-use \Tribe__Main;
 
 /**
  * Class Notices
@@ -34,66 +33,6 @@ class Notices extends tad_DI52_ServiceProvider {
 			[ $this, 'render_success_notice' ],
 			[ 'dismiss' => false, 'type' => 'error' ],
 			[ $this, 'should_render_success_notice' ]
-		);
-
-		tribe_notice(
-			'event-tickets-tickets-commerce-anonymous-purchases',
-			[ $this, 'render_anonymous_purchases_notice' ],
-			[ 'dismiss' => false, 'type' => 'error' ],
-			[ $this, 'should_render_anonymous_purchases_notice' ]
-		);
-	}
-
-	/**
-	 * Display a notice when Tickets Commerce is enabled, but users aren't required to log in.
-	 *
-	 * @since 5.2.3
-	 *
-	 * @return bool
-	 */
-	public function should_render_anonymous_purchases_notice() {
-		// If we're not on our own settings page, bail.
-		if ( Tribe__Settings::$parent_slug !== tribe_get_request_var( 'page' ) ) {
-			return false;
-		}
-
-		$options = get_option( Tribe__Main::OPTIONNAME, [] );
-
-		if (
-			empty( $options[ 'ticket-authentication-requirements' ] ) ||
-			! is_array( $options[ 'ticket-authentication-requirements' ] ) ||
-			! in_array( 'event-tickets_all', $options[ 'ticket-authentication-requirements' ] )
-		) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Gets the HTML for the notice that is shown when users aren't required to log in.
-	 *
-	 * @since 5.2.3
-	 *
-	 * @return string Notice HTML.
-	 */
-	public function render_anonymous_purchases_notice() {
-		$notice_link = sprintf(
-			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
-			esc_url( 'https://evnt.is/1b1t' ),
-			esc_html__( 'Learn More', 'event-tickets' )
-		);
-		$notice_header = esc_html__( 'Anonymous purchases are enabled', 'event-tickets' );
-		$notice_text = sprintf(
-			// translators: %1$s: Link to knowledgebase article.
-			esc_html__( 'It is recommended that you require users to log in before purchasing tickets on the Settings > Tickets page. Otherwise, it is possible for users to purchase a ticket and never receive the tickets via email. %1$s', 'event-tickets' ),
-			$notice_link
-		);
-
-		return sprintf(
-			'<p><strong>%1$s</strong></p><p>%2$s</p>',
-			$notice_header,
-			$notice_text
 		);
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1379] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Removing the notice now that we have implemented the purchaser info functionality for anonymous purchases (ET-1378)

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
- N/A

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1379]: https://theeventscalendar.atlassian.net/browse/ET-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ