### PR TITLE
[ET-1435] Theme compatibility tweak with Genesis

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.3.3] TBD =
 
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
+* Tweak - Lighten color of disabled "Get Tickets" button text when using the Genesis theme. [ET-1435]
 
 = [5.3.2] 2022-04-05 =
 

--- a/src/resources/postcss/tickets/_block-footer.pcss
+++ b/src/resources/postcss/tickets/_block-footer.pcss
@@ -77,6 +77,7 @@
 
 			&:disabled {
 				background-color: var(--tec-color-accent-primary);
+				color: var(--tec-color-text-disabled);
 				cursor: not-allowed;
 			}
 		}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1435] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
When using the Genesis theme, the "Get Tickets" button text is too dark when it is disabled.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before: https://d.pr/i/QhTAas
After: https://i.imgur.com/KsbIVtZ.png

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1435]: https://theeventscalendar.atlassian.net/browse/ET-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ