### PR TITLE
[ET-1502] Fix Fatal Error When Exporting Attendees in PHP 8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.3.4] TBD =
 
+* Fix - Fatal error when exporting attendees in PHP 8 [ET-1502]
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
 
 = [5.3.3] 2022-04-28 =

--- a/readme.txt
+++ b/readme.txt
@@ -190,7 +190,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.3.4] TBD =
 
-* Fix - Fatal error when exporting attendees in PHP 8 [ET-1502]
+* Fix - Fatal error when exporting attendees in PHP 8. [ET-1502]
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
 
 = [5.3.3] 2022-04-28 =

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -538,6 +538,11 @@ class Tribe__Tickets__Attendees {
 				// should simply be passed back unmodified
 				$row[ $column_id ] = $this->attendees_table->column_default( $single_item, $column_id );
 
+				// In the case of orphaned field data, handle converting array to string.
+				if ( is_array( $row[ $column_id ] ) && array_key_exists( 'value', $row[ $column_id ] ) ) {
+					$row[ $column_id ] = $row[ $column_id ]['value'];
+				}
+
 				// Special handling for the check_in column
 				if ( ! empty( $single_item[ $column_id ] ) && 'check_in' === $column_id && 1 == $single_item[ $column_id ] ) {
 					$row[ $column_id ] = esc_html__( 'Yes', 'event-tickets' );

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -1,4 +1,7 @@
 <?php
+
+use Illuminate\Support\Arr;
+
 /**
  * Handles most actions related to an Attendeees or Multiple ones
  */
@@ -539,8 +542,8 @@ class Tribe__Tickets__Attendees {
 				$row[ $column_id ] = $this->attendees_table->column_default( $single_item, $column_id );
 
 				// In the case of orphaned field data, handle converting array to string.
-				if ( is_array( $row[ $column_id ] ) && array_key_exists( 'value', $row[ $column_id ] ) ) {
-					$row[ $column_id ] = $row[ $column_id ]['value'];
+				if ( is_array( $row[ $column_id ] ) ) {
+					$row[ $column_id ] = Arr::get( $row[ $column_id ], 'value', '' );
 				}
 
 				// Special handling for the check_in column

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Support\Arr;
+use Tribe__Utils__Array as Arr;
 
 /**
  * Handles most actions related to an Attendeees or Multiple ones


### PR DESCRIPTION
### 🎫 Ticket

[ET-1502] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
There was a fatal error being thrown when trying to export attendees in PHP 8. This PR fixes it by using `array_key_exists()` instead of `isset()`.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1502]: https://theeventscalendar.atlassian.net/browse/ET-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ