### PR TITLE
Implement the stripe currency section with messaging.

### DIFF
--- a/src/admin-views/settings/tickets-commerce/stripe/connect/active.php
+++ b/src/admin-views/settings/tickets-commerce/stripe/connect/active.php
@@ -23,6 +23,8 @@ if ( false === $merchant_status['connected'] ) {
 
 	<?php $this->template( 'settings/tickets-commerce/stripe/connect/active/stripe-status' ); ?>
 
+	<?php $this->template( 'settings/tickets-commerce/stripe/connect/active/stripe-currency' ); ?>
+
 	<?php $this->template( 'settings/tickets-commerce/stripe/connect/active/button' ); ?>
 
 	<?php $this->template( 'settings/tickets-commerce/stripe/connect/help-links' ); ?>

--- a/src/admin-views/settings/tickets-commerce/stripe/connect/active/stripe-currency.php
+++ b/src/admin-views/settings/tickets-commerce/stripe/connect/active/stripe-currency.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * The Template for displaying the Tickets Commerce Stripe currency.
+ *
+ * @since   TBD
+ *
+ * @version TBD
+ *
+ * @var string                                        $plugin_url      [Global] The plugin URL.
+ * @var TEC\Tickets\Commerce\Gateways\Stripe\Signup   $signup          [Global] The Signup class.
+ * @var TEC\Tickets\Commerce\Gateways\Stripe\Merchant $merchant        [Global] The Signup class.
+ * @var array                                         $merchant_status [Global] Merchant Status data.
+ */
+
+use TEC\Tickets\Commerce\Utils\Currency;
+
+if ( false === $merchant_status['connected'] ) {
+	return;
+}
+
+if ( empty( $merchant_status['default_currency'] ) ) {
+	return;
+}
+
+$stripe_currency = strtoupper( $merchant_status['default_currency'] );
+$tc_currency     = Currency::get_currency_code();
+
+if ( $stripe_currency !== $tc_currency ) {
+	$message = sprintf(
+		// Translators: %1$s is the Stripe currency, %2$s is the Tickets Commerce currency symbol.
+		__( 'Your Stripe account is set to %1$s, but your Tickets Commerce site is set to %2$s. Please update your Tickets Commerce currency to match the one on Stripe.', 'event-tickets' ),
+		'<strong>' . $stripe_currency . '</strong>',
+		'<strong>' . $tc_currency . '</strong>'
+	);
+} else {
+	$message = sprintf(
+		// Translators: %1$s The opening `<a>` tag with the stripe link, %2$s The closing `</a>` tag.
+		__( 'Please be sure to enable all the payment methods you want to use for this currency on your %1$sstripe dashboard%2$s.', 'event-tickets' ),
+		'<a href="https://dashboard.stripe.com/settings/payment_methods" target="_blank" rel="noopener noreferrer">',
+		'</a>'
+	);
+}
+
+$message_classes = [
+	'tec-tickets__admin-settings-tickets-commerce-gateway-currency-message',
+	'tec-tickets__admin-settings-tickets-commerce-gateway-currency-message--error' => $stripe_currency !== $tc_currency,
+];
+
+?>
+<div class="tec-tickets__admin-settings-tickets-commerce-gateway-connected-row">
+	<div class="tec-tickets__admin-settings-tickets-commerce-gateway-connected-col1">
+		<?php esc_html_e( 'Stripe currency:', 'event-tickets' ); ?>
+	</div>
+	<div class="tec-tickets__admin-settings-tickets-commerce-gateway-connected-col2">
+		<div class="tec-tickets__admin-settings-tickets-commerce-gateway-currency"><?php echo esc_html( Currency::get_currency_name( $stripe_currency ) ); ?></div>
+		<div <?php tribe_classes( $message_classes ); ?>><?php echo wp_kses_post( $message ); ?></div>
+	</div>
+</div>

--- a/src/admin-views/settings/tickets-commerce/stripe/connect/active/stripe-status.php
+++ b/src/admin-views/settings/tickets-commerce/stripe/connect/active/stripe-status.php
@@ -41,7 +41,7 @@ $capabilities = $merchant_status['capabilities'];
 					?>
 					<li>
 						<span <?php tribe_classes( $capability_classes ); ?> title="<?php echo esc_attr( $capability_title ); ?>"></span>
-						<?php echo esc_html( $capability ); ?>
+						<?php echo esc_html( str_replace( '_payments', '', $capability ) ); ?>
 					</li>
 				<?php endforeach; ?>
 			</ul>

--- a/src/resources/postcss/tickets-admin/settings/_tickets-commerce.pcss
+++ b/src/resources/postcss/tickets-admin/settings/_tickets-commerce.pcss
@@ -305,6 +305,20 @@ a.tec-tickets__admin-settings-tickets-commerce-gateway-connect-button-link {
 	}
 }
 
+.tec-tickets__admin-settings-tickets-commerce-gateway-currency {
+	color: var(--tec-color-text-primary);
+	font-weight: bold;
+}
+
+.tec-tickets__admin-settings-tickets-commerce-gateway-currency-message {
+	color: #a3a3a3;
+	margin-top: var(--tec-spacer-1);
+}
+
+.tec-tickets__admin-settings-tickets-commerce-gateway-currency-message--error {
+	color: var(--tec-color-icon-error);
+}
+
 .tec-tickets__admin-settings-tickets-commerce-gateway-capability--no {
 	color: var(--tec-color-icon-error);
 }


### PR DESCRIPTION
### 🎫 Ticket

- N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- After meeting with David he liked the idea to implement the stripe currency info section on the active connection box. https://www.figma.com/file/TvIXoUEJAGb0AptZI260UO/TicketsCommerce?node-id=1823%3A255

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://user-images.githubusercontent.com/252415/153714026-5be1057b-2eeb-46be-9806-fd6e1a4cd6bd.mov

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
