### PR TITLE
[ET-1537] Tickets Commerce - Wrong Ticket # in Attendee Emails

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Enhancement - Unify CSS class names for many admin elements. [ET-1536]
 * Enhancement - Add a `Currency Position` setting for Tickets Commerce. [ET-1534]
 * Fix - Some CSS issues within the tickets block in the block editor. [ET-1530]
+* Fix - The wrong `Ticket #` was being sent in attendee emails for Ticket Commerce tickets. [ET-1537]
 
 = [5.4.1] 2022-06-08 =
 

--- a/src/Tickets/Commerce/Models/Attendee_Model.php
+++ b/src/Tickets/Commerce/Models/Attendee_Model.php
@@ -91,7 +91,7 @@ class Attendee_Model extends Base {
 				'user_id'         => $user_id,
 				'holder_name'     => $full_name,
 				'holder_email'    => $email,
-				'ticket_id'       => $ticket_id,
+				'ticket_id'       => $post_id,
 				'qr_ticket_id'    => $post_id,
 				'security_code'   => $security,
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1537] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Tickets Commerce was sending the wrong `Ticket #` to attendees. It should be their `Attendee ID` but it was sending the `Ticket Product ID` instead.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/7432506/174682882-a4a3cf77-a3a3-4ab9-8370-738cc3f8079f.png)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
