### PR TITLE
Validate webhook transactions before erroring out

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Fixed Events Tickets App check-in for Tickets Commerce tickets. [ET-1436]
+* Fix - Improved validation of Stripe webhook events to avoid handling events created by other apps. [ET-1474]
 
 = [5.3.1] 2022-03-15 =
 

--- a/src/Tickets/Commerce/Gateways/Stripe/Payment_Intent.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Payment_Intent.php
@@ -35,6 +35,15 @@ class Payment_Intent {
 	public static $test_metadata_key = 'payment_intent_validation_test';
 
 	/**
+	 * The key used to identify payment intents created in Tickets Commerce.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public static $tc_metadata_identifier = 'tec_tc_payment_intent';
+
+	/**
 	 * Create a simple payment intent with the designated payment methods to check for errors.
 	 *
 	 * If the payment intent succeeds it is cancelled. If it fails we display a notice to the user and not apply their
@@ -56,12 +65,15 @@ class Payment_Intent {
 		$fee   = Application_Fee::calculate( $value );
 
 		$query_args = [];
-		$body = [
+		$body       = [
 			'currency'               => $value->get_currency_code(),
 			'amount'                 => (string) $value->get_integer(),
 			'payment_method_types'   => $payment_methods,
 			'application_fee_amount' => (string) $fee->get_integer(),
-			'metadata'               => [ static::$test_metadata_key => true ],
+			'metadata'               => [
+				static::$test_metadata_key      => true,
+				static::$tc_metadata_identifier => true,
+			],
 		];
 
 		$args = [
@@ -107,6 +119,9 @@ class Payment_Intent {
 			'amount'                 => (string) $value->get_integer(),
 			'payment_method_types'   => tribe( Merchant::class )->get_payment_method_types( $retry ),
 			'application_fee_amount' => (string) $fee->get_integer(),
+			'metadata'               => [
+				static::$tc_metadata_identifier => true,
+			],
 		];
 
 		$stripe_statement_descriptor = tribe_get_option( Settings::$option_statement_descriptor );

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
@@ -34,6 +34,18 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 
 		if ( empty( $order ) ) {
 
+			if ( empty( $payment_intent['metadata'][ Payment_Intent::$tc_metadata_identifier ] ) ) {
+				$response->set_status( 200 );
+				$response->set_data( sprintf(
+				// Translators: %1$s is the event id and %2$s is the event type name.
+					__( 'Event %1$s was received and will not be handled because the Payment Intent %2$s does not refer to an Event Tickets transaction.', 'event-tickets' ),
+					esc_html( Arr::get( $event, 'id' ) ),
+					esc_html( $payment_intent_id )
+				) );
+
+				return $response;
+			}
+
 			if ( ! empty( $payment_intent['metadata'][ Payment_Intent::$test_metadata_key ] ) ) {
 				$response->set_status( 200 );
 				$response->set_data(
@@ -59,7 +71,7 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 					esc_html( $payment_intent_id )
 				)
 			);
-			
+
 			return $response;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1474] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Before discarding a PI validation as an error, check that it was indeed created in ET so we don't throw errors for PIs created in other applications.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1474]: https://theeventscalendar.atlassian.net/browse/ET-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ