### PR TITLE
Fix nullable param in function signature.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [5.5.1] TBD =
+
+* Fix - Correct parameter type hinting when param can be null. [ET-1582]
+
 = [5.5.0] 2022-09-06 =
 
 * Version - Event Tickets 5.5.0 is only compatible with The Events Calendar 6.0.0 and higher.

--- a/src/Tickets/Custom_Tables/V1/Provider.php
+++ b/src/Tickets/Custom_Tables/V1/Provider.php
@@ -42,7 +42,7 @@ class Provider extends tad_DI52_ServiceProvider {
 			define( 'TEC_ET_CUSTOM_TABLES_V1_ROOT', __DIR__ );
 		}
 
-		$this->lock_for_maintence();
+		$this->lock_for_maintenance();
 
 		add_filter( 'admin_body_class', [ $this, 'prevent_tickets_on_recurring_events' ] );
 		add_filter( 'body_class', [ $this, 'prevent_tickets_on_recurring_events_front_end' ] );
@@ -58,7 +58,7 @@ class Provider extends tad_DI52_ServiceProvider {
 	 *
 	 * @since 5.5.0
 	 */
-	private function lock_for_maintence(): void {
+	private function lock_for_maintenance(): void {
 		$state = $this->container->make( State::class );
 
 		if ( $state->should_lock_for_maintenance() ) {
@@ -67,7 +67,7 @@ class Provider extends tad_DI52_ServiceProvider {
 	}
 
 	/**
-	 * Filter the body clases in admin context to prevent tickets from being added to
+	 * Filter the body classes in admin context to prevent tickets from being added to
 	 * recurring Events or ticketed Events from being made recurring.
 	 *
 	 * @since 5.5.0
@@ -77,7 +77,7 @@ class Provider extends tad_DI52_ServiceProvider {
 	 * @return string A space-separated list of classes, updated to include the
 	 *                `tec-no-tickets-on-recurring` class.
 	 */
-	public function prevent_tickets_on_recurring_events( string $admin_body_classes ): string {
+	public function prevent_tickets_on_recurring_events( ?string $admin_body_classes ): string {
 		$state = $this->container->make( State::class );
 
 		if ( ! $state->is_migrated() ) {


### PR DESCRIPTION
### 🎫 Ticket

[ET-1582]

### 🗒️ Description

in PHP8, type-hinted params will fail when passed null unless you specifically make them nullable.

Also corrected a couple typos in a docblock and a (private) function name.


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1582]: https://theeventscalendar.atlassian.net/browse/ET-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ