### PR TITLE
[ET-1674] Fix - Tickets/RSVP blocks crashing when hovering over their tooltips.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Enhancement - Add the Attendee count for the site to the `At a Glance` admin widget. [ET-1654]
+* Fix - Fixed Tickets/RSVP blocks crashing when hovering over their tooltips. [ET-1674]
 
 = [5.5.9.1] 2023-03-13 =
 

--- a/src/modules/elements/label-with-tooltip/__tests__/__snapshots__/element.test.js.snap
+++ b/src/modules/elements/label-with-tooltip/__tests__/__snapshots__/element.test.js.snap
@@ -19,9 +19,7 @@ exports[`Tooltip Element renders a tooltip 1`] = `
     <span>
       <button
         aria-label="here is the tooltip text"
-        className="tribe-editor__button tribe-editor__tooltip-label tribe-editor__label-with-tooltip__tooltip-label"
-        onClick={[Function]}
-        type="button"
+        className="tribe-editor__tooltip-label tribe-editor__label-with-tooltip__tooltip-label"
       >
         tooltip label
       </button>

--- a/src/modules/elements/label-with-tooltip/element.js
+++ b/src/modules/elements/label-with-tooltip/element.js
@@ -8,7 +8,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { LabeledItem, Tooltip } from '@moderntribe/common/elements';
+import { LabeledItem } from '@moderntribe/common/elements';
+import { Tooltip } from '@wordpress/components';
 import './style.pcss';
 
 const LabelWithTooltip = ( {
@@ -27,13 +28,15 @@ const LabelWithTooltip = ( {
 		isLabel={ isLabel }
 		label={ label }
 	>
-		<Tooltip
-			disabled={ tooltipDisabled }
-			label={ tooltipLabel }
-			labelClassName="tribe-editor__label-with-tooltip__tooltip-label"
-			position={ tooltipPosition }
-			text={ tooltipText }
-		/>
+		<Tooltip text={ tooltipText } position={ tooltipPosition }>
+			<button
+				aria-label={ tooltipText }
+				className={ classNames( 'tribe-editor__tooltip-label', "tribe-editor__label-with-tooltip__tooltip-label" ) }
+				disabled={ tooltipDisabled }
+			>
+				{ tooltipLabel }
+			</button>
+		</Tooltip>
 	</LabeledItem>
 );
 


### PR DESCRIPTION
### 🎫 Ticket

[1674](https://theeventscalendar.atlassian.net/browse/ET-1674)

### 🗒️ Description

When you try to hover over the tooltip component in either of the RSVP or Tickets blocks, it crashes! I have simply refactored the Tooltip component directly into the LabelWithToolTip component to fix this.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot1](https://drive.google.com/file/d/1jYD72N_ui0G1tTM2QBl4SM-UFKGT6DY8/view?usp=share_link)
[Screenshot2](https://drive.google.com/file/d/1arlDrHYQmYPSmoWbbH_eMPC6cwRWIRJI/view?usp=share_link)
[Screenshot3](https://drive.google.com/file/d/15Ni8nqy4f48c1vP8VTi_8ufu1VygAXKD/view?usp=share_link)
[Screencast](https://drive.google.com/file/d/114q7pAfa0h4LdEWDlNtO27ourP3v-IFF/view?usp=share_link)

### ✔️ Checklist
- [X] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).