### PR TITLE
[ET-1531] Tickets Commerce - SelectWoo Asset Missing When TEC is Deactivated

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,7 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Remove duplicate `Total Event Capacity` wording when ET+ is activated. [ET-1535]
 * Enhancement - Sorting support added on Tickets Commerce Order report page Order, Email, Date, Status, and Total columns. [ET-1527]
 * Enhancement - Unify CSS class names for many admin elements. [ET-1536]
-* Fix - When using ET as a standalone plugin, the SelectWoo asset was not being properly loaded. [ET-1531]
+* Fix - When using Event Tickets as a standalone plugin, the SelectWoo asset was not being properly loaded. [ET-1531]
 * Enhancement - Add a `Currency Position` setting for Tickets Commerce. [ET-1534]
 * Fix - Some CSS issues within the tickets block in the block editor. [ET-1530]
 * Fix - The wrong `Ticket #` was being sent in attendee emails for Ticket Commerce tickets. [ET-1537]

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.4.2] TBD =
 
 * Fix - Remove duplicate `Total Event Capacity` wording when ET+ is activated. [ET-1535]
+* Fix - When using ET as a standalone plugin, the SelectWoo asset was not being properly loaded. [ET-1531]
 
 = [5.4.1] 2022-06-08 =
 

--- a/src/Tickets/Commerce/Assets.php
+++ b/src/Tickets/Commerce/Assets.php
@@ -33,7 +33,11 @@ class Assets extends tad_DI52_ServiceProvider {
 			$tickets_main,
 			'tribe-tickets-admin-commerce-settings',
 			'admin/tickets-commerce-settings.js',
-			[ 'jquery' ],
+			[ 
+				'jquery',
+				'tribe-dropdowns',
+				'tribe-select2',
+			],
 			'admin_enqueue_scripts'
 		);
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1531] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
When TEC is deactivated and ET is used as a standalone plugin, we noticed that the dropdowns on the TC settings pages weren't using SelectWoo. We need to load these as dependencies in ET and not just TEC.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before fix: https://www.screencast.com/t/DC507CcDRKO
After fix: https://www.screencast.com/t/8v2SOZFtGb

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1531]: https://theeventscalendar.atlassian.net/browse/ET-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ