### PR TITLE
[ETP-775] Hide View Link in Tickets Shortcode

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,11 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Hides view link when showing tickets within a shortcode. [ETP-775]
+* Tweak - Added filter: `tec_tickets_hide_view_link` filter to hide/show view link. [ETP-775]
+
 = [5.3.1] 2022-03-15 =
 
 * Fix - Fixed a warning message when creating an event via Community Events. [CT-51]

--- a/readme.txt
+++ b/readme.txt
@@ -194,8 +194,6 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Tweak - Hides view link when showing tickets within a shortcode. [ETP-775]
-* Tweak - Added filter: `tec_tickets_hide_view_link` filter to hide/show view link. [ETP-775]
 * Enhancement - Added a notice when an enabled Tickets Commerce gateway doesn't support it's selected currency. [ET-1392]
 * Enhancement - Adding the South African Rand to list of supported currencies in Tickets Commerce. [ET-1438]
 * Fix - Fixed Events Tickets App check-in for Tickets Commerce tickets. [ET-1436]
@@ -203,6 +201,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Fixed Issue with Tickets Commerce Attendees not displaying in shortcodes. [ET-1461]
 * Fix - Fixed JS assets loading and causing errors on checkout page for Tickets Commerce. [ET-1426]
 * Fix - Fixed WooCommerce currency settings not getting reflected on Event Cost Field . [ETP-783]
+* Enhancement - Hide 'View My Tickets' link when showing tickets within the `[tribe_tickets]` shortcode. [ETP-775]
 
 = [5.3.1] 2022-03-15 =
 

--- a/src/views/blocks/attendees/view-link.php
+++ b/src/views/blocks/attendees/view-link.php
@@ -29,6 +29,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+/**
+ * Filters the arg to determine whether or not to hide the view link.
+ *
+ * @since TBD
+ *
+ * @param bool True/false to hide view link.
+ */
+$hide_view_link = apply_filters( 'tec_tickets_hide_view_link', tribe_doing_shortcode( 'tribe_tickets' ) );
+if ( $hide_view_link ) {
+	return;
+}
+
 $view      = Tribe__Tickets__Tickets_View::instance();
 $event_id  = $this->get( 'post_id' );
 $event     = get_post( $event_id );

--- a/src/views/blocks/attendees/view-link.php
+++ b/src/views/blocks/attendees/view-link.php
@@ -19,8 +19,9 @@
  * @since 4.10.9 Uses new functions to get singular and plural texts.
  * @since 4.12.1 Account for empty post type object, such as if post type got disabled. Fix typo in sprintf placeholders.
  * @since 5.0.2 Fix template path in documentation block.
+ * @since TBD Added use of $hide_view_my_tickets_link variable to hide link as an option.
  *
- * @version 5.0.2
+ * @version TBD
  *
  * @var Tribe__Tickets__Editor__Template $this
  */
@@ -29,15 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-/**
- * Filters the arg to determine whether or not to hide the view link.
- *
- * @since TBD
- *
- * @param bool True/false to hide view link.
- */
-$hide_view_link = apply_filters( 'tec_tickets_hide_view_link', tribe_doing_shortcode( 'tribe_tickets' ) );
-if ( $hide_view_link ) {
+if ( isset( $hide_view_my_tickets_link ) && tribe_is_truthy( $hide_view_my_tickets_link ) ) {
 	return;
 }
 

--- a/src/views/tickets/view-link.php
+++ b/src/views/tickets/view-link.php
@@ -51,6 +51,18 @@ if ( empty( $post_type ) || ! is_user_logged_in() ) {
 	return;
 }
 
+/**
+ * Filters the arg to determine whether or not to hide the view link.
+ *
+ * @since TBD
+ *
+ * @param bool True/false to hide view link.
+ */
+$hide_view_link = apply_filters( 'tec_tickets_hide_view_link', tribe_doing_shortcode( 'tribe_tickets' ) );
+if ( $hide_view_link ) {
+	return;
+}
+
 $is_event_page = class_exists( 'Tribe__Events__Main' ) && Tribe__Events__Main::POSTTYPE === $event->post_type;
 
 $post_type_singular = $post_type ? $post_type->labels->singular_name : _x( 'Post', 'fallback post type singular name', 'event-tickets' );

--- a/src/views/tickets/view-link.php
+++ b/src/views/tickets/view-link.php
@@ -20,14 +20,19 @@
  * @since   5.0.1 Add additional checks to prevent PHP errors when called from automated testing.
  * @since   5.0.2 Fix template path in documentation block.
  * @since   5.1.3 Use /tribe-events/ for the template path in documentation block.
+ * @since   TBD Added use of $hide_view_my_tickets_link variable to hide link as an option.
  *
- * @version 5.1.3
+ * @version TBD
  *
  * @var Tribe__Tickets__Tickets_View $this
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
+}
+
+if ( isset( $hide_view_my_tickets_link ) && tribe_is_truthy( $hide_view_my_tickets_link ) ) {
+	return;
 }
 
 $view = Tribe__Tickets__Tickets_View::instance();


### PR DESCRIPTION
### 🎫 Ticket

[ETP-775] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
When using the `[tribe_tickets]` shortcode, we want to hide the 'view link'. We're also adding a `tec_tickets_hide_view_link` filter to allow users to override this decision, too, in case they want it back.

This ticket requires work both in ET and ETP. The ETP PR is here:
https://github.com/the-events-calendar/event-tickets-plus/pull/1323

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://i.imgur.com/KnxpBeM.png

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-775]: https://theeventscalendar.atlassian.net/browse/ETP-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ