### PR TITLE
[ET-1504] Fix Typo in Value Utility for Tickets Commerce

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -192,9 +192,6 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Typo was causing a JS `setAttribute` error in `vue.min.js`. [ET-1504]
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
-
-= [5.3.3] 2022-04-28 =
-
 * Enhancement - Notify users of the Manual Addition of Attendees feature that is available. [ET-1492]
 * Enhancement - Notify users of Capacity and Attendee Registration Field features that are available. [ET-1493]
 * Fix - RSVP title is being encoded within the block editor fields. [ET-1478]
@@ -202,6 +199,11 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Fixed template override path for a few templates. [ET-1491]
 * Enhancement - Added availability dates and icons to ticket listing in classic editor. [ET-1494]
 * Tweak - Lighten color of disabled "Get Tickets" button text when using the Genesis theme. [ET-1435]
+
+= [5.3.3] 2022-04-28 =
+
+* Fix - Updates the plugin validation library to track licenses in a more fault-tolerant way. [ET-1498]
+* Language - 0 new strings added, 1 updated, 0 fuzzied, and 0 obsoleted.
 
 = [5.3.2] 2022-04-05 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.3.4] TBD =
 
+* Fix - Typo was causing a JS `setAttribute` error in `vue.min.js`. [ET-1504]
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
 
 = [5.3.3] 2022-04-28 =

--- a/src/Tickets/Commerce/Utils/Value.php
+++ b/src/Tickets/Commerce/Utils/Value.php
@@ -62,7 +62,7 @@ class Value extends Abstract_Currency {
 		$html[] = '<span class="tribe-amount">%2$s</span>';
 		$html[] = '</span>';
 
-		if ( $position !== 'prefix' ) {
+		if ( 'prefix' !== $position ) {
 			// If position is not prefix, swap the symbol and amount span tags.
 			$hold    = $html[1];
 			$html[1] = $html[2];

--- a/src/Tickets/Commerce/Utils/Value.php
+++ b/src/Tickets/Commerce/Utils/Value.php
@@ -57,7 +57,7 @@ class Value extends Abstract_Currency {
 
 		$position = 'prefix' === $this->get_currency_symbol_position() ? 'prefix' : 'postfix';
 
-		$html[] = "<span class'tribe-formatted-currency-wrap tribe-currency-{$position}'>";
+		$html[] = "<span class='tribe-formatted-currency-wrap tribe-currency-{$position}'>";
 		$html[] = '<span class="tribe-currency-symbol">%1$s</span>';
 		$html[] = '<span class="tribe-amount">%2$s</span>';
 		$html[] = '</span>';


### PR DESCRIPTION
### 🎫 Ticket

[ET-1504] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Quick and simple typo fix. Missing `=`.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1504]: https://theeventscalendar.atlassian.net/browse/ET-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ