### PR TITLE
[ET-1588] Enhancement - Check IN or Check out attendee using attendee REST API endpoints.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,6 +194,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - TicketsCommerce ticketed events not showing up for Events REST API. [ET-1567]
 * Enhancement - Add template tag to properly check if The Events Calendar is active. [ETP-820]
 * Enhancement - Add `attendance` information to the `events` REST API endpoint. [ET-1580]
+* Enhancement - Add `check_in` argument support for `attendees` REST API endpoint. [ET-1588]
 
 = [5.5.0] 2022-09-06 =
 

--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -762,6 +762,10 @@ class Module extends \Tribe__Tickets__Tickets {
 				$attendee->set( 'email', $attendee_data['email'] );
 			}
 
+			if ( isset( $attendee_data['check_in'] ) ) {
+				$attendee->set( 'checked_in', $attendee_data['check_in'] );
+			}
+
 			$attendee->save();
 
 			// Send attendee email.

--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -131,6 +131,7 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 				'price_currency' => '_tribe_tickets_price_currency_symbol',
 				'full_name'      => '_tribe_tickets_full_name',
 				'email'          => '_tribe_tickets_email',
+				'check_in'       => current( $this->checked_in_keys() ),
 			]
 		);
 
@@ -901,6 +902,7 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 			'attendee_status'   => null,
 			'price_paid'        => null,
 			'optout'            => null,
+			'check_in'          => null,
 		];
 
 		$args = array_merge( $args, $attendee_data );
@@ -969,6 +971,11 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 			if ( isset( $args['optout'] ) ) {
 				// Enforce a 0/1 value for the optout value.
 				$args['optout'] = (int) tribe_is_truthy( $args['optout'] );
+			}
+
+			if ( isset( $args['check_in'] ) ) {
+				// Enforce a 0/1 value for the check_in value.
+				$args['check_in'] = (int) tribe_is_truthy( $args['check_in'] );
 			}
 		}
 

--- a/src/Tribe/REST/V1/Endpoints/Single_Attendee.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Attendee.php
@@ -155,6 +155,11 @@ class Tribe__Tickets__REST__V1__Endpoints__Single_Attendee
 				'type'              => 'string',
 				'description'       => __( 'Order Status for the attendee.', 'event-tickets' ),
 			],
+			'check_in'              => [
+				'required'          => false,
+				'type'              => 'bool',
+				'description'       => __( 'Check in value for the attendee.', 'event-tickets' ),
+			],
 
 		];
 
@@ -215,6 +220,11 @@ class Tribe__Tickets__REST__V1__Endpoints__Single_Attendee
 				'in'                => 'path',
 				'description'       => __( 'The attendee post ID', 'event-tickets' ),
 				'required'          => true,
+			],
+			'check_in'              => [
+				'required'          => false,
+				'type'              => 'bool',
+				'description'       => __( 'Check in value for the attendee.', 'event-tickets' ),
 			],
 		];
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1588] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Added support for `check_in` data update within Attendees ORM.
* Added support for `check_in` data update within TicketsCommerce ( `tec_tc_attendees` ) ORM.
* Added Create and Update Test for newly added argument for RSVP ORM.
* Added REST API documentation for the `check_in` param.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://d.pr/v/v2KGiK

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1588]: https://theeventscalendar.atlassian.net/browse/ET-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ