### PR TITLE
[ET-1590] Enhancement - Add `post_title` data for created attendees using Tickets Commerce.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Enhancement - Add the Attendee count for the site to the `At a Glance` admin widget. [ET-1654]
+* Enhancement - Add `post_title` data for attendees created using Tickets Commerce. [ET-1590]
 * Fix - When using Tickets Commerce the SKU will properly appear when creating a ticket using Community Tickets. [CT-64]
 * Fix - Fixed Tickets/RSVP blocks crashing when hovering over their tooltips. [ET-1674]
 

--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -365,6 +365,7 @@ class Attendee {
 
 		if ( ! empty( $args['full_name'] ) ) {
 			$create_args['full_name'] = $args['full_name'];
+			$create_args['title']     = $args['full_name'];
 		}
 
 		if (
@@ -372,6 +373,7 @@ class Attendee {
 			&& ! empty( $order->purchaser['full_name'] )
 		) {
 			$create_args['full_name'] = $order->purchaser['full_name'];
+			$create_args['title']     = $order->purchaser['full_name'];
 		}
 
 		$fields = Arr::get( $args, 'fields', [] );

--- a/tests/commerce_integration/TEC/Tickets/Attendees_ListTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Attendees_ListTest.php
@@ -88,4 +88,18 @@ class Attendees_ListTest extends \Codeception\TestCase\WPTestCase{
 		$total_attendees = count( $rsvp_attendees ) + count( $ticket_attendees );
 		$this->assertEquals( $total_attendees, $attendees_list->get_attendance_counts( $post_id ) );
 	}
+
+	/**
+	 * @test
+	 */
+	public function test_generated_attendee_has_post_title() {
+		$post_id = $this->factory()->post->create();
+		$tickets_commerce_ticket_id = $this->create_tc_ticket( $post_id );
+		$ticket_attendees = $this->create_many_attendees_for_ticket( 1, $tickets_commerce_ticket_id, $post_id );
+
+		$attendee = tec_tc_attendees()->by( 'event_id', $post_id )->first();
+
+		$this->assertNotEmpty( $attendee );
+		$this->assertNotEmpty( $attendee->post_title );
+	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/EventStockTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/EventStockTest.php
@@ -432,4 +432,25 @@ class EventStockTest extends \Codeception\TestCase\WPTestCase {
 		// Make sure that we have the proper initial data.
 		$this->assertEqualSets( $expected, $data );
 	}
+
+	/**
+	 * @test Test attendance count with unlimited tickets.
+	 *
+	 * @todo @rafsuntaskin Maybe shift this test to Attendee related test class when available.
+	 */
+	public function test_created_attendee_has_post_title() {
+		$maker = new Event();
+		$event_id = $maker->create();
+
+		// create ticket with default capacity of 100.
+		$ticket_a_id = $this->create_tc_ticket( $event_id, 10 );
+
+		$order = $this->create_order( [
+			$ticket_a_id => 1,
+		] );
+
+		$attendee = tec_tc_attendees()->by( 'event_id', $event_id )->first();
+
+		$this->assertNotEmpty( $attendee->post_title );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1590] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Attendees created with TicketsCommerce didn't have the `post_title` data added.
* This caused the Attendee Table search to not work as expected.
* This will fix the Attendee Table search by title for new attendees.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1590]: https://theeventscalendar.atlassian.net/browse/ET-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ