### PR TITLE
[ET-1520] Fix - Avoid loading partner JS everywhere on WP Admin

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.4.1] TBD =
 
 * Fix - Encoding issue in the block editor's price block of The Events Calendar events. [ET-1434]
+* Fix - Avoid loading PayPal partner JS script on all admin pages. [ET-1520]
 
 = [5.4.0.1] 2022-05-23 =
 

--- a/src/Tickets/Commerce/Gateways/PayPal/Assets.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Assets.php
@@ -201,6 +201,6 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 * @return bool If the `PayPal` assets should be enqueued or not.
 	 */
 	public function should_enqueue_assets_payments_tab() {
-		return 'payments' === tribe_get_request_var( 'tab' ) && \Tribe\Tickets\Admin\Settings::$settings_page_id === tribe_get_request_var( 'page' );
+		return 'paypal' === tribe_get_request_var( 'tc-section' ) && 'payments' === tribe_get_request_var( 'tab' ) && \Tribe\Tickets\Admin\Settings::$settings_page_id === tribe_get_request_var( 'page' );
 	}
 }

--- a/src/Tickets/Commerce/Gateways/PayPal/Assets.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Assets.php
@@ -36,6 +36,7 @@ class Assets extends \tad_DI52_ServiceProvider {
 			[],
 			'admin_enqueue_scripts',
 			[
+				'conditionals' => [ $this, 'should_enqueue_assets_payments_tab' ],
 				'localize' => [
 					[
 						'name' => 'tribeTicketsCommercePayPaCommerce',


### PR DESCRIPTION
### 🎫 Ticket

[ET-1520] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* PayPal's signup partner JS asset was getting loaded on every page of the admin.

 📷 screenshot: https://d.pr/i/vrKRq2

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1520]: https://theeventscalendar.atlassian.net/browse/ET-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ