### PR TITLE
Fix: Use `is_connected()` instead of `is_active()`

### DIFF
--- a/src/Tickets/Commerce/Payments_Tab.php
+++ b/src/Tickets/Commerce/Payments_Tab.php
@@ -342,7 +342,7 @@ class Payments_Tab extends tad_DI52_ServiceProvider {
 			'name'     => $option_key,
 			'id'       => 'tickets-commerce-enable-input',
 			'class'    => 'tec-tickets__admin-settings-tickets-commerce-toggle-checkbox tribe-dependency tribe-dependency-verified',
-			'disabled' => ! $section_gateway::is_active(),
+			'disabled' => ! $section_gateway::is_connected(),
 			'checked'  => $section_gateway::is_enabled(),
 		] );
 

--- a/src/admin-views/settings/tickets-commerce/gateways/status.php
+++ b/src/admin-views/settings/tickets-commerce/gateways/status.php
@@ -24,7 +24,7 @@ if ( ! $gateway::should_show() ) {
 
 $classes = [
 	'tec-tickets__admin-settings-tickets-commerce-gateways-item-status',
-	'tec-tickets__admin-settings-tickets-commerce-gateways-item-status--enabled' => $gateway->is_enabled() && $gateway->is_active(),
+	'tec-tickets__admin-settings-tickets-commerce-gateways-item-status--enabled' => $gateway->is_enabled() && $gateway->is_connected(),
 ];
 
 ?>


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
I saw that there were some changes to how `is_active` and `is_connected` behave. To keep consistency, we need to use `is_connected` when determining whether or not a gateway can be enabled or not.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
