### PR TITLE
[ET-1535] Remove Duplicate Total Event Capacity

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [5.4.2] TBD =
+
+* Fix - Remove duplicate `Total Event Capacity` wording when ET+ is activated. [ET-1535]
+
 = [5.4.1] 2022-06-08 =
 
 * Enhancement - Expanded list of supported currencies for Tickets Commerce, for details visit: https://evnt.is/tec-tc-currencies. [ET-1454, ET-1455, ET-1456]

--- a/src/admin-views/editor/total-capacity.php
+++ b/src/admin-views/editor/total-capacity.php
@@ -1,0 +1,31 @@
+<?php
+$post_id = get_the_ID();
+
+/** @var Tribe__Tickets__Tickets_Handler $handler */
+$handler = tribe( 'tickets.handler' );
+
+$total_tickets = tribe_get_event_capacity( $post_id );
+
+// only show if there are tickets
+if ( empty( $total_tickets ) ) {
+	return;
+}
+?>
+<span id="ticket_form_total_capacity">
+	<?php esc_html_e( 'Total Event Capacity:', 'event-tickets-plus' ); ?>
+	<span id="ticket_form_total_capacity_value" title="<?php esc_attr_e( 'The total number of possible attendees for this event', 'event-tickets-plus' ); ?>">
+		<?php
+		switch ( $total_tickets ) {
+			case -1:
+				printf( '<i>%s</i>', esc_html( $handler->unlimited_term ) );
+				break;
+			case 0:
+				printf( '<i>%s</i>', esc_html__( 'No tickets created yet', 'event-tickets-plus' ) );
+				break;
+			default:
+				echo esc_html( number_format_i18n( $total_tickets ) );
+				break;
+		}
+		?>
+	</span>
+</span>

--- a/src/admin-views/editor/total-capacity.php
+++ b/src/admin-views/editor/total-capacity.php
@@ -12,15 +12,15 @@ if ( empty( $total_tickets ) ) {
 }
 ?>
 <span id="ticket_form_total_capacity">
-	<?php esc_html_e( 'Total Event Capacity:', 'event-tickets-plus' ); ?>
-	<span id="ticket_form_total_capacity_value" title="<?php esc_attr_e( 'The total number of possible attendees for this event', 'event-tickets-plus' ); ?>">
+	<?php esc_html_e( 'Total Event Capacity:', 'event-tickets' ); ?>
+	<span id="ticket_form_total_capacity_value" title="<?php esc_attr_e( 'The total number of possible attendees for this event', 'event-tickets' ); ?>">
 		<?php
 		switch ( $total_tickets ) {
 			case -1:
 				printf( '<i>%s</i>', esc_html( $handler->unlimited_term ) );
 				break;
 			case 0:
-				printf( '<i>%s</i>', esc_html__( 'No tickets created yet', 'event-tickets-plus' ) );
+				printf( '<i>%s</i>', esc_html__( 'No tickets created yet', 'event-tickets' ) );
 				break;
 			default:
 				echo esc_html( number_format_i18n( $total_tickets ) );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1535] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
ET is referencing a template that only exists in ET+. ET+ is also referencing that same template. This causes the template to appear twice when ET+ is activated.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/7432506/173680277-95f6783b-def6-47a1-aebc-1b2b2dfea83e.png)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1535]: https://theeventscalendar.atlassian.net/browse/ET-1535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ