### PR TITLE
[ET-1629] Fix - Tickets Commerce cart cookie params missing `httponly` flag.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [5.5.8] TBD =
+
+* Fix - Fixed Ticket Commerce cart cookies not getting saved. [ET-1629]
+
 = [5.5.6] 2023-01-16 =
 
 * Tweak - Updated the settings description for stock handling options. [ET-1603]

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -329,7 +329,7 @@ class Cart {
 			$expire = 1;
 		}
 
-		$is_cookie_set = setcookie( static::$cart_hash_cookie_name, $value, $expire, COOKIEPATH ?: '/', COOKIE_DOMAIN, $secure );
+		$is_cookie_set = setcookie( static::$cart_hash_cookie_name, $value, $expire, COOKIEPATH ?: '/', COOKIE_DOMAIN, $secure, true );
 
 		// Overwrite local variable so we can use it right away.
 		$_COOKIE[ static::$cart_hash_cookie_name ] = $value;

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -316,23 +316,18 @@ class Cart {
 		 * @param int $expires The expiry time, as passed to setcookie().
 		 */
 		$expire  = apply_filters( 'tec_tickets_commerce_cart_expiration', time() + 1 * HOUR_IN_SECONDS );
-		$referer = wp_get_referer();
-
-		if ( $referer ) {
-			$secure = ( 'https' === parse_url( $referer, PHP_URL_SCHEME ) );
-		} else {
-			$secure = false;
-		}
 
 		// When null means we are deleting.
 		if ( null === $value ) {
 			$expire = 1;
 		}
 
-		$is_cookie_set = setcookie( static::$cart_hash_cookie_name, $value, $expire, COOKIEPATH ?: '/', COOKIE_DOMAIN, $secure, true );
+		$is_cookie_set = setcookie( static::$cart_hash_cookie_name, $value, $expire, COOKIEPATH ?: '/', COOKIE_DOMAIN, is_ssl(), true );
 
-		// Overwrite local variable so we can use it right away.
-		$_COOKIE[ static::$cart_hash_cookie_name ] = $value;
+		if ( $is_cookie_set ) {
+			// Overwrite local variable, so we can use it right away.
+			$_COOKIE[ static::$cart_hash_cookie_name ] = $value;
+		}
 
 		return $is_cookie_set;
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1629] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* The `httponly` flag was not set to `true` while creating cookies, which causes issues in hosting environments where non `httponly` cookies are not saved resulting in an invalid cart.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
📷 screenshot(s):

Before: https://d.pr/i/MQQ1Xh

After: https://d.pr/i/CVCCGH

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1629]: https://theeventscalendar.atlassian.net/browse/ET-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ