### PR TITLE
[ET-1534] Fix Currency Position in API

### DIFF
--- a/src/Tribe/Commerce/Currency.php
+++ b/src/Tribe/Commerce/Currency.php
@@ -529,6 +529,10 @@ class Tribe__Tickets__Commerce__Currency {
 			return 'before' === $position ? 'prefix' : 'postfix';
 		}
 
+		if ( 'TEC\Tickets\Commerce\Module' === $provider && function_exists( 'tec_tickets_commerce_currency_position' ) ) {
+			return tec_tickets_commerce_currency_position();
+		}
+
 		return $this->get_currency_symbol_position( $object_id );
 	}
 

--- a/src/template-tags/commerce.php
+++ b/src/template-tags/commerce.php
@@ -36,3 +36,14 @@ function tec_tickets_commerce_currency_code() {
 function tec_tickets_commerce_currency_symbol() {
 	return Currency::get_currency_symbol( tec_tickets_commerce_currency_code() );
 }
+
+/**
+ * Returns the Tickets Commerce currency position.
+ *
+ * @since TBD
+ *
+ * @return string String containing the Tickets Commerce currency position. Either `prefix` or `postfix`.
+ */
+function tec_tickets_commerce_currency_position() {
+	return Currency::get_currency_symbol_position( tec_tickets_commerce_currency_code() );
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1534] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
It was found, with the new currency position setting, that the tickets block wasn't honoring that position and this was due to the API not returning the position information correctly. Instead, it was always returning 'prefix' and showing the currency symbol before the value. This PR resolves that issue.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://user-images.githubusercontent.com/7432506/174851691-3665d8e7-793b-4b43-ab7d-3b29e648b4a7.png)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1534]: https://theeventscalendar.atlassian.net/browse/ET-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ