### PR TITLE
[ET-1497] Fix saving webhook secret on failed validation.

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks.php
@@ -114,6 +114,9 @@ class Webhooks extends Abstract_Webhooks {
 		$is_valid = tribe_get_option( static::$option_is_valid_webhooks, false );
 		if ( $is_valid ) {
 			$status = esc_html__( 'Webhooks were properly validated for sales.', 'event-tickets' );
+		} else {
+			// Reset saved signing key.
+			tribe_update_option( static::$option_webhooks_signing_key, '' );
 		}
 
 		wp_send_json_success( [ 'is_valid_webhook' => $is_valid, 'updated' => $updated, 'status' => $status ] );

--- a/src/resources/postcss/tickets-commerce/admin/gateway/stripe/webhooks.pcss
+++ b/src/resources/postcss/tickets-commerce/admin/gateway/stripe/webhooks.pcss
@@ -22,3 +22,21 @@
 		}
 	}
 }
+
+#tribe-field-tickets-commerce-stripe-webhooks-signing-key {
+	.dashicons{
+		&.dashicons-update {
+			animation: rotate 1s infinite;
+		}
+		&.dashicons-no {
+			color: var(--tec-color-icon-error);
+		}
+		&.dashicons-yes {
+			color: #50b078;
+		}
+	}
+
+	@keyframes rotate {
+		100% {transform: rotate(360deg);}
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1497] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Avoid saving the webhook secret signing key if validation failed.
* Add colors to dashicons to provide better UX.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://d.pr/v/tWrtCT

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1497]: https://theeventscalendar.atlassian.net/browse/ET-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ