### PR TITLE
[ET-1408] Stripe: Hide Settings if Not Connected

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Settings.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Settings.php
@@ -230,7 +230,7 @@ class Settings extends Abstract_Settings {
 		];
 
 		// If gateway isn't connected/active, only show the connection settings.
-		$is_connected = tribe( Gateway::class )->is_active();
+		$is_connected = tribe( Merchant::class )->is_connected();
 		if ( ! $is_connected ) {
 			/**
 			 * Allow filtering the list of Stripe settings.

--- a/src/Tickets/Commerce/Gateways/Stripe/Settings.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Settings.php
@@ -200,7 +200,7 @@ class Settings extends Abstract_Settings {
 			esc_html__( 'You are using the free Stripe payment gateway integration. This includes an additional 2%% fee for processing ticket sales. This fee is removed by activating Event Tickets Plus. %1$s.', 'event-tickets' ),
 			$plus_link
 		);
-		$settings = [
+		$main_settings = [
 			'tickets-commerce-stripe-commerce-description' => [
 				'type' => 'html',
 				'html' => '<div class="tec-tickets__admin-settings-tickets-commerce-description">' . $stripe_message . '</div>',
@@ -209,7 +209,24 @@ class Settings extends Abstract_Settings {
 				'type'            => 'wrapped_html',
 				'html'            => $this->get_connection_settings_html(),
 				'validation_type' => 'html',
-			],
+			]
+		];
+		
+		// If gateway isn't connected/active, only show the connection settings.
+		$is_connected = tribe( Gateway::class )->is_active();
+		if ( ! $is_connected ) {
+			/**
+			 * Allow filtering the list of Stripe settings.
+			 *
+			 * @since TBD
+			 *
+			 * @param array $settings     The list of Stripe Commerce settings.
+			 * @param bool  $is_connected Whether or not gateway is connected.
+			 */
+			return apply_filters( 'tec_tickets_commerce_stripe_settings', $main_settings, $is_connected );
+		}
+		
+		$connected_settings = [
 			'tickets-commerce-stripe-settings-heading'     => [
 				'type' => 'html',
 				'html' => '<h3 class="tribe-dependent -input">' . __( 'Stripe Settings', 'event-tickets' ) . '</h3><div class="clear"></div>',
@@ -301,9 +318,10 @@ class Settings extends Abstract_Settings {
 		 *
 		 * @since TBD
 		 *
-		 * @param array $settings The list of Stripe Commerce settings.
+		 * @param array $settings     The list of Stripe Commerce settings.
+		 * @param bool  $is_connected Whether or not gateway is connected.
 		 */
-		return apply_filters( 'tec_tickets_commerce_stripe_settings', $settings );
+		return apply_filters( 'tec_tickets_commerce_stripe_settings', array_merge( $main_settings, $connected_settings ), $is_connected );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Stripe/Settings.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Settings.php
@@ -209,9 +209,9 @@ class Settings extends Abstract_Settings {
 				'type'            => 'wrapped_html',
 				'html'            => $this->get_connection_settings_html(),
 				'validation_type' => 'html',
-			]
+			],
 		];
-		
+
 		// If gateway isn't connected/active, only show the connection settings.
 		$is_connected = tribe( Gateway::class )->is_active();
 		if ( ! $is_connected ) {
@@ -225,7 +225,7 @@ class Settings extends Abstract_Settings {
 			 */
 			return apply_filters( 'tec_tickets_commerce_stripe_settings', $main_settings, $is_connected );
 		}
-		
+
 		$connected_settings = [
 			'tickets-commerce-stripe-settings-heading'     => [
 				'type' => 'html',


### PR DESCRIPTION
### 🎫 Ticket

[ET-1408] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We do not want to show the non-connection settings until they are connected to Stripe.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://i.imgur.com/f1kaIey.png

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1408]: https://theeventscalendar.atlassian.net/browse/ET-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ