### PR TITLE
[ETP-811] allow the count to update even if not public

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/checkout@v2
         if: steps.skip.outputs.value != 1
         with:
-          repository: the-events-calendar/tric
-          ref: main
+          repository: stellarwp/slic
+          ref: 0.5.35
           path: tric
           fetch-depth: 1
       # ------------------------------------------------------------------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 == Changelog ==
 
 = [TBD]
-* Fix - Fixes the issues where while using `tribe_tickets_attendees` shortcode, 0 attendees always shows up.
+* Fix - Fixes the issues where while using `tribe_tickets_attendees` shortcode, 0 attendees always shows up. [ETP-811]
 
 = [5.4.4] TBD =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,11 @@
 == Changelog ==
 
-= [5.5.4] 2022-11-09 =
+= [TBD] TBD =
 
 * Fix - Fixes the issues where while using `tribe_tickets_attendees` shortcode, 0 attendees always shows up. [ETP-811]
+
+= [5.5.4] 2022-11-09 =
+
 * Fix - Fixes multiple of the same ticket form being on the same page being out of sync. [GTRIA-729]
 * Fix - Added a JS event that checks for attendee label validation if ET+ is active. [ETP-803]
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= [TBD]
+* Fix - Fixes the issues where while using `tribe_tickets_attendees` shortcode, 0 attendees always shows up.
+
 = [5.4.4] TBD =
 
 * Fix - Tickets/RSVP blocks appear in wrong place on non-events when block editor is disabled in The Events Calendar. [ET-1544]

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Fixes the issues where while using `tribe_tickets_attendees` shortcode, 0 attendees always shows up. [ETP-811]
 
 = [5.5.4] 2022-11-09 =
 

--- a/src/Tribe/Events/Attendees_List.php
+++ b/src/Tribe/Events/Attendees_List.php
@@ -197,7 +197,6 @@ class Attendees_List {
 		if ( ! $post instanceof WP_Post ) {
 			return [];
 		}
-
 		$args = [
 			'by' => [
 				// Exclude people who have opted out or not specified optout.
@@ -206,8 +205,6 @@ class Attendees_List {
 				'post_status' => 'publish',
 				// Only include RSVP status yes.
 				'rsvp_status__or_none' => 'yes',
-				// Only include public order statuses.
-				'order_status' => 'public',
 			],
 		];
 

--- a/src/views/blocks/attendees.php
+++ b/src/views/blocks/attendees.php
@@ -15,9 +15,11 @@
  * @version 4.11.3
  */
 
-$title     = $this->attr( 'title' );
-$attendees = $this->get( 'attendees', null );
-$classes   = [ 'tribe-block', 'tribe-block__attendees' ];
+$title           = $this->attr( 'title' );
+$classes         = [ 'tribe-block', 'tribe-block__attendees' ];
+$attendees_list  = tribe( 'tickets.events.attendees-list' );
+$attendees       = $attendees_list->get_attendees_for_post( $post_id );
+$attendees_total = $attendees_list->get_attendance_counts( $post_id );
 
 if ( ! is_array( $attendees ) ) {
 	return;
@@ -27,7 +29,7 @@ if ( ! is_array( $attendees ) ) {
 
 	<?php $this->template( 'blocks/attendees/title', [ 'title' => $title ] ); ?>
 
-	<?php $this->template( 'blocks/attendees/description', [ 'attendees' => $attendees ] ); ?>
+	<?php $this->template( 'blocks/attendees/description', [ 'attendees_total' => $attendees_total ] ); ?>
 
 	<?php foreach ( $attendees as $key => $attendee ) : ?>
 

--- a/src/views/blocks/attendees.php
+++ b/src/views/blocks/attendees.php
@@ -17,6 +17,8 @@
 
 $title           = $this->attr( 'title' );
 $classes         = [ 'tribe-block', 'tribe-block__attendees' ];
+
+/** @var \Tribe\Tickets\Events\Attendees_List $attendees_list */
 $attendees_list  = tribe( 'tickets.events.attendees-list' );
 $attendees       = $attendees_list->get_attendees_for_post( $post_id );
 $attendees_total = $attendees_list->get_attendance_counts( $post_id );


### PR DESCRIPTION
### 🎫 Ticket

[[ETP-811](https://theeventscalendar.atlassian.net/browse/ETP-811)] 

### 🗒️ Description

Fixes the issues where while using `tribe_tickets_attendees` shortcode, 0 attendees always shows up.
Did so by matching how the Block version was handling the variables, then matched the template variable being passed because it wasn't matching.

I also removed the public call to the Attendee List query as it only removes all the avatars from showing. The user being able to hide their avatar when purchasing a ticket still functions properly. 

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/bb1b0c481ea5411bb98a91c973cefc86

### ✔️ Checklist
- [✔️] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [✔️] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [✔️] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-811]: https://theeventscalendar.atlassian.net/browse/ETP-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ