### PR TITLE
[ET-1567] Fix - TicketsCommerce ticketed events not showing up for Events ORM query.

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/checkout@v2
         if: steps.skip.outputs.value != 1
         with:
-          repository: the-events-calendar/tric
-          ref: main
+          repository: stellarwp/slic
+          ref: 0.5.35
           path: tric
           fetch-depth: 1
       # ------------------------------------------------------------------------------

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Properly save the check-in details for attendees on check-in. [ETP-819]
+* Fix - TicketsCommerce ticketed events not showing up for Events REST API. [ET-1567]
 * Enhancement - Add template tag to properly check if The Events Calendar is active. [ETP-820]
 * Enhancement - Add `attendance` information to the `events` REST API endpoint. [ET-1580]
 

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -307,12 +307,17 @@ trait Post_Tickets {
 
 		global $wpdb;
 		$prefix = 'has_rsvp_or_tickets_';
+		$tc_relation_meta_key = \TEC\Tickets\Commerce\Ticket::$event_relation_meta_key;
 
 		if ( (bool) $has_rsvp_or_tickets ) {
 			// Join to the meta that relates tickets to events but exclude RSVP tickets.
 			$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event ON (
 					{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
-					AND {$prefix}_ticket_event.meta_key REGEXP '^(_tribe_|_tec_).*(_for_event|_event)$'
+					AND (
+						{$prefix}_ticket_event.meta_key REGEXP '^_tribe.*_for_event$'
+						OR
+						{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
+					)
 				)" );
 
 			return;

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -89,7 +89,7 @@ trait Post_Tickets {
 			ON (
 				{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 				AND (
-					{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
+					{$prefix}_ticket_event.meta_key = '{$tc_relation_meta_key}'
 					OR
 					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 				)
@@ -292,7 +292,7 @@ trait Post_Tickets {
 			ON (
 				{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 				AND (
-					{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
+					{$prefix}_ticket_event.meta_key = '{$tc_relation_meta_key}'
 					OR
 					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 				)
@@ -327,7 +327,7 @@ trait Post_Tickets {
 			$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event ON (
 					{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 					AND (
-						{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
+						{$prefix}_ticket_event.meta_key = '{$tc_relation_meta_key}'
 						OR
 						{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 					)

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -89,9 +89,9 @@ trait Post_Tickets {
 			ON (
 				{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 				AND (
-					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
-					OR
 					{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
+					OR
+					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 				)
 			)" );
 
@@ -292,9 +292,9 @@ trait Post_Tickets {
 			ON (
 				{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 				AND (
-					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
-					OR
 					{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
+					OR
+					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 				)
 			)" );
 		// Keep any event without tickets or not related to an RSVP ticket.
@@ -327,9 +327,9 @@ trait Post_Tickets {
 			$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event ON (
 					{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 					AND (
-						{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
-						OR
 						{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
+						OR
+						{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 					)
 				)" );
 

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -312,7 +312,7 @@ trait Post_Tickets {
 			// Join to the meta that relates tickets to events but exclude RSVP tickets.
 			$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event ON (
 					{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
-					AND {$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
+					AND {$prefix}_ticket_event.meta_key REGEXP '^(_tribe_|_tec_).*(_for_event|_event)$'
 				)" );
 
 			return;

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -91,7 +91,7 @@ trait Post_Tickets {
 				AND (
 					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 					OR
-					{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
+					{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
 				)
 			)" );
 
@@ -294,7 +294,7 @@ trait Post_Tickets {
 				AND (
 					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 					OR
-					{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
+					{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
 				)
 			)" );
 		// Keep any event without tickets or not related to an RSVP ticket.
@@ -329,7 +329,7 @@ trait Post_Tickets {
 					AND (
 						{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 						OR
-						{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
+						{$prefix}_ticket_event.meta_key = {$tc_relation_meta_key}'
 					)
 				)" );
 

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -13,6 +13,7 @@ use Tribe__Repository;
 use Tribe__Repository__Usage_Error;
 use Tribe__Repository__Void_Query_Exception;
 use Tribe__Utils__Array;
+use TEC\Tickets\Commerce\Ticket as TEC_Ticket;
 
 /**
  * Class Post_Tickets
@@ -79,6 +80,7 @@ trait Post_Tickets {
 
 		$operator_name = Tribe__Utils__Array::get( Tribe__Repository::get_comparison_operators(), $operator, '' );
 		$prefix        = str_replace( '-', '_', 'by_cost_' . $operator_name );
+		$tc_relation_meta_key = TEC_Ticket::$event_relation_meta_key;
 
 		global $wpdb;
 
@@ -86,7 +88,11 @@ trait Post_Tickets {
 		$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event
 			ON (
 				{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
-				AND {$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
+				AND (
+					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
+					OR
+					{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
+				)
 			)" );
 
 		$price_regexp_frags = [
@@ -279,11 +285,17 @@ trait Post_Tickets {
 			return;
 		}
 
+		$tc_relation_meta_key = TEC_Ticket::$event_relation_meta_key;
+
 		// Join to the meta that relates tickets to events.
 		$repo->join_clause( "LEFT JOIN {$wpdb->postmeta} {$prefix}_ticket_event
 			ON (
 				{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
-				AND {$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
+				AND (
+					{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
+					OR
+					{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
+				)
 			)" );
 		// Keep any event without tickets or not related to an RSVP ticket.
 		$repo->where_clause( "{$prefix}_ticket_event.meta_id IS NULL
@@ -307,14 +319,15 @@ trait Post_Tickets {
 
 		global $wpdb;
 		$prefix = 'has_rsvp_or_tickets_';
-		$tc_relation_meta_key = \TEC\Tickets\Commerce\Ticket::$event_relation_meta_key;
 
 		if ( (bool) $has_rsvp_or_tickets ) {
+			$tc_relation_meta_key = TEC_Ticket::$event_relation_meta_key;
+
 			// Join to the meta that relates tickets to events but exclude RSVP tickets.
 			$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event ON (
 					{$prefix}_ticket_event.meta_value = {$wpdb->posts}.ID
 					AND (
-						{$prefix}_ticket_event.meta_key REGEXP '^_tribe.*_for_event$'
+						{$prefix}_ticket_event.meta_key REGEXP '^_tribe_.*_for_event$'
 						OR
 						{$prefix}_ticket_event.meta_key REGEXP '^{$tc_relation_meta_key}$'
 					)


### PR DESCRIPTION
### 🎫 Ticket

[ET-1567] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Fixes the query issue where making a query for `ticketed` events were not showing Events with TicketsComommerce tickets.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://d.pr/v/aQmAkg
### ✔️ Checklist
- [x] ~I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->~ ( Not required )
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1567]: https://theeventscalendar.atlassian.net/browse/ET-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ