### PR TITLE
[ET-1524] Let Price Block Value Override Ticket Range String

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Enhancement - Unify CSS class names for many admin elements. [ET-1536]
 * Enhancement - Add a `Currency Position` setting for Tickets Commerce. [ET-1534]
 * Fix - Some CSS issues within the tickets block in the block editor. [ET-1530]
+* Fix - Allow price block to override the string that is dynamically created from ticket values. [ET-1524]
 
 = [5.4.1] 2022-06-08 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2724,6 +2724,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return array
 		 */
 		public function get_ticket_prices( array $prices, $post_id ) {
+			// If value already exists, do not override it. Return it.
+			if ( ! empty( $prices ) ) {
+				return $prices;
+			}
+
 			// Iterate through all tickets from all providers
 			foreach ( self::get_all_event_tickets( $post_id ) as $ticket ) {
 				// No need to add the pricepoint if it is already in the array


### PR DESCRIPTION
### 🎫 Ticket

[ET-1524] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
The price block doesn't "play nice" with ET when you enter your own value into it. It takes the value you enter, mixes it in with other ticket values, then creates a string based on all values. This fix allows you to enter in a value into the price block to override the dynamic price that is created based on ticket values alone.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.screencast.com/t/ldO2PKamtI7p

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1524]: https://theeventscalendar.atlassian.net/browse/ET-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ