### PR TITLE
[ET-1547] Return the content if is not requesting the email preview.

### DIFF
--- a/src/Tickets/Emails/Hooks.php
+++ b/src/Tickets/Emails/Hooks.php
@@ -156,6 +156,10 @@ class Hooks extends tad_DI52_ServiceProvider {
 	 * @return string $content The response for the preview modal content.
 	 */
 	public function filter_add_preview_modal_content( $render_response, $vars ) {
+		if ( 'tec_tickets_preview_email' !== $vars['request'] ) {
+			return $render_response;
+		}
+
 		return $this->container->make( Admin\Preview_modal::class )->get_modal_content_ajax( $render_response, $vars );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1547] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Returning early if the AJAX request is not for the email preview modal (if not it messes up with manual attendees)

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1547]: https://theeventscalendar.atlassian.net/browse/ET-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ