### PR TITLE
[ET-1418] TicketsCommerce Checkout unavailable notice logic fixed for 0 available gateways.

### DIFF
--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -11,7 +11,7 @@ use Tribe__Utils__Array as Arr;
  *
  * @since   5.1.9
  *
- * @package TEC\Tickets\Commerce\Gateways\PayPal
+ * @package TEC\Tickets\Commerce
  */
 class Module extends \Tribe__Tickets__Tickets {
 

--- a/src/Tickets/Commerce/Payments_Tab.php
+++ b/src/Tickets/Commerce/Payments_Tab.php
@@ -324,6 +324,8 @@ class Payments_Tab extends tad_DI52_ServiceProvider {
 	 *
 	 * @since TBD
 	 *
+	 * @param Gateway $section_gateway Gateway class.
+	 *
 	 * @return array[]
 	 */
 	public function get_gateway_section_fields( $section_gateway ): array {

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -60,7 +60,7 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 			'is_tec_active'      => defined( 'TRIBE_EVENTS_FILE' ) && class_exists( 'Tribe__Events__Main' ),
 			'gateways'           => $gateways,
 			'gateways_active'    => $this->get_gateways_active(),
-			'gateways_connected' => $this->get_gateways_available(),
+			'gateways_connected' => $this->get_gateways_connected(),
 		];
 
 		$this->template_vars = $args;

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -101,9 +101,21 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	}
 
 	/**
-	 * Get the number of available gateways that can be used for checkout. A gateway is only available if it's properly connected and enabled.
+	 * Get the number of connected gateways.
 	 *
 	 * @since 5.2.0
+	 *
+	 * @return int The number of connected gateways.
+	 */
+	public function get_gateways_connected() {
+		_deprecated_function( __METHOD__, 'TBD', __CLASS__ . '::get_gateways_available' );
+		return $this->get_gateways_available();
+	}
+
+	/**
+	 * Get the number of available gateways that can be used for checkout. A gateway is only available if it's properly connected and enabled.
+	 *
+	 * @since TBD
 	 *
 	 * @return int The number of available gateways.
 	 */

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -45,7 +45,7 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 		$sections   = array_unique( array_filter( wp_list_pluck( $items, 'event_id' ) ) );
 		$sub_totals = Value::build_list( array_filter( wp_list_pluck( $items, 'sub_total' ) ) );
 		$total_value = Value::create();
-		
+
 		$gateways = tribe( Manager::class )->get_gateways();
 
 		$args = [
@@ -60,15 +60,8 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 			'is_tec_active'      => defined( 'TRIBE_EVENTS_FILE' ) && class_exists( 'Tribe__Events__Main' ),
 			'gateways'           => $gateways,
 			'gateways_active'    => $this->get_gateways_active(),
-			'gateways_connected' => $this->get_gateways_connected(),
-			'gateways_enabled' => 0,
+			'gateways_connected' => $this->get_available_gateways(),
 		];
-		
-		foreach ( $gateways as $gateway ) {
-			if ( $gateway->is_enabled() ) {
-				$args['gateways_enabled']++;
-			}
-		}
 
 		$this->template_vars = $args;
 	}
@@ -108,17 +101,17 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	}
 
 	/**
-	 * Get the number of connected gateways.
+	 * Get the number of available gateways.
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return int The number of connected gateways.
+	 * @return int The number of available gateways.
 	 */
-	public function get_gateways_connected() {
+	public function get_available_gateways() {
 		$gateways = tribe( Manager::class )->get_gateways();
 
 		$gateways_connected = array_filter( array_map( static function ( $gateway ) {
-			return $gateway::is_connected() && $gateway::should_show() ? $gateway : null;
+			return $gateway::should_show() && $gateway::is_enabled() && $gateway::is_connected() ? $gateway : null;
 		}, $gateways ) );
 
 		return count( $gateways_connected );

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -108,7 +108,6 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	 * @return int The number of connected gateways.
 	 */
 	public function get_gateways_connected() {
-		_deprecated_function( __METHOD__, 'TBD', __CLASS__ . '::get_gateways_available' );
 		return $this->get_gateways_available();
 	}
 

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -41,9 +41,9 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function setup_template_vars() {
-		$items      = tribe( Cart::class )->get_items_in_cart( true );
-		$sections   = array_unique( array_filter( wp_list_pluck( $items, 'event_id' ) ) );
-		$sub_totals = Value::build_list( array_filter( wp_list_pluck( $items, 'sub_total' ) ) );
+		$items       = tribe( Cart::class )->get_items_in_cart( true );
+		$sections    = array_unique( array_filter( wp_list_pluck( $items, 'event_id' ) ) );
+		$sub_totals  = Value::build_list( array_filter( wp_list_pluck( $items, 'sub_total' ) ) );
 		$total_value = Value::create();
 
 		$gateways = tribe( Manager::class )->get_gateways();
@@ -94,7 +94,7 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	public function get_gateways_active() {
 		$gateways        = tribe( Manager::class )->get_gateways();
 		$gateways_active = array_filter( array_map( static function ( $gateway ) {
-			return $gateway::is_active() && $gateway::should_show() ? $gateway : null;
+			return $gateway::is_active() && $gateway::is_enabled() && $gateway::should_show() ? $gateway : null;
 		}, $gateways ) );
 
 		return count( $gateways_active );
@@ -108,21 +108,10 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	 * @return int The number of connected gateways.
 	 */
 	public function get_gateways_connected() {
-		return $this->get_gateways_available();
-	}
-
-	/**
-	 * Get the number of available gateways that can be used for checkout. A gateway is only available if it's properly connected and enabled.
-	 *
-	 * @since TBD
-	 *
-	 * @return int The number of available gateways.
-	 */
-	public function get_gateways_available() {
 		$gateways = tribe( Manager::class )->get_gateways();
 
 		$gateways_connected = array_filter( array_map( static function ( $gateway ) {
-			return $gateway::should_show() && $gateway::is_enabled() && $gateway::is_connected() ? $gateway : null;
+			return $gateway::is_connected() && $gateway::should_show() ? $gateway : null;
 		}, $gateways ) );
 
 		return count( $gateways_connected );

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -60,7 +60,7 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 			'is_tec_active'      => defined( 'TRIBE_EVENTS_FILE' ) && class_exists( 'Tribe__Events__Main' ),
 			'gateways'           => $gateways,
 			'gateways_active'    => $this->get_gateways_active(),
-			'gateways_connected' => $this->get_available_gateways(),
+			'gateways_connected' => $this->get_gateways_available(),
 		];
 
 		$this->template_vars = $args;
@@ -101,13 +101,13 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	}
 
 	/**
-	 * Get the number of available gateways.
+	 * Get the number of available gateways that can be used for checkout. A gateway is only available if it's properly connected and enabled.
 	 *
 	 * @since 5.2.0
 	 *
 	 * @return int The number of available gateways.
 	 */
-	public function get_available_gateways() {
+	public function get_gateways_available() {
 		$gateways = tribe( Manager::class )->get_gateways();
 
 		$gateways_connected = array_filter( array_map( static function ( $gateway ) {

--- a/src/views/v2/commerce/checkout/footer/gateway-error.php
+++ b/src/views/v2/commerce/checkout/footer/gateway-error.php
@@ -27,7 +27,7 @@
  */
 
 // Bail if the cart is empty or if there's active gateways.
-if ( empty( $items ) || tribe_is_truthy( $gateways_connected ) ) {
+if ( empty( $items ) || tribe_is_truthy( $gateways_active ) ) {
 	return;
 }
 

--- a/src/views/v2/commerce/checkout/footer/gateway-error.php
+++ b/src/views/v2/commerce/checkout/footer/gateway-error.php
@@ -10,8 +10,9 @@
  * @link    https://evnt.is/1amp Help article for RSVP & Ticket template files.
  *
  * @since   5.1.10
+ * @since   TBD Improve check for active gateways now that we can enable or disable gateways.
  *
- * @version 5.1.10
+ * @version TBD
  *
  * @var \Tribe__Template $this               [Global] Template object.
  * @var Module           $provider           [Global] The tickets provider instance.

--- a/src/views/v2/commerce/checkout/footer/gateway-error.php
+++ b/src/views/v2/commerce/checkout/footer/gateway-error.php
@@ -24,11 +24,10 @@
  * @var array[]          $gateways           [Global] An array with the gateways.
  * @var int              $gateways_active    [Global] The number of active gateways.
  * @var int              $gateways_connected [Global] The number of connected gateways.
- * @var int              $gateways_enabled   [Global] The number of enabled gateways.
  */
 
 // Bail if the cart is empty or if there's active gateways.
-if ( empty( $items ) || ( tribe_is_truthy( $gateways_active ) && tribe_is_truthy( $gateways_enabled ) ) ) {
+if ( empty( $items ) || tribe_is_truthy( $gateways_connected ) ) {
 	return;
 }
 

--- a/src/views/v2/commerce/checkout/gateways.php
+++ b/src/views/v2/commerce/checkout/gateways.php
@@ -27,7 +27,7 @@
  */
 
 // Bail if user needs to login, the cart is empty or if there are no active gateways.
-if ( $must_login || empty( $items ) || ! tribe_is_truthy( $gateways_connected ) ) {
+if ( $must_login || empty( $items ) || ! tribe_is_truthy( $gateways_active ) ) {
 	return;
 }
 

--- a/src/views/v2/commerce/checkout/gateways.php
+++ b/src/views/v2/commerce/checkout/gateways.php
@@ -24,11 +24,10 @@
  * @var Abstract_Gateway[] $gateways           [Global] An array with the gateways.
  * @var int                $gateways_active    [Global] The number of active gateways.
  * @var int                $gateways_connected [Global] The number of connected gateways.
- * @var int                $gateways_enabled   [Global] The number of enabled gateways.
  */
 
 // Bail if user needs to login, the cart is empty or if there are no active gateways.
-if ( $must_login || empty( $items ) || ! tribe_is_truthy( $gateways_active ) || ! tribe_is_truthy( $gateways_enabled ) ) {
+if ( $must_login || empty( $items ) || ! tribe_is_truthy( $gateways_connected ) ) {
 	return;
 }
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Footer/GatewayErrorTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Footer/GatewayErrorTest.php
@@ -12,16 +12,18 @@ class GatewayErrorTest extends TicketsCommerceSnapshotTestCase {
 	 */
 	public function test_should_render_notice() {
 		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-				'items'              => [ 'Ticket 1', 'Ticket 2' ],
-				'gateways_connected' => 0,
+				'items'            => [ 'Ticket 1', 'Ticket 2' ],
+				'gateways_active'  => 0,
+				'gateways_enabled' => 0,
 			]
 		) );
 	}
 
 	public function test_should_render_empty_if_no_tickets() {
 		$this->assertEmpty( $this->get_partial_html( [
-				'items'               => [],
-				'gateways_connected'  => 0,
+				'items'            => [],
+				'gateways_active'  => 0,
+				'gateways_enabled' => 0,
 			]
 		) );
 	}
@@ -29,7 +31,8 @@ class GatewayErrorTest extends TicketsCommerceSnapshotTestCase {
 	public function test_should_render_empty_if_gateway_active() {
 		$this->assertEmpty( $this->get_partial_html( [
 				'items'            => [ 'Ticket 1', 'Ticket 2' ],
-				'gateways_connected'  => 1,
+				'gateways_active'  => 1,
+				'gateways_enabled' => 1,
 			]
 		) );
 	}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Footer/GatewayErrorTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Footer/GatewayErrorTest.php
@@ -12,18 +12,16 @@ class GatewayErrorTest extends TicketsCommerceSnapshotTestCase {
 	 */
 	public function test_should_render_notice() {
 		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-				'items'            => [ 'Ticket 1', 'Ticket 2' ],
-				'gateways_active'  => 0,
-				'gateways_enabled' => 0,
+				'items'              => [ 'Ticket 1', 'Ticket 2' ],
+				'gateways_connected' => 0,
 			]
 		) );
 	}
 
 	public function test_should_render_empty_if_no_tickets() {
 		$this->assertEmpty( $this->get_partial_html( [
-				'items'            => [],
-				'gateways_active'  => 0,
-				'gateways_enabled' => 0,
+				'items'               => [],
+				'gateways_connected'  => 0,
 			]
 		) );
 	}
@@ -31,8 +29,7 @@ class GatewayErrorTest extends TicketsCommerceSnapshotTestCase {
 	public function test_should_render_empty_if_gateway_active() {
 		$this->assertEmpty( $this->get_partial_html( [
 				'items'            => [ 'Ticket 1', 'Ticket 2' ],
-				'gateways_active'  => 1,
-				'gateways_enabled' => 1,
+				'gateways_connected'  => 1,
 			]
 		) );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1418] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* `gateways_enabled` logic was flawed as it was only counting the enabled gateways irrespective of the individual gateway.
* We had the generic `Checkout Unavailable` notice already in place but it was not showing for the following case:
If you have Stripe _Connected_ but _not_ _enabled_ and PayPal _not connected_ but _enabled_ then the `gateways_enabled` was returning `1` which should have been 0.
* So, I renamed the `get_gateways_connected` method to `get_available_gateways` for clarity and modified the logic to check for `is_enabled` as well.
* Remove the redundant `gateways_enabled` argument.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1418]: https://theeventscalendar.atlassian.net/browse/ET-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ