### PR TITLE
[ET-1547] Tickets Emails: Preview per email

### DIFF
--- a/src/Tickets/Emails/Admin/Preview_Modal.php
+++ b/src/Tickets/Emails/Admin/Preview_Modal.php
@@ -221,7 +221,6 @@ class Preview_Modal {
 			$email = tribe( \TEC\Tickets\Emails\Email_Handler::class )->get_email_by_id( $current_email );
 
 			if ( ! empty( $email ) ) {
-				// get_preview_data.
 				$email_class = tribe( $email::class );
 				$html        = $email_class->get_content( $email_class->get_preview_context() );
 			}

--- a/src/Tickets/Emails/Admin/Preview_Modal.php
+++ b/src/Tickets/Emails/Admin/Preview_Modal.php
@@ -191,10 +191,9 @@ class Preview_Modal {
 		/** @var Tribe__Tickets__Editor__Template $template */
 		$tickets_template = tribe( 'tickets.editor.template' );
 
-		$email_template = tribe( Email_Template::class );
-		$email_template->set_preview( true );
-
-		$context = [];
+		$context = [
+			'is_preview' => true,
+		];
 
 		$ticket_bg_color = Arr::get( $vars, 'ticketBgColor', '' );
 
@@ -214,7 +213,26 @@ class Preview_Modal {
 			$context['header_image_url'] = $header_img_url;
 		}
 
-		$html  = $email_template->get_html( $context );
+		$current_email = Arr::get( $vars, 'currentEmail', '' );
+
+		$html = '';
+
+		if ( ! empty( $current_email ) ) {
+			$email = tribe( \TEC\Tickets\Emails\Email_Handler::class )->get_email_by_id( $current_email );
+
+			if ( ! empty( $email ) ) {
+				// get_preview_data.
+				$email_class = tribe( $email::class );
+				$html        = $email_class->get_content( $email_class->get_preview_context() );
+			}
+
+		} else {
+			$email_template = tribe( Email_Template::class );
+			$email_template->set_preview( true );
+			$context = $email_template->get_preview_context( $context );
+			$html    = $email_template->get_html( 'ticket', $context );
+		}
+
 		$html .= $tickets_template->template( 'v2/components/loader/loader', [], false );
 
 		return $html;

--- a/src/Tickets/Emails/Email/Completed_Order.php
+++ b/src/Tickets/Emails/Email/Completed_Order.php
@@ -173,6 +173,24 @@ class Completed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get preview context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 * @return array $args The modified arguments
+	 */
+	public function get_preview_context( $args = [] ): array {
+		$defaults = [
+			'is_preview' => true,
+			'title'      => $this->get_heading(),
+			'heading'    => $this->get_heading(),
+		];
+
+		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since TBD
@@ -182,14 +200,20 @@ class Completed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	 * @return string The email content.
 	 */
 	public function get_content( $args = [] ): string {
-		// @todo: Parse args, etc.
-		$context = ! empty( $args['context'] ) ? $args['context'] : [];
-
 		// @todo: We need to grab the proper information that's going to be sent as context.
+		$is_preview = ! empty( $args['is_preview'] );
+
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		$args = wp_parse_args( $args, $defaults );
 
 		$email_template = tribe( Email_Template::class );
+		$email_template->set_preview( $is_preview );
 
-		// @todo @juanfra @codingmusician: we may want to inverse these parameters.
-		return $email_template->get_html( $context, $this->template );
+		return $email_template->get_html( $this->template, $args );
 	}
 }

--- a/src/Tickets/Emails/Email/Completed_Order.php
+++ b/src/Tickets/Emails/Email/Completed_Order.php
@@ -201,7 +201,7 @@ class Completed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: We need to grab the proper information that's going to be sent as context.
-		$is_preview = ! empty( $args['is_preview'] );
+		$is_preview = tribe_is_truthy( $args['is_preview'] );
 
 		$defaults = [
 			'title'              => $this->get_title(),

--- a/src/Tickets/Emails/Email/Failed_Order.php
+++ b/src/Tickets/Emails/Email/Failed_Order.php
@@ -173,6 +173,24 @@ class Failed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get preview context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 * @return array $args The modified arguments
+	 */
+	public function get_preview_context( $args = [] ): array {
+		$defaults = [
+			'is_preview' => true,
+			'title'      => $this->get_heading(),
+			'heading'    => $this->get_heading(),
+		];
+
+		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since TBD
@@ -182,14 +200,20 @@ class Failed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	 * @return string The email content.
 	 */
 	public function get_content( $args = [] ): string {
-		// @todo: Parse args, etc.
-		$context = ! empty( $args['context'] ) ? $args['context'] : [];
-
 		// @todo: We need to grab the proper information that's going to be sent as context.
+		$is_preview = ! empty( $args['is_preview'] );
+
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		$args = wp_parse_args( $args, $defaults );
 
 		$email_template = tribe( Email_Template::class );
+		$email_template->set_preview( $is_preview );
 
-		// @todo @juanfra @codingmusician: we may want to inverse these parameters.
-		return $email_template->get_html( $context, $this->template );
+		return $email_template->get_html( $this->template, $args );
 	}
 }

--- a/src/Tickets/Emails/Email/Failed_Order.php
+++ b/src/Tickets/Emails/Email/Failed_Order.php
@@ -201,7 +201,7 @@ class Failed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: We need to grab the proper information that's going to be sent as context.
-		$is_preview = ! empty( $args['is_preview'] );
+		$is_preview = tribe_is_truthy( $args['is_preview'] );
 
 		$defaults = [
 			'title'              => $this->get_title(),

--- a/src/Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Tickets/Emails/Email/Purchase_Receipt.php
@@ -95,7 +95,7 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	 * @return string
 	 */
 	public function get_default_heading(): string {
-		return esc_html__( 'Your purchase receipt for #{order-number}', 'event-tickets' );
+		return esc_html__( 'Your purchase receipt for #{order_number}', 'event-tickets' );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	 * @return string
 	 */
 	public function get_default_subject(): string {
-		return esc_html__( 'Your purchase receipt for #{order-number}', 'event-tickets' );
+		return esc_html__( 'Your purchase receipt for #{order_number}', 'event-tickets' );
 	}
 
 	/**
@@ -177,6 +177,24 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get preview context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 * @return array $args The modified arguments
+	 */
+	public function get_preview_context( $args = [] ): array {
+		$defaults = [
+			'is_preview' => true,
+			'title'      => $this->get_heading(),
+			'heading'    => $this->get_heading(),
+		];
+
+		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since TBD
@@ -186,14 +204,20 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	 * @return string The email content.
 	 */
 	public function get_content( $args = [] ): string {
-		// @todo: Parse args, etc.
-		$context = ! empty( $args['context'] ) ? $args['context'] : [];
-
 		// @todo: We need to grab the proper information that's going to be sent as context.
+		$is_preview = ! empty( $args['is_preview'] );
+
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		$args = wp_parse_args( $args, $defaults );
 
 		$email_template = tribe( Email_Template::class );
+		$email_template->set_preview( $is_preview );
 
-		// @todo @juanfra @codingmusician: we may want to inverse these parameters.
-		return $email_template->get_html( $context, $this->template );
+		return $email_template->get_html( $this->template, $args );
 	}
 }

--- a/src/Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Tickets/Emails/Email/Purchase_Receipt.php
@@ -205,7 +205,7 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: We need to grab the proper information that's going to be sent as context.
-		$is_preview = ! empty( $args['is_preview'] );
+		$is_preview = tribe_is_truthy( $args['is_preview'] );
 
 		$defaults = [
 			'title'              => $this->get_title(),

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -341,7 +341,7 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: Parse args, etc.
-		$is_preview = ! empty( $args['is_preview'] );
+		$is_preview = tribe_is_truthy( $args['is_preview'] );
 
 		// @todo @juanfra @codingmusician: we need to see if we initialize tickets.
 		$defaults = [

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -109,9 +109,9 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 
 	/**
 	 * Get heading for plural tickets.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_heading_plural(): string {
@@ -180,9 +180,9 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 
 	/**
 	 * Get subject for plural rsvps.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_subject_plural(): string {
@@ -317,6 +317,20 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get preview context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 * @return array $args The modified arguments
+	 */
+	public function get_preview_context( $args = [] ): array {
+		$defaults = tribe( Email_Template::class )->get_preview_context( $args );
+
+		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since TBD
@@ -327,13 +341,21 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: Parse args, etc.
-		$context = ! empty( $args['context'] ) ? $args['context'] : [];
+		$is_preview = ! empty( $args['is_preview'] );
 
-		// @todo: We need to grab the proper information that's going to be sent as context.
+		// @todo @juanfra @codingmusician: we need to see if we initialize tickets.
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : [],
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		$args = wp_parse_args( $args, $defaults );
 
 		$email_template = tribe( Email_Template::class );
+		$email_template->set_preview( $is_preview );
 
-		// @todo @juanfra @codingmusician: we may want to inverse these parameters.
-		return $email_template->get_html( $context, $this->template );
+		return $email_template->get_html( $this->template, $args );
 	}
 }

--- a/src/Tickets/Emails/Email/Ticket.php
+++ b/src/Tickets/Emails/Email/Ticket.php
@@ -324,7 +324,7 @@ class Ticket extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: Parse args, etc.
-		$is_preview = ! empty( $args['is_preview'] );
+		$is_preview = tribe_is_truthy( $args['is_preview'] );
 
 		// @todo @juanfra @codingmusician: we need to see if we initialize tickets from a method.
 		$defaults = [

--- a/src/Tickets/Emails/Email/Ticket.php
+++ b/src/Tickets/Emails/Email/Ticket.php
@@ -300,6 +300,20 @@ class Ticket extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get preview context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 * @return array $args The modified arguments
+	 */
+	public function get_preview_context( $args = [] ): array {
+		$defaults = tribe( Email_Template::class )->get_preview_context( $args );
+
+		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since TBD
@@ -310,21 +324,21 @@ class Ticket extends \TEC\Tickets\Emails\Email_Abstract {
 	 */
 	public function get_content( $args = [] ): string {
 		// @todo: Parse args, etc.
-		$context = ! empty( $args['context'] ) ? $args['context'] : [];
+		$is_preview = ! empty( $args['is_preview'] );
 
-		// @todo @juanfra @codingmusician: we need to see if we can initialize this as part of the class.
-		$context = [
+		// @todo @juanfra @codingmusician: we need to see if we initialize tickets from a method.
+		$defaults = [
 			'title'              => $this->get_title(),
 			'heading'            => $this->get_heading(),
 			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : [],
 			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
 		];
 
-		// @todo: We need to grab the proper information that's going to be sent as context.
+		$args = wp_parse_args( $args, $defaults );
 
 		$email_template = tribe( Email_Template::class );
+		$email_template->set_preview( $is_preview );
 
-		// @todo @juanfra @codingmusician: we may want to inverse these parameters.
-		return $email_template->get_html( $context, $this->template );
+		return $email_template->get_html( $this->template, $args );
 	}
 }

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -420,6 +420,8 @@ abstract class Email_Abstract {
 	 *
 	 * @since TBD
 	 *
+	 * @param string $option The option name.
+	 *
 	 * @return string
 	 */
 	public function get_option_key( $option ): string {
@@ -447,7 +449,7 @@ abstract class Email_Abstract {
 	 */
 	public function get_recipient(): string {
 		$option_key = $this->get_option_key( 'recipient' );
-		$recipient = tribe_get_option( $option_key, $this->get_default_recipient() );
+		$recipient  = tribe_get_option( $option_key, $this->get_default_recipient() );
 
 		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
 
@@ -485,7 +487,7 @@ abstract class Email_Abstract {
 	 */
 	public function get_subject(): string {
 		$option_key = $this->get_option_key( 'subject' );
-		$subject = tribe_get_option( $option_key, $this->get_default_subject() );
+		$subject    = tribe_get_option( $option_key, $this->get_default_subject() );
 
 		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
 
@@ -523,7 +525,7 @@ abstract class Email_Abstract {
 	 */
 	public function get_heading(): string {
 		$option_key = $this->get_option_key( 'heading' );
-		$heading = tribe_get_option( $option_key, $this->get_default_heading() );
+		$heading    = tribe_get_option( $option_key, $this->get_default_heading() );
 
 		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
 
@@ -561,7 +563,7 @@ abstract class Email_Abstract {
 	 */
 	public function get_additional_content(): string {
 		$option_key = $this->get_option_key( 'add-content' );
-		$content = tribe_get_option( $option_key, $this->get_default_additional_content() );
+		$content    = tribe_get_option( $option_key, $this->get_default_additional_content() );
 
 		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
 

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -122,7 +122,7 @@ abstract class Email_Abstract {
 
 	/**
 	 * Get default recipient.
-	 * 
+	 *
 	 * @since TBD
 	 *
 	 * @return string
@@ -157,6 +157,17 @@ abstract class Email_Abstract {
 	abstract public function get_settings_fields(): array;
 
 	/**
+	 * Get preview context.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 *
+	 * @return string The email preview context.
+	 */
+	abstract public function get_preview_context( $args ): array;
+
+	/**
 	 * Get email content.
 	 *
 	 * @since TBD
@@ -169,9 +180,9 @@ abstract class Email_Abstract {
 
 	/**
 	 * Is customer email.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return string
 	 */
 	public function is_customer_email(): bool {
@@ -395,9 +406,9 @@ abstract class Email_Abstract {
 
 	/**
 	 * Get ID.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_id(): string {
@@ -406,9 +417,9 @@ abstract class Email_Abstract {
 
 	/**
 	 * Get setting option key.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_option_key( $option ): string {
@@ -467,9 +478,9 @@ abstract class Email_Abstract {
 
 	/**
 	 * Get the subject of the email.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_subject(): string {

--- a/src/Tickets/Emails/Email_Template.php
+++ b/src/Tickets/Emails/Email_Template.php
@@ -72,9 +72,10 @@ class Email_Template {
 	 *
 	 * @return string The HTML of the template.
 	 */
-	public function get_html( $context = [], $email = 'template' ) {
+	public function get_html( $email = 'template', $context = [] ) {
 		$template = $this->get_template();
-		$context  = wp_parse_args( $context, $this->get_context( $email ) );
+		$defaults = $this->get_context( $email );
+		$context  = wp_parse_args( $context, $defaults );
 
 		return $template->template( $email, $context, false );
 	}
@@ -150,9 +151,6 @@ class Email_Template {
 		$context['header_text_color'] = Tribe__Utils__Color::get_contrast_color( $context['header_bg_color'] );
 		$context['ticket_text_color'] = Tribe__Utils__Color::get_contrast_color( $context['ticket_bg_color'] );
 
-		if ( $this->preview ) {
-			$this->context_data = $this->get_preview_context_array();
-		}
 
 		$this->context_data = wp_parse_args( $this->context_data, $context );
 
@@ -169,11 +167,11 @@ class Email_Template {
 	/**
 	 * Get the context data in the case of a template preview.
 	 *
-	 * @since 5.5.7
+	 * @since TBD
 	 *
 	 * @return array Context data.
 	 */
-	private function get_preview_context_array() {
+	public function get_preview_context( $args = [] ): array {
 		$current_user = wp_get_current_user();
 		$title        = empty( $current_user->first_name ) ?
 		__( 'Here\'s your ticket!', 'event-tickets' ) :
@@ -184,8 +182,10 @@ class Email_Template {
 		);
 
 		return [
-			'title'   => $title,
-			'tickets' => [
+			'title'      => $title,
+			'heading'    => $title,
+			'is_preview' => true,
+			'tickets'    => [
 				[
 					'ticket_id'         => '1234',
 					'ticket_name'       => esc_html__( 'General Admission', 'event-tickets' ),

--- a/src/resources/js/admin/tickets-emails.js
+++ b/src/resources/js/admin/tickets-emails.js
@@ -38,7 +38,7 @@ tribe.tickets.emails = {};
 		modalContent: '.tribe-modal__content',
 		form: '.tribe-tickets__manual-attendees-form',
 		hiddenElement: '.tribe-common-a11y-hidden',
-		validationNotice: '.tribe-tickets__notice--error',
+		formCurrentEmail: 'tec_tickets_emails_current_section',
 		formHeaderImageUrl: 'tec-tickets-emails-header-image-url',
 		formTicketBgColorName: 'tec-tickets-emails-ticket-bg-color',
 		formHeaderBgColorName: 'tec-tickets-emails-header-bg-color',
@@ -155,6 +155,11 @@ tribe.tickets.emails = {};
 			.find( 'input[name=' + obj.selectors.formHeaderImageUrl + ']' ).val();
 
 		context.headerImageUrl = headerImageUrl;
+
+		const currentEmail = $document
+			.find( 'input[name=' + obj.selectors.formCurrentEmail + ']' ).val();
+
+		context.currentEmail = currentEmail;
 
 		return context;
 	};


### PR DESCRIPTION
### 🎫 Ticket

[ET-1547] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Adding logic to have preview per email, rather than relying on just one email all the time.
- Inverting `get_html` parameters of the email template class, to make it consistent with the generic template class.
- Adding an abstract method to have preview data per email.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://user-images.githubusercontent.com/252415/225935583-2886c8c8-f654-40fe-a634-e3dd6eef7d32.mov


### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1547]: https://theeventscalendar.atlassian.net/browse/ET-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ