### PR TITLE
[ET-1591] Spotfix - Attendee REST API support for orderby `title` should search by full_name data

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,8 +190,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Orderby param not working for Attendee archive REST API. [ET-1591]
 * Fix - Properly save the check-in details for attendees on check-in. [ETP-819]
 * Fix - TicketsCommerce ticketed events not showing up for Events REST API. [ET-1567]
+* Enhancement - Added support for `name` and `email` param for searching in Attendee archive REST API. [ET-1591]
 * Enhancement - Add template tag to properly check if The Events Calendar is active. [ETP-820]
 * Enhancement - Add `attendance` information to the `events` REST API endpoint. [ET-1580]
 * Enhancement - Add `check_in` argument support for `attendees` REST API endpoint. [ET-1588]

--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -1361,6 +1361,9 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 			$override = $loop === 0;
 
 			switch ( $order_by ) {
+				case 'full_name':
+					$this->order_by_full_name( $order, $after, $override );
+					break;
 				case 'security_code':
 					$this->order_by_security_code( $order, $after, $override );
 					break;
@@ -1401,6 +1404,46 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 					}
 			}
 		}
+	}
+
+	/**
+	 * Sets up the query filters to order attendees by the full name meta.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $order      The order direction, either `ASC` or `DESC`; defaults to `null` to use the order
+	 *                           specified in the current query or default arguments.
+	 * @param bool   $after      Whether to append the duration ORDER BY clause to the existing clauses or not;
+	 *                           defaults to `false` to prepend the duration clause to the existing ORDER BY
+	 *                           clauses.
+	 * @param bool   $override   Whether to override existing ORDER BY clauses with this one or not; default to
+	 *                           `true` to override existing ORDER BY clauses.
+	 */
+	protected function order_by_full_name( $order = null, $after = false, $override = true ) {
+		global $wpdb;
+
+		$meta_alias     = 'full_name';
+		$meta_keys_in   = $this->prepare_interval( $this->holder_name_keys() );
+		$postmeta_table = "orderby_{$meta_alias}_meta";
+		$filter_id      = 'order_by_full_name';
+
+		$this->filter_query->join(
+			"
+			LEFT JOIN {$wpdb->postmeta} AS {$postmeta_table}
+				ON (
+					{$postmeta_table}.post_id = {$wpdb->posts}.ID
+					AND {$postmeta_table}.meta_key IN {$meta_keys_in}
+				)
+			"
+			,
+			$filter_id,
+			true
+		);
+
+		$order = $this->get_query_order_type( $order );
+
+		$this->filter_query->orderby( [ $meta_alias => $order ], $filter_id, true, $after );
+		$this->filter_query->fields( "{$postmeta_table}.meta_value AS {$meta_alias}", $filter_id, $override );
 	}
 
 	/**

--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -1434,8 +1434,7 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 					{$postmeta_table}.post_id = {$wpdb->posts}.ID
 					AND {$postmeta_table}.meta_key IN {$meta_keys_in}
 				)
-			"
-			,
+			",
 			$filter_id,
 			true
 		);

--- a/src/Tribe/REST/V1/Attendee_Repository.php
+++ b/src/Tribe/REST/V1/Attendee_Repository.php
@@ -86,7 +86,7 @@ class Tribe__Tickets__REST__V1__Attendee_Repository
 			'relevance' => 'relevance',
 			'id'        => 'id',
 			'include'   => 'meta_value_num',
-			'title'     => 'title',
+			'title'     => 'full_name',
 			'slug'      => 'name',
 		);
 

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -452,6 +452,16 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 				'required'    => false,
 				'type'        => 'boolean',
 			),
+			'name' => array(
+				'description' => __( 'Limit results to attendees by name. It will search for names that are like the specified value', 'event-tickets' ),
+				'required'    => false,
+				'type'        => 'string',
+			),
+			'email' => array(
+				'description' => __( 'Limit results to attendees by email. It will search for emails that are like the specified value', 'event-tickets' ),
+				'required'    => false,
+				'type'        => 'string',
+			),
 		);
 	}
 }

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -150,6 +150,8 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 			$query->offset( $request['offset'] );
 		}
 
+		$query = $this->process_search( $query_args, $query );
+
 		$query_args = array_intersect_key( $query_args, $this->READ_args() );
 		$found      = $query->found();
 
@@ -185,6 +187,32 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 		];
 
 		return new WP_REST_Response( $data, 200, $headers );
+	}
+
+	/**
+	 * Process the search terms for attendees.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $request_args Array of request args.
+	 * @param Tribe__Tickets__REST__V1__Attendee_Repository $query The query object.
+	 *
+	 * @return Tribe__Tickets__REST__V1__Attendee_Repository $query The query object.
+	 */
+	protected function process_search( array $request_args, Tribe__Tickets__REST__V1__Attendee_Repository $query ) {
+
+		$search_keys = [
+			'name'  => 'holder_name__like',
+			'email' => 'holder_email__like',
+		];
+
+		foreach ( $search_keys as $key => $search_term ) {
+			if ( isset( $request_args[ $key ] ) ) {
+				$query->by( $search_term, '%' . $request_args[ $key ] . '%' );
+			}
+		}
+
+		return $query;
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -208,7 +208,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 
 		foreach ( $search_keys as $key => $search_term ) {
 			if ( isset( $request_args[ $key ] ) ) {
-				$query->by( $search_term, '%' . $request_args[ $key ] . '%' );
+				$query->by( $search_term, '%' . sanitize_text_field( $request_args[ $key ] ) . '%' );
 			}
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1591] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* orderby -> title param used to search against `post_title` by default but that data is not uniform in all attendee post types.
* We have now pointed the `title` param to search against `full_name` meta which is available within all attendees.
* Added search by Name support where if `name` parameter is set then it should look against `holder_name` of the attendee.
* Added search by Email support where if `email` parameter is set then it should look against `holder_email` of the attendee.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s):
* Orderby --> https://recordit.co/G1g9mu3rTB
* Search --> https://recordit.co/rxQFXNnaDu
### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1591]: https://theeventscalendar.atlassian.net/browse/ET-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ