### PR TITLE
[ET-1581] Fix conflict with Custom Table query overriding ET queries for `tribe_events`

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -24,8 +24,6 @@ if( ! defined( 'TRIBE_TESTS_HOME_URL' ) ) {
 	define( 'TRIBE_TESTS_HOME_URL', 'http://wordpress.test/' );
 }
 
-define( 'TEC_CUSTOM_TABLES_V1_DISABLED', true );
-
 /**
  * Codeception will regenerate snapshots on `--debug`, while the `spatie/snapshot-assertions`
  * library will do the same on `--update-snapshots`.
@@ -36,3 +34,7 @@ define( 'TEC_CUSTOM_TABLES_V1_DISABLED', true );
 if ( in_array( '--debug', $_SERVER['argv'], true ) ) {
 	$_SERVER['argv'][] = '--update-snapshots';
 }
+
+// By default, do not enable the Custom Tables v1 implementation in tests.
+putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=1' );
+$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 1;

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -24,6 +24,8 @@ if( ! defined( 'TRIBE_TESTS_HOME_URL' ) ) {
 	define( 'TRIBE_TESTS_HOME_URL', 'http://wordpress.test/' );
 }
 
+define( 'TEC_CUSTOM_TABLES_V1_DISABLED', true );
+
 /**
  * Codeception will regenerate snapshots on `--debug`, while the `spatie/snapshot-assertions`
  * library will do the same on `--update-snapshots`.

--- a/tests/wpunit/Tribe/Tickets/Event_RepositoryTest.php
+++ b/tests/wpunit/Tribe/Tickets/Event_RepositoryTest.php
@@ -31,7 +31,7 @@ class Event_RepositoryTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * It should allow filtering events by ticket cost
+	 * It should allow filtering events by ticket cost.
 	 *
 	 * @test
 	 */


### PR DESCRIPTION
### 🎫 Ticket

[ET-1581] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* The newly introduced Custom Tables query needed to be disabled for the test suites, otherwise it overrides the SQL queries for `tribe_events` causing the results to fail.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] ~I've included a changelog entry in the readme.txt file.~ ( Not Required )
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1581]: https://theeventscalendar.atlassian.net/browse/ET-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ