### PR TITLE
Fix for Checkout Headers in Twenty Twenty theme

### DIFF
--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -316,5 +316,9 @@
 		&.tribe-tickets__commerce-checkout {
 			padding: initial;
 		}
+
+		.tribe-tickets__commerce-checkout-section-header {
+			margin-bottom: var(--tec-spacer-3);
+		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
There were some overrides added into the checkout styling for the Twenty Twenty theme that removed the spacing below some of the section headers on the checkout page. This adds them back in for one specific heading.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
