### PR TITLE
Don't change the animation via customizer, change the dot color.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correct a misapplied Customizer color that breaks the loading "dot" animation. [ET-1437]
+
 = [5.3.0.1] 2022-03-01 =
 
 * Tweak - Update version of Freemius to 2.4.3.

--- a/src/Tribe/Service_Providers/Customizer.php
+++ b/src/Tribe/Service_Providers/Customizer.php
@@ -154,11 +154,7 @@ class Customizer extends \tad_DI52_ServiceProvider {
 
 			// overrides for common components/full/_loader.pcss.
 			$template .= '
-				@keyframes tribe-common-c-loader-bounce {
-					0% {}
-					50% { background-color: <%= global_elements.accent_color %>; }
-					100% {}
-				}
+			.tribe-common .tribe-common-c-svgicon--dot { color: <%= global_elements.accent_color %>; }
 			';
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1437]

[ET-1453]

### 🗒️ Description

The `@keyframes tribe-common-c-loader-bounce` animation doesn't animate color, [it animates opacity](https://github.com/the-events-calendar/tribe-common/blob/master/src/resources/postcss/components/full/_loader.pcss#L39).
This was breaking the loader animation in instances where it was triggered. (FSE compatibility is in flux and triggered it)

There is also some question in my mind about the way this is implemented - there's no v2 check although the comments appear to indicate there should be.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1437]: https://theeventscalendar.atlassian.net/browse/ET-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-1453]: https://theeventscalendar.atlassian.net/browse/ET-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ