### PR TITLE
[ETP-815] Fixed shared cap sync causing tickets to use lower capacity all the time.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Fixed shared capacity tickets only showing the lowest capacity between the shared pool tickets. [ETP-815]
 
 = [5.5.4] 2022-11-09 =
 

--- a/src/Tribe/REST/V1/Endpoints/Ticket_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Ticket_Archive.php
@@ -196,7 +196,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Ticket_Archive
 
 		if ( 0 === $found && 1 === $page ) {
 			$tickets = array();
-		} elseif ( 1 !== $page && $per_page > $total_pages ) {
+		} elseif ( 1 !== $page && $page > $total_pages ) {
 			return new WP_Error( 'invalid-page-number', $this->messages->get_message( 'invalid-page-number' ), array( 'status' => 400 ) );
 		} else {
 			$tickets = $query

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -657,7 +657,7 @@ class Tribe__Tickets__Tickets_Handler {
 	 */
 	public function trigger_shared_cap_sync( $post_id, $ticket, $raw_data ) {
 		$ticket_capacity_data = Tribe__Utils__Array::get( $raw_data, 'tribe-ticket', [] );
-		$ticket_capacity      = Tribe__Utils__Array::get( $ticket_capacity_data, 'capacity', false );
+		$ticket_capacity      = Tribe__Utils__Array::get( $ticket_capacity_data, 'event_capacity', false );
 		$capacity_mode        = Tribe__Utils__Array::get( $ticket_capacity_data, 'mode', false );
 
 		if ( Tribe__Tickets__Global_Stock::OWN_STOCK_MODE === $capacity_mode ) {

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/CapacityTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/CapacityTest.php
@@ -48,7 +48,15 @@ class CapacityTest extends \Codeception\TestCase\WPTestCase {
 		$cart = new Cart();
 		$cart->get_repository()->add_item( $ticket_a_id, 5 );
 
-		$order     = tribe( Order::class )->create_from_cart( tribe( Gateway::class ) );
+		$purchaser = [
+			'purchaser_user_id'    => 0,
+			'purchaser_full_name'  => 'Test Purchaser',
+			'purchaser_first_name' => 'Test',
+			'purchaser_last_name'  => 'Purchaser',
+			'purchaser_email'      => 'test@test.com',
+		];
+
+		$order     = tribe( Order::class )->create_from_cart( tribe( Gateway::class ), $purchaser );
 		$completed = tribe( Order::class )->modify_status( $order->ID, Pending::SLUG );
 
 		// refresh ticket.


### PR DESCRIPTION
### 🎫 Ticket

[ETP-815] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Shared capacity sync error was causing the lowest capacity to be applied among all the shared capacity tickets irrespective of the own capped capacities.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://d.pr/v/07xd6J

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-815]: https://theeventscalendar.atlassian.net/browse/ETP-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ