### PR TITLE
[ET-1478] Block Editor - RSVP - Title Encoding Issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.3.3] TBD =
 
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
+* Fix - RSVP title is being encoded within the block editor fields. [ET-1478]
 
 = [5.3.2] 2022-04-05 =
 

--- a/src/modules/data/blocks/rsvp/thunks.js
+++ b/src/modules/data/blocks/rsvp/thunks.js
@@ -162,7 +162,7 @@ export const getRSVP = ( postId, page = 1 ) => ( dispatch ) => {
 						),
 					);
 					dispatch( actions.setRSVPDetails( {
-						title: rsvp.title.rendered,
+						title: rsvp.title.raw,
 						description: rsvp.excerpt.raw,
 						capacity,
 						notGoingResponses,
@@ -178,7 +178,7 @@ export const getRSVP = ( postId, page = 1 ) => ( dispatch ) => {
 						endTimeInput: momentUtil.toTime( endMoment ),
 					} ) );
 					dispatch( actions.setRSVPTempDetails( {
-						tempTitle: rsvp.title.rendered,
+						tempTitle: rsvp.title.raw,
 						tempDescription: rsvp.excerpt.raw,
 						tempCapacity: capacity,
 						tempNotGoingResponses: notGoingResponses,


### PR DESCRIPTION
### 🎫 Ticket

[ET-1478] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
When using quotes or apostrophes in the title of an RSVP, the block editor is displaying the encoded characters instead of the raw characters.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://i.imgur.com/HnNSCIs.png

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1478]: https://theeventscalendar.atlassian.net/browse/ET-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ