### PR TITLE
[ET-1521] Settings > Add permalinks configuration notice

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 
 * Fix - Encoding issue in the block editor's price block of The Events Calendar events. [ET-1434]
 * Fix - Add India to the list of countries ET cannot process fees from. [ET-1522]
+* Enhancement - Add a new notice to set up permalinks to something different than "Plain" in order to use Tickets Commerce. [ET-1521]
 
 = [5.4.0.1] 2022-05-23 =
 
@@ -16,7 +17,12 @@
 * Feature - Introducing the new Tickets menu on the WordPress admin. [ET-1335]
 * Language - 6 new strings added, 171 updated, 1 fuzzied, and 2 obsoleted
 
-= [5.3.4] 2022-05-10 =
+= [5.3.4.1] 2022-05-12 =
+
+* Version - Event Tickets 5.3.4.1 is only compatible with Event Tickets Plus 5.4.4.1 and higher
+* Fix - Ensure that Event Tickets Plus customers never encounter application fees on Stripe for Tickets Commerce purchases. [ET-1513]
+
+= [5.3.4] 2022-05-11 =
 
 * Fix - Typo was causing a JS `setAttribute` error in `vue.min.js`. [ET-1504]
 * Fix - Fatal error when exporting attendees in PHP 8. [ET-1502]
@@ -24,9 +30,9 @@
 * Fix - RSVP title is being encoded within the block editor fields. [ET-1478]
 * Fix - Tickets Commerce manual attendee's ticket price is set to 0. [ETP-781]
 * Fix - Fixed template override path for a few templates. [ET-1491]
+* Enhancement - Added availability dates and icons to ticket listing in classic editor. [ET-1494]
 * Enhancement - Notify users of the Manual Addition of Attendees feature that is available. [ET-1492]
 * Enhancement - Notify users of Capacity and Attendee Registration Field features that are available. [ET-1493]
-* Enhancement - Added availability dates and icons to ticket listing in classic editor. [ET-1494]
 * Tweak - Lighten color of disabled "Get Tickets" button text when using the Genesis theme. [ET-1435]
 * Tweak - Added actions: `tec_tickets_attendees_event_summary_table_extra`
 * Tweak - Changed views: `blocks/tickets/opt-out-hidden`, `blocks/tickets/registration/summary/content`, `registration-js/attendees/fields/number`, `v2/tickets/commerce/fields/tribe-commerce`, `v2/tickets/item/extra/description-toggle`, `v2/tickets/submit/must-login`.

--- a/readme.txt
+++ b/readme.txt
@@ -226,42 +226,4 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Tweak - Changed views: `blocks/tickets/opt-out-hidden`, `blocks/tickets/registration/summary/content`, `registration-js/attendees/fields/number`, `v2/tickets/commerce/fields/tribe-commerce`, `v2/tickets/item/extra/description-toggle`, `v2/tickets/submit/must-login`.
 * Language - 2 new strings added, 46 updated, 0 fuzzied, and 0 obsoleted.
 
-= [5.3.3] 2022-04-28 =
-
-* Fix - Updates the plugin validation library to track licenses in a more fault-tolerant way. [ET-1498]
-* Language - 0 new strings added, 1 updated, 0 fuzzied, and 0 obsoleted.
-
-= [5.3.2] 2022-04-05 =
-
-* Feature - REST API endpoints added for creating and updating attendees. [ET-1346]
-* Enhancement - Added a notice when an enabled Tickets Commerce gateway doesn't support it's selected currency. [ET-1392]
-* Enhancement - Adding the South African Rand to list of supported currencies in Tickets Commerce. [ET-1438]
-* Enhancement - Hide 'View My Tickets' link when showing tickets within the `[tribe_tickets]` shortcode. [ETP-775]
-* Fix - Fixed Events Tickets App check-in for Tickets Commerce tickets. [ET-1436]
-* Fix - Improved validation of Stripe webhook events to avoid handling events created by other apps. [ET-1474]
-* Fix - Fixed Issue with Tickets Commerce Tickets not displaying in REST API. [ET-1458]
-* Fix - Fixed Issue with Tickets Commerce Attendees not displaying in shortcodes. [ET-1461]
-* Fix - Fixed Issue with Tickets Commerce Attendees not being synced with Promoter. [ET-1476]
-* Fix - Fixed JS assets loading and causing errors on checkout page for Tickets Commerce. [ET-1426]
-* Fix - Fixed WooCommerce currency settings not getting reflected on Event Cost Field . [ETP-783]
-* Fix - Correct a misapplied Customizer color that breaks the loading "dot" animation. [ET-1437]
-* Fix - Add Mexico to the list of countries ET cannot process fees from. [ET-1479]
-* Tweak - Updated links in readme.txt file. [ET-1459]
-* Tweak - Added filters: `tec_tickets_commerce_admin_notices`, `tec_tickets_commerce_gateway_supported_currencies_`, `tec_tickets_commerce_currency_code_options`, `tribe_ticket_rest_api_post_attendee_args`, `tribe_ticket_rest_api_edit_attendee_args`, `tribe_tickets_rest_api_post_attendee_data`, `tribe_tickets_rest_api_update_attendee_data`, `tec_tickets_completed_status_by_provider_name`, `tec_tickets_hide_view_link`
-* Tweak - Added actions: `tribe_tickets_promoter_trigger_attendee`, `tec-tickets-commerce-checkout-shortcode-assets`, `tec-tickets-commerce-checkout-shortcode-assets`
-* Tweak - Changed views: `blocks/attendees/view-link`, `tickets/view-link`
-* Language - 17 new strings added, 70 updated, 0 fuzzied, and 0 obsoleted
-
-= [5.3.1] 2022-03-15 =
-
-* Fix - Fixed a warning message when creating an event via Community Events. [CT-51]
-* Fix - Fixed errors for Tickets Commerce with Stripe during checkout. [ET-1447]
-* Fix - Fixed the default views (v2) for users that are using Event Tickets as standalone, after version `5.3.0`. [ET-1448]
-* Fix - Avoid sending duplicate ticket emails for using Tickets Commerce Stripe Webhooks. [ET-1446]
-* Fix - Respect the selected currency when using Tickets Commerce in the blocks editor. [ET-1450]
-* Enhancement - Updated theme compatibility class to make use of common compatibility classes. Deprecate the `filter_body_class` and `get_body_classes` methods from `Tribe__Tickets__Theme_Compatibility`. [ET-850]
-* Enhancement - Tweaked `get_tickets` method to improve stability and performance around ticket. [ET-1362]
-* Tweak - Removed filters: `tribe_tickets_theme_compatibility_registered`
-* Language - 0 new strings added, 33 updated, 0 fuzzied, and 0 obsoleted
-
 [See changelog for all versions](https://evnt.is/1b5k)

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Encoding issue in the block editor's price block of The Events Calendar events. [ET-1434]
 * Fix - Add India to the list of countries ET cannot process fees from. [ET-1522]
+* Enhancement - Add a new notice to set up permalinks to something different than "Plain" in order to use Tickets Commerce. [ET-1521]
 
 = [5.4.0.1] 2022-05-23 =
 

--- a/src/Tickets/Commerce/Admin/Notices.php
+++ b/src/Tickets/Commerce/Admin/Notices.php
@@ -157,7 +157,7 @@ class Notices extends tad_DI52_ServiceProvider {
 	 *
 	 * @since TBD
 	 *
-	 * @return bool
+	 * @return bool Whether or not to render the notice.
 	 */
 	public function should_render_permalinks_notice() {
 		// If the site is using pretty permalinks, bail.

--- a/src/Tickets/Commerce/Admin/Notices.php
+++ b/src/Tickets/Commerce/Admin/Notices.php
@@ -5,6 +5,7 @@ namespace TEC\Tickets\Commerce\Admin;
 use \tad_DI52_ServiceProvider;
 use TEC\Tickets\Commerce\Checkout;
 use TEC\Tickets\Commerce\Success;
+use Tribe\Tickets\Admin\Settings as Plugin_Settings;
 
 /**
  * Class Notices
@@ -33,6 +34,12 @@ class Notices extends tad_DI52_ServiceProvider {
 				[ 'dismiss' => false, 'type' => 'error' ],
 				[ $this, 'should_render_success_notice' ],
 			],
+			[
+				'event-tickets-tickets-commerce-permalinks',
+				[ $this, 'render_permalinks_notice' ],
+				[ 'dismiss' => true, 'type' => 'error' ],
+				[ $this, 'should_render_permalinks_notice' ],
+			],
 		];
 
 		/**
@@ -58,7 +65,7 @@ class Notices extends tad_DI52_ServiceProvider {
 	 */
 	public function should_render_checkout_notice() {
 		// If we're not on our own settings page, bail.
-		if ( \Tribe\Tickets\Admin\Settings::$settings_page_id !== tribe_get_request_var( 'page' ) ) {
+		if ( tribe_get_request_var( 'page' ) !== \Tribe\Tickets\Admin\Settings::$settings_page_id ) {
 			return false;
 		}
 
@@ -84,8 +91,10 @@ class Notices extends tad_DI52_ServiceProvider {
 		);
 		$notice_header = esc_html__( 'Set up your checkout page', 'event-tickets' );
 		$notice_text = sprintf(
-			// translators: %1$s: Link to knowledgebase article.
-			esc_html__( 'In order to start selling with Tickets Commerce, you\'ll need to set up your checkout page. Please configure the setting on Settings > Payments and confirm that the page you have selected has the proper shortcode. %1$s', 'event-tickets' ),
+			// translators: %1$s: Opening `<a>` tag for the Payments tab on the Tickets Settings. %2$s: Closing `</a>` tag. %3$s: Link to knowledgebase article.
+			esc_html__( 'In order to start selling with Tickets Commerce, you\'ll need to set up your checkout page. Please configure the setting on %1$sTickets > Settings > Payments%2$s and confirm that the page you have selected has the proper shortcode. %3$s', 'event-tickets' ),
+			'<a href="' . tribe( Plugin_Settings::class )->get_url( [ 'tab' => 'payments' ] ) . '">',
+			'</a>',
 			$notice_link
 		);
 
@@ -103,7 +112,7 @@ class Notices extends tad_DI52_ServiceProvider {
 	 */
 	public function should_render_success_notice() {
 		// If we're not on our own settings page, bail.
-		if ( \Tribe\Tickets\Admin\Settings::$settings_page_id !== tribe_get_request_var( 'page' ) ) {
+		if ( tribe_get_request_var( 'page' ) !== \Tribe\Tickets\Admin\Settings::$settings_page_id ) {
 			return false;
 		}
 
@@ -115,7 +124,7 @@ class Notices extends tad_DI52_ServiceProvider {
 	}
 
 	/**
-	 * Gets the HTML for the notice that is shown when checkout setting is not set.
+	 * Gets the HTML for the notice that is shown when success setting is not set.
 	 *
 	 * @since 5.2.0
 	 *
@@ -128,9 +137,67 @@ class Notices extends tad_DI52_ServiceProvider {
 			esc_html__( 'Learn More', 'event-tickets' )
 		);
 		$notice_header = esc_html__( 'Set up your order success page', 'event-tickets' );
-		$notice_text = sprintf(
-			// translators: %1$s: Link to knowledgebase article.
-			esc_html__( 'In order to start selling with Tickets Commerce, you\'ll need to set up your order success page. Please configure the setting on Settings > Payments and confirm that the page you have selected has the proper shortcode. %1$s', 'event-tickets' ),
+		$notice_text   = sprintf(
+			// translators: %1$s: Opening `<a>` tag for the Payments tab on the Tickets Settings. %2$s: Closing `</a>` tag.  %3$s: Link to knowledgebase article.
+			esc_html__( 'In order to start selling with Tickets Commerce, you\'ll need to set up your order success page. Please configure the setting on %1$sTickets > Settings > Payments%2$s and confirm that the page you have selected has the proper shortcode. %3$s', 'event-tickets' ),
+			'<a href="' . tribe( Plugin_Settings::class )->get_url( [ 'tab' => 'payments' ] ) . '">',
+			'</a>',
+			$notice_link
+		);
+
+		return sprintf(
+			'<p><strong>%1$s</strong></p><p>%2$s</p>',
+			$notice_header,
+			$notice_text
+		);
+	}
+
+	/**
+	 * Display a notice when Tickets Commerce is enabled, and the site is not using pretty permalinks.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_render_permalinks_notice() {
+		// If the site is using pretty permalinks, bail.
+		if ( '' !== get_option( 'permalink_structure' ) ) {
+			return false;
+		}
+
+		// If we're not on our own settings page, bail.
+		if ( tribe_get_request_var( 'page' ) !== \Tribe\Tickets\Admin\Settings::$settings_page_id ) {
+			return false;
+		}
+
+		// If Tickets Commerce is not enabled, bail.
+		if ( ! tec_tickets_commerce_is_enabled() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the HTML for the notice that is shown when permalinks are not set.
+	 *
+	 * @since TBD
+	 *
+	 * @return string Notice HTML.
+	 */
+	public function render_permalinks_notice() {
+		$notice_link = sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+			esc_url( 'https://evnt.is/tec-tc-permalinks' ),
+			esc_html__( 'Learn More', 'event-tickets' )
+		);
+
+		$notice_header = esc_html__( 'Set up your permalinks to sell with Tickets Commerce', 'event-tickets' );
+		$notice_text   = sprintf(
+			// translators: %3$s: Link to knowledgebase article.
+			esc_html__( 'In order to start selling with Tickets Commerce, you\'ll need to set up your permalinks setting to an option different than "Plain". Please configure the setting on %1$sSettings > Permalinks%2$s and confirm that you are not using plain permalinks. %3$s', 'event-tickets' ),
+			'<a href="' . get_admin_url( null, 'options-permalink.php' ) . '">',
+			'</a>',
 			$notice_link
 		);
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1521] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Adding a notice that they need to use their permalinks setting to something different than "Plain" in order to use Tickets Commerce.
- Updating conditionals to yoda.
- Adding link to `Tickets > Settings > Payments` in other notices.
- Sync `changelog.txt` and add missing version, and trim versions from `readme.txt`

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://user-images.githubusercontent.com/252415/170278165-737068df-076f-4760-8de0-987fc8c44658.mov

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1521]: https://theeventscalendar.atlassian.net/browse/ET-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ