### PR TITLE
[ET-1544] RSVP Appears Twice on Front End

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3411,8 +3411,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			// Blocks and ticket templates merged - bail if we should be seeing blocks.
 			if (
 				has_blocks( $post->ID )
-				&& $editor->should_load_blocks()
-				&& ! $editor->is_classic_editor()
 			) {
 				return false;
 			}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3417,9 +3417,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$editor = tribe( 'editor' );
 
 			// Blocks and ticket templates merged - bail if we should be seeing blocks.
-			if (
-				has_blocks( $post->ID )
-			) {
+			if ( has_blocks( $post->ID ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1544] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
QA found that after a previous fix, the RSVP block was showing twice. Once in the correct place and again after the content. I found that there were checks that are relying on the block editor setting in events, which is unnecessary in the case of anything other than events.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://share.getcloudapp.com/7Ku69NLZ

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1544]: https://theeventscalendar.atlassian.net/browse/ET-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ