### PR TITLE
[ET-1426] Tickets Commerce - Fix JS Errors on Checkout due to Assets Loading Improperly

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fixed JS assets loading and causing errors on checkout page for Tickets Commerce. [ET-1426]
+
 = [5.3.1] 2022-03-15 =
 
 * Fix - Fixed a warning message when creating an event via Community Events. [CT-51]

--- a/src/Tickets/Commerce/Gateways/PayPal/Assets.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Assets.php
@@ -94,10 +94,9 @@ class Assets extends \tad_DI52_ServiceProvider {
 				'tribe-tickets-commerce-notice-js',
 				'tribe-tickets-commerce-base-gateway-checkout-toggler',
 			],
-			null,
+			'tec-tickets-commerce-checkout-shortcode-assets',
 			[
 				'groups'       => [
-					'tribe-tickets-commerce-checkout',
 					'tec-tickets-commerce-gateway-paypal',
 				],
 				'conditionals' => [ $this, 'should_enqueue_assets' ],
@@ -190,7 +189,7 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 * @return bool If the `PayPal` assets should be enqueued or not.
 	 */
 	public function should_enqueue_assets() {
-		return tribe( Checkout::class )->is_current_page() && tribe( Gateway::class )->is_active();
+		return tribe( Checkout::class )->is_current_page() && tribe( Gateway::class )->is_enabled() && tribe( Gateway::class )->is_active();
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -56,11 +56,10 @@ class Assets extends \tad_DI52_ServiceProvider {
 				'tribe-tickets-commerce-notice-js',
 				'tribe-tickets-commerce-base-gateway-checkout-toggler',
 			],
-			null,
+			'tec-tickets-commerce-checkout-shortcode-assets',
 			[
 				'module'       => true,
 				'groups'       => [
-					'tribe-tickets-commerce-checkout',
 					'tec-tickets-commerce-gateway-stripe',
 				],
 				'conditionals' => [ $this, 'should_enqueue_assets' ],
@@ -180,6 +179,6 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 * @return bool If the `Stripe` assets should be enqueued or not.
 	 */
 	public function should_enqueue_assets() {
-		return tribe( Gateway::class )->is_active() && tribe( Checkout::class )->is_current_page();
+		return tribe( Checkout::class )->is_current_page() && tribe( Gateway::class )->is_enabled() && tribe( Gateway::class )->is_active();
 	}
 }

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -124,6 +124,7 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 	 */
 	public static function enqueue_assets() {
 		// Enqueue assets.
+		do_action( 'tec-tickets-commerce-checkout-shortcode-assets' );
 		tribe_asset_enqueue_group( 'tribe-tickets-commerce-checkout' );
 		tribe_asset_enqueue( 'tribe-tickets-forms-style' );
 	}

--- a/src/Tribe/Shortcodes/Tribe_Tickets_Checkout.php
+++ b/src/Tribe/Shortcodes/Tribe_Tickets_Checkout.php
@@ -65,6 +65,7 @@ class Tribe_Tickets_Checkout extends Shortcode_Abstract {
 		$template->add_template_globals( $args );
 
 		// Enqueue assets.
+		do_action( 'tec-tickets-commerce-checkout-shortcode-assets' );
 		tribe_asset_enqueue_group( 'tribe-tickets-commerce-checkout' );
 
 		return $template->template( 'v2/tickets/commerce/checkout', $args, false );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1426] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
It was found that the PayPal and Stripe JS assets were loading on the checkout page even when they were disabled or disconnected. It was found that loading assets using `tribe_asset_enqueue_group()` was the culprit and was bypassing the `conditionals` parameter. Using an action filter and adding an `is_enabled()` check in the `conditionals` function solved the issue. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://i.imgur.com/F5B5rnA.png

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1426]: https://theeventscalendar.atlassian.net/browse/ET-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ