### PR TITLE
invert order of implode() for PHP8 compat

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Payment_Intent_Handler.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Payment_Intent_Handler.php
@@ -240,7 +240,7 @@ class Payment_Intent_Handler {
 		$metadata[ 'purchaser_email' ] = $order->purchaser_email;
 		$metadata[ 'event_name' ]      = get_post( current( $events_in_order ) )->post_title;
 		$metadata[ 'event_url' ]       = get_post_permalink( current( $events_in_order ) );
-		$metadata[ 'ticket_names' ]    =  implode( $ticket_names, ' ,' );
+		$metadata[ 'ticket_names' ]    =  implode( ',', $ticket_names );
 
 		/**
 		 * Filter the updated metadata for a completed order's payment intent.


### PR DESCRIPTION
### 🎫 Ticket

https://www.php.net/manual/en/function.implode.php

[TICKET_ID] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
