### PR TITLE
[ET-1518] Blocks Editor - Ticket Sales Times Load as Midnight

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD
+
+* Fix - In the blocks editor, the ticket sale start/end times always load as midnight. [ET-1518]
+
 = [5.3.4.1] 2022-05-12 =
 
 * Version - Event Tickets 5.3.4.1 is only compatible with Event Tickets Plus 5.4.4.1 and higher

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -509,11 +509,15 @@ class Tribe__Tickets__REST__V1__Post_Repository
 		/** @var Tribe__Tickets__Tickets_Handler $handler */
 		$handler = tribe( 'tickets.handler' );
 
-		$start_date = get_post_meta( $ticket_id, $handler->key_start_date, true );
+		$start_info = [
+			get_post_meta( $ticket_id, $handler->key_start_date, true ),
+			get_post_meta( $ticket_id, $handler->key_start_time, true )
+		];
+		$start_string = implode( ' ', $start_info );
 
 		return $get_details
-			? $this->get_date_details( $start_date )
-			: $start_date;
+			? $this->get_date_details( $start_string )
+			: $start_string;
 	}
 
 	/**
@@ -530,11 +534,15 @@ class Tribe__Tickets__REST__V1__Post_Repository
 		/** @var Tribe__Tickets__Tickets_Handler $handler */
 		$handler = tribe( 'tickets.handler' );
 
-		$end_date = get_post_meta( $ticket_id, $handler->key_end_date, true );
+		$end_info = [
+			get_post_meta( $ticket_id, $handler->key_end_date, true ),
+			get_post_meta( $ticket_id, $handler->key_end_time, true ),
+		];
+		$end_string = implode( ' ', $end_info );
 
 		return $get_details
-			? $this->get_date_details( $end_date )
-			: $end_date;
+			? $this->get_date_details( $end_string )
+			: $end_string;
 	}
 
 	/**

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -43,6 +43,15 @@ class Tribe__Tickets__Tickets_Handler {
 	public $key_start_date = '_ticket_start_date';
 
 	/**
+	 * Post meta key for the ticket start time
+	 *
+	 * @since  TBD
+	 *
+	 * @var    string
+	 */
+	public $key_start_time = '_ticket_start_time';
+
+	/**
 	 * Post meta key for the ticket end date
 	 *
 	 * @since  4.6
@@ -50,6 +59,15 @@ class Tribe__Tickets__Tickets_Handler {
 	 * @var    string
 	 */
 	public $key_end_date = '_ticket_end_date';
+
+	/**
+	 * Post meta key for the ticket end time
+	 *
+	 * @since  TBD
+	 *
+	 * @var    string
+	 */
+	public $key_end_time = '_ticket_end_time';
 
 	/**
 	 * Post meta key for the manual updated meta keys


### PR DESCRIPTION
### 🎫 Ticket

[ET-1518] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Fixes and issue where the tickets block's sales start/end times always loaded as midnight. This root cause was that the API was always returning midnight because it was only looking at the date that was stored and not the time.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.screencast.com/t/Zclxx5OmB

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
