### PR TITLE
[ET-1580] Add `attendance` information to the `events` REST API endpoint.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Enhancement - Add `attendance` information to the `events` REST API endpoint. [ET-1580]
+
 = [5.4.4] 2022-08-15 =
 
 * Fix - Tickets/RSVP blocks appear in wrong place on non-events when block editor is disabled in The Events Calendar. [ET-1544]

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -13,7 +13,7 @@ class Tribe__Tickets__REST__V1__Main extends Tribe__REST__Main {
 	/**
 	 * Event Tickets REST API URL prefix.
 	 *
-	 * This prefx is appended to the Modern Tribe REST API URL ones.
+	 * This prefix is appended to the `The Events Calendar` REST API URL ones.
 	 *
 	 * @var string
 	 */
@@ -41,7 +41,74 @@ class Tribe__Tickets__REST__V1__Main extends Tribe__REST__Main {
 		}
 
 		// Add support for `ticketed` param on tribe_events filter on REST API.
-		add_filter( 'tribe_events_archive_get_args', [ $this , 'parse_events_rest_args' ], 10, 3 );
+		add_filter( 'tribe_events_archive_get_args', [ $this, 'parse_events_rest_args' ], 10, 3 );
+
+		add_filter( 'tribe_rest_event_data', [ $this, 'rest_event_data_add_attendance' ], 10, 2 );
+		add_filter( 'tribe_rest_events_archive_data', [ $this, 'rest_events_archive_add_attendance' ], 10, 2 );
+	}
+
+	/**
+	 * Filters the data that will be returned for the events endpoint, adding attendance.
+	 *
+	 * @since TBD
+	 *
+	 * @param array           $data    The retrieved data.
+	 * @param WP_REST_Request $request The original request.
+	 *
+	 * @return array          $data    The retrieved data, updated with attendance if the request has access.
+	 */
+	public function rest_events_archive_add_attendance( $data, $request ) : array {
+
+		if ( ! $this->request_has_manage_access() ) {
+			return $data;
+		}
+
+		if ( empty( $data['events'] ) ) {
+			return $data;
+		}
+
+		foreach ( $data['events'] as $event ) {
+			$attendee_count = Tribe__Tickets__Tickets::get_event_attendees_count( $event->id );
+			$checked_in     = Tribe__Tickets__Tickets::get_event_checkedin_attendees_count( $event->id );
+
+			$event['attendance'] = [
+				'total_attendees' => $attendee_count,
+				'checked_in'      => $checked_in,
+				'not_checked_in'  => $attendee_count - $checked_in,
+			];
+
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Filters the data that will be returned for a single event, adding attendance.
+	 *
+	 * @since TBD
+	 *
+	 * @param array   $data  The data that will be returned in the response.
+	 * @param WP_Post $event The requested event.
+	 *
+	 * @return array  $data  The retrieved data, updated with attendance if the request has access.
+	 */
+	public function rest_event_data_add_attendance( $data, $event ) : array {
+
+		if ( ! $this->request_has_manage_access() ) {
+			return $data;
+		}
+
+		$post_id        = $event->ID;
+		$attendee_count = Tribe__Tickets__Tickets::get_event_attendees_count( $post_id );
+		$checked_in     = Tribe__Tickets__Tickets::get_event_checkedin_attendees_count( $post_id );
+
+		$data['attendance'] = [
+			'total_attendees' => $attendee_count,
+			'checked_in'      => $checked_in,
+			'not_checked_in'  => $attendee_count - $checked_in,
+		];
+
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[ET-1580] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Add `attendance` information to the events REST API endpoint.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1640" alt="Screenshot 2022-09-06 at 13 15 02" src="https://user-images.githubusercontent.com/252415/188622655-9745ed6f-152f-4570-85a9-07d64ed4f848.png">


### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1580]: https://theeventscalendar.atlassian.net/browse/ET-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ