### PR TITLE
[ET-1544] ET Blocks Appear in Wrong Place in Non-Event Posts

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.4.4] TBD =
 
+* Fix - Tickets/RSVP blocks appear in wrong place on non-events when blocks are disabled in The Events Calendar. [ET-1544]
 * Fix - Fixed searching attendees by purchaser name and email for Tickets Commerce attendees. [ET-1543]
 * Fix - Fixed concurrent RSVP booking not showing error messages for out of stock tickets. [ET-1506]
 * Fix - Fixed showing proper ticket unavailable message for past events. [ET-1146]

--- a/readme.txt
+++ b/readme.txt
@@ -190,7 +190,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.4.4] TBD =
 
-* Fix - Tickets/RSVP blocks appear in wrong place on non-events when blocks are disabled in The Events Calendar. [ET-1544]
+* Fix - Tickets/RSVP blocks appear in wrong place on non-events when block editor is disabled in The Events Calendar. [ET-1544]
 * Fix - Fixed searching attendees by purchaser name and email for Tickets Commerce attendees. [ET-1543]
 * Fix - Fixed concurrent RSVP booking not showing error messages for out of stock tickets. [ET-1506]
 * Fix - Fixed showing proper ticket unavailable message for past events. [ET-1146]

--- a/src/Tribe/Editor/Template/Overwrite.php
+++ b/src/Tribe/Editor/Template/Overwrite.php
@@ -94,6 +94,11 @@ class Tribe__Tickets__Editor__Template__Overwrite {
 	public function has_classic_editor( $post_id ) {
 		$is_event = function_exists( 'tribe_is_event' ) && tribe_is_event( $post_id );
 
+		// If not an event, just check if it has blocks or not.
+		if ( ! $is_event ) {
+			return ! has_blocks( $post_id );
+		}
+
 		if ( $is_event && $this->has_early_access_to_blocks() ) {
 			return false;
 		}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1544] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
When TEC and ET installed and activated and the blocks editor is deactivated in TEC, Tickets and RSVP blocks that are added into Pages or Posts appear in the wrong place. Using `has_blocks()` on non-Event post types fixes the problem.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://drive.google.com/file/d/1737NkxDyV5iNwOq0X2IKWCl5mGjPZ6b1/view?usp=sharing

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1544]: https://theeventscalendar.atlassian.net/browse/ET-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ