### PR TITLE
Make sure before array_merge we cast as array both ends of the merge

### DIFF
--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -519,8 +519,8 @@ class Tribe__Tickets__Tickets_Handler {
 			$provider = call_user_func( array( $provider_class, 'get_instance' ) );
 			$module_args = $provider->get_tickets_query_args( $post );
 
-			$args['post_type'] = array_merge( $args['post_type'], $module_args['post_type'] );
-			$args['meta_query'] = array_merge( $args['meta_query'], $module_args['meta_query'] );
+			$args['post_type'] = array_merge( (array) $args['post_type'], (array) $module_args['post_type'] );
+			$args['meta_query'] = array_merge( (array) $args['meta_query'], (array) $module_args['meta_query'] );
 		}
 
 		$query = new WP_Query( $args );


### PR DESCRIPTION
Warning on the CE Submit page when ET is active:
```
Warning: array_merge(): Expected parameter 2 to be an array, string given in /var/www/public/relieved-leopard/wp-content/plugins/event-tickets/src/Tribe/Tickets_Handler.php on line 522
```