### PR TITLE
[ET-1492] Fix margin for deleted attendees

### DIFF
--- a/src/resources/postcss/tickets-report.pcss
+++ b/src/resources/postcss/tickets-report.pcss
@@ -158,10 +158,6 @@
 				&:first-child {
 					margin-bottom: 0;
 				}
-
-				&:last-child {
-					margin-top: 0;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1492] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
During a demo of the upsell feature, it was found that the "Deleted Attendees" column spacing was a bit off. This PR fixes that.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Issue shown here: https://i.imgur.com/AqTFHfX.png

### ✔️ Checklist
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1492]: https://theeventscalendar.atlassian.net/browse/ET-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ