### PR TITLE
[CT-67] Remove upsell outside of dashboard

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,7 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [5.5.8] TBD =
 
 * Fix - Fixed Ticket Commerce cart cookies not getting saved. [ET-1629]
-* Tweak - Updated ARF upsell notice to only display in admin dashboard. [CT-67]
+* Tweak - Updated Attendee Registration Fields upsell notice to only display in admin dashboard. [CT-67]
 
 = [5.5.6] 2023-01-16 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Updated ARF upsell notice to only display in admin dashboard. [CT-67]
+
 = [5.5.6] 2023-01-16 =
 
 * Tweak - Updated the settings description for stock handling options. [ET-1603]

--- a/src/Tickets/Admin/Upsell.php
+++ b/src/Tickets/Admin/Upsell.php
@@ -26,11 +26,12 @@ class Upsell {
 	/**
 	 * Maybe show upsell for Capacity and ARF features.
 	 *
+	 * @since TBD - Added is_admin() to make sure upsells only display within the admin area.
 	 * @since 5.3.4
 	 */
 	public function maybe_show_capacity_arf() {
-		// If they already have ET+ activated, then bail.
-		if ( class_exists( 'Tribe__Tickets_Plus__Main' ) ) {
+		// If they already have ET+ activated or are not within the admin area, then bail.
+		if ( class_exists( 'Tribe__Tickets_Plus__Main' ) || ! is_admin() ) {
 			return;
 		}
 
@@ -56,11 +57,12 @@ class Upsell {
 	/**
 	 * Maybe show upsell for Manual Attendees.
 	 *
+	 * @since TBD - Added is_admin() to make sure upsells only display within the admin area.
 	 * @since 5.3.4
 	 */
 	public function maybe_show_manual_attendees() {
-		// If they already have ET+ activated, then bail.
-		if ( class_exists( 'Tribe__Tickets_Plus__Main' ) ) {
+		// If they already have ET+ activated or are not within the admin area, then bail.
+		if ( class_exists( 'Tribe__Tickets_Plus__Main' ) || ! is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[CT-67] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
This change introduces the `is_admin()` method into `maybe_show_capacity_arf` and `maybe_show_manual_attendees`. Before this change the upsell was showing on Community Tickets. 
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before Change -
![image](https://user-images.githubusercontent.com/12241059/212929137-74980189-0cee-4f54-978b-9d2e4b26297f.png)


### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[CT-67]: https://theeventscalendar.atlassian.net/browse/CT-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ