### PR TITLE
[ET-1534] Tickets Commerce - Add Currency Position Setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.4.2] TBD =
 
 * Fix - Remove duplicate `Total Event Capacity` wording when ET+ is activated. [ET-1535]
+* Enhancement - Add a `Currency Position` setting for Tickets Commerce. [ET-1534]
 
 = [5.4.1] 2022-06-08 =
 

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -262,7 +262,7 @@ class Settings {
 				'type'            => 'dropdown',
 				'label'           => esc_html__( 'Currency Position', 'event-tickets' ),
 				'tooltip'         => esc_html__( 'The position of the currency symbol as it relates to the ticket values.', 'event-tickets' ),
-				'default'         => 'before',
+				'default'         => 'prefix',
 				'validation_type' => 'options',
 				'options'         => [
 					'prefix'  => esc_html__( 'Before', 'event-tickets' ),

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -265,8 +265,8 @@ class Settings {
 				'default'         => 'before',
 				'validation_type' => 'options',
 				'options'         => [
-					'prefix'  => 'Before',
-					'postfix' => 'After',
+					'prefix'  => esc_html__( 'Before', 'event-tickets' ),
+					'postfix' => esc_html__( 'After', 'event-tickets' ),
 				],
 			],
 			static::$option_stock_handling                  => [

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -54,6 +54,15 @@ class Settings {
 	public static $option_currency_code = 'tickets-commerce-currency-code';
 
 	/**
+	 * The option key for currency position.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public static $option_currency_position = 'tickets-commerce-currency-position';
+
+	/**
 	 * The option key for stock handling.
 	 *
 	 * @since 5.1.6
@@ -248,6 +257,17 @@ class Settings {
 				'default'         => 'USD',
 				'validation_type' => 'options',
 				'options'         => $paypal_currency_code_options,
+			],
+			static::$option_currency_position               => [
+				'type'            => 'dropdown',
+				'label'           => esc_html__( 'Currency Position', 'event-tickets' ),
+				'tooltip'         => esc_html__( 'The position of the currency symbol as it relates to the ticket values.', 'event-tickets' ),
+				'default'         => 'before',
+				'validation_type' => 'options',
+				'options'         => [
+					'prefix'  => 'Before',
+					'postfix' => 'After',
+				],
 			],
 			static::$option_stock_handling                  => [
 				'type'            => 'radio',

--- a/src/Tickets/Commerce/Utils/Currency.php
+++ b/src/Tickets/Commerce/Utils/Currency.php
@@ -2,6 +2,8 @@
 
 namespace TEC\Tickets\Commerce\Utils;
 
+use TEC\Tickets\Commerce\Settings;
+
 /**
  * Class Currency Utils
  *
@@ -286,20 +288,7 @@ class Currency {
 	 *
 	 */
 	public static function get_currency_symbol_position( $code ) {
-		$map = static::get_default_currency_map();
-		if ( ! isset( $map[ $code ]['position'] ) ) {
-			$currency_position = 'prefix';
-		} else {
-			$currency_position = $map[ $code ]['position'];
-		}
-
-		if (
-			'prefix' === $currency_position
-			&& 'EUR' === $code
-			&& 0 !== strpos( get_locale(), 'en_' ) // site language does not start with 'en_'
-		) {
-			$currency_position = 'postfix';
-		}
+		$currency_position = tribe_get_option( Settings::$option_currency_position, 'prefix' );
 
 		/**
 		 * Whether the currency position should be 'prefix' or 'postfix' (i.e. suffix).


### PR DESCRIPTION
### 🎫 Ticket

[ET-1534] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Allow users to choose where they want to currency symbol to show on their site while using Tickets Commerce.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/7432506/174336996-deb4ed38-7d50-4fae-a5d4-a6def04db7eb.png)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1534]: https://theeventscalendar.atlassian.net/browse/ET-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ