### PR TITLE
[ET-1528] Don't Promoter ET+ if it's Already Installed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [5.4.2] TBD =
+
+* Fix - No need to promoter ET+ if it's already installed. [ET-1528]
+
 = [5.4.1] 2022-06-08 =
 
 * Enhancement - Expanded list of supported currencies for Tickets Commerce, for details visit: https://evnt.is/tec-tc-currencies. [ET-1454, ET-1455, ET-1456]

--- a/src/Tickets/Commerce/Payments_Tab.php
+++ b/src/Tickets/Commerce/Payments_Tab.php
@@ -294,17 +294,25 @@ class Payments_Tab extends tad_DI52_ServiceProvider {
 	public function get_tickets_commerce_section_fields() {
 		$fields = [];
 
-		// If no gateway section is selected, show main settings.
-		$plus_link = sprintf(
-			'<a href="https://evnt.is/19zl" target="_blank" rel="noopener noreferrer">%s</a>',
-			esc_html__( 'Event Tickets Plus', 'event-tickets' )
-		);
+		// Show settings description
+		$plus_messages = [
+			esc_html_x( 'Tickets Commerce provides a simple and flexible ecommerce checkout for purchasing tickets. Just choose your payment gateway and configure checkout options and you\'re all set.', 'about Tickets Commerce', 'event-tickets' ),
+		];
 
-		$plus_message = sprintf(
-		// Translators: %1$s: The Event Tickets Plus link.
-			esc_html_x( 'Tickets Commerce provides a simple and flexible ecommerce checkout for purchasing tickets. Just choose your payment gateway and configure checkout options and you\'re all set.  If you need more advanced features like custom attendee information, QR code check in, and stock sharing between tickets, take a look at %1$s for these features and more.', 'about Tickets Commerce', 'event-tickets' ),
-			$plus_link
-		);
+		// Promote Event Tickets Plus if not installed.
+		if ( ! class_exists( 'Tribe__Tickets_Plus__Main' ) ) {
+			$plus_link = sprintf(
+				'<a href="https://evnt.is/19zl" target="_blank" rel="noopener noreferrer">%s</a>',
+				esc_html__( 'Event Tickets Plus', 'event-tickets' )
+			);
+
+			$plus_messages[] = sprintf(
+				// Translators: %1$s: The Event Tickets Plus link.
+				esc_html_x( 'If you need more advanced features like custom attendee information, QR code check in, and stock sharing between tickets, take a look at %1$s for these features and more.', 'about Event Tickets Plus', 'event-tickets' ),
+				$plus_link
+			);
+		}
+		$plus_message = implode( ' ', $plus_messages );
 
 		$is_tickets_commerce_enabled = tec_tickets_commerce_is_enabled();
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1528] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
On the Tickets -> Settings page, we are promoting ET+ even when it's already installed. We're adding in logic to remove the mention of ET+ when it's installed and activated already.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/7432506/173684368-49c3fdec-a5ce-40cd-a96e-01ca2138bac0.png)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
