### PR TITLE
Remove Minimum Height on Attendees Page

### DIFF
--- a/src/resources/postcss/tickets-report.pcss
+++ b/src/resources/postcss/tickets-report.pcss
@@ -20,6 +20,10 @@
 		color: inherit;
 	}
 
+	.welcome-panel-content {
+		min-height: unset;
+	}
+
 	.welcome-panel-column-container {
 		display: grid;
 		gap: unset;

--- a/src/resources/postcss/tickets-report.pcss
+++ b/src/resources/postcss/tickets-report.pcss
@@ -21,7 +21,7 @@
 	}
 
 	.welcome-panel-content {
-		min-height: unset;
+		min-height: initial;
 	}
 
 	.welcome-panel-column-container {


### PR DESCRIPTION
### 🎫 Ticket

[ET-1492] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
There was a large space below the top section for some events. It was found to be some CSS that WordPress had put into their "Welcome Page" code and it was conflicting with the attendees page. This PR unsets that `min-height` setting for the attendees page.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1492]: https://theeventscalendar.atlassian.net/browse/ET-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ