### PR TITLE
[ET-1615] - Removed the locale param for PayPal JS SDK to avoid invalid local errors.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,7 +194,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Fixed the order of tickets in an event changing when you haven't manually requested it. [ET-1568]
 * Fix - Fixed shared capacity tickets only showing the lowest capacity between the shared pool tickets. [ETP-815]
-* Tweak - Removed locale param for TicketsCommerce JS SDK as per PayPal recommendation. [ET-1615]
+* Tweak - Removed locale param for Tickets Commerce JS SDK as per PayPal recommendation. [ET-1615]
 
 = [5.5.4] 2022-11-09 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -194,6 +194,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Fixed the order of tickets in an event changing when you haven't manually requested it. [ET-1568]
 * Fix - Fixed shared capacity tickets only showing the lowest capacity between the shared pool tickets. [ETP-815]
+* Tweak - Removed locale param for TicketsCommerce JS SDK as per PayPal recommendation. [ET-1615]
 
 = [5.5.4] 2022-11-09 =
 

--- a/src/Tickets/Commerce/Gateways/PayPal/Client.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Client.php
@@ -90,7 +90,6 @@ class Client {
 			'merchant-id'     => $merchant->get_merchant_id_in_paypal(),
 			'components'      => 'hosted-fields,buttons',
 			'intent'          => 'capture',
-			'locale'          => $merchant->get_locale(),
 			'disable-funding' => 'credit',
 			'currency'        => tribe_get_option( \TEC\Tickets\Commerce\Settings::$option_currency_code, 'USD' ),
 		], $query_args );

--- a/src/Tickets/Commerce/Gateways/PayPal/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Merchant.php
@@ -912,6 +912,27 @@ class Merchant extends Abstract_Merchant {
 		 *
 		 * @param string $locale
 		 */
-		return apply_filters( 'tec_tickets_commerce_gateway_paypal_merchant_locale', $locale );
+		$locale = apply_filters( 'tec_tickets_commerce_gateway_paypal_merchant_locale', $locale );
+
+		return $this->validate_locale( $locale );
+	}
+
+	/**
+	 * Validates the locale to make sure it has a valid length.
+	 * If it's not, it will return the default locale.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $locale The Locale code.
+	 *
+	 * @return string
+	 */
+	public function validate_locale( string $locale ) : string {
+		// check if the length is valid.
+		if ( 5 !== strlen( $locale ) ) {
+			return 'en_US';
+		}
+
+		return $locale;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/PayPal/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Merchant.php
@@ -929,10 +929,19 @@ class Merchant extends Abstract_Merchant {
 	 */
 	public function validate_locale( string $locale ) : string {
 		// check if the length is valid.
-		if ( 5 !== strlen( $locale ) ) {
-			return 'en_US';
+		if ( 5 === strlen( $locale ) ) {
+			return $locale;
 		}
 
-		return $locale;
+		$fallback_locale = 'en_US';
+
+		/**
+		 * Allows filtering of the fallback locale value for the PayPal SDK if the existing is invalid.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $fallback_locale
+		 */
+		return apply_filters( 'tec_tickets_commerce_gateway_paypal_locale_fallback_default', $fallback_locale );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1615] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* As per PayPal recommendation we can remove the optional `locale` param to reduce JS SDK issues with this: https://d.pr/i/zRT5LX
* We have kept the `locale` method and added a new validation method in case anyone wants to use the `locale` param with  the `tec_tickets_commerce_gateway_paypal_js_sdk_url` filter.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1615]: https://theeventscalendar.atlassian.net/browse/ET-1615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ