### PR TITLE
Tickets Emails > Tickets Commerce > Dliver purchase receipt completed order

### DIFF
--- a/src/Tickets/Commerce/Communication/Email.php
+++ b/src/Tickets/Commerce/Communication/Email.php
@@ -17,13 +17,13 @@ class Email {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @param string $order_id Order post ID
-	 * @param int    $post_id  Parent post ID (optional)
+	 * @param string $order_id Order post ID.
+	 * @param int    $post_id  Parent post ID (optional).
 	 */
 	public function send_tickets_email( $order_id, $post_id = null ) {
 		$all_attendees = tribe( Module::class )->get_attendees_by_order_id( $order_id );
 
-		$to_send = array();
+		$to_send = [];
 
 		if ( empty( $all_attendees ) ) {
 			return;
@@ -33,7 +33,7 @@ class Email {
 		// has not yet been sent we should a) send the ticket out by email and b) record the
 		// fact it was sent
 		foreach ( $all_attendees as $single_attendee ) {
-			// Only add those attendees/tickets that haven't already been sent
+			// Only add those attendees/tickets that haven't already been sent.
 			if ( ! empty( $single_attendee['ticket_sent'] ) ) {
 				continue;
 			}
@@ -50,7 +50,6 @@ class Email {
 		 * @param array  $all_attendees list of all attendees/tickets, including those already sent out
 		 * @param int    $post_id
 		 * @param string $order_id
-		 *
 		 */
 		$to_send = (array) apply_filters( 'tec_tickets_commerce_legacy_email_tickets_to_send', $to_send, $all_attendees, $post_id, $order_id );
 

--- a/src/Tickets/Commerce/Flag_Actions/Flag_Action_Handler.php
+++ b/src/Tickets/Commerce/Flag_Actions/Flag_Action_Handler.php
@@ -33,6 +33,8 @@ class Flag_Action_Handler extends \tad_DI52_ServiceProvider {
 		Archive_Attendees::class,
 		Backfill_Purchaser::class,
 		Send_Email::class,
+		Send_Email_Purchase_Receipt::class,
+		Send_Email_Completed_Order::class,
 		Increase_Sales::class,
 		Decrease_Sales::class,
 		End_Duplicated_Pending_Orders::class,

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email.php
@@ -9,7 +9,7 @@ use TEC\Tickets\Commerce\Ticket;
 use Tribe__Utils__Array as Arr;
 
 /**
- * Class Increase_Stock, normally triggered when refunding on orders get set to not-completed.
+ * Class Send_Email, normally triggered when an order is complete.
  *
  * @since   5.1.9
  *
@@ -18,6 +18,8 @@ use Tribe__Utils__Array as Arr;
 class Send_Email extends Flag_Action_Abstract {
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @var array
 	 */
 	protected $flags = [
 		'send_email',
@@ -25,9 +27,11 @@ class Send_Email extends Flag_Action_Abstract {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @var array
 	 */
 	protected $post_types = [
-		Order::POSTTYPE
+		Order::POSTTYPE,
 	];
 
 	/**

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_Completed_Order.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_Completed_Order.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Flag_Actions;
+
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Status_Interface;
+
+/**
+ * Class Send_Email_Completed_Order, normally triggered when an order is completed.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Commerce\Flag_Actions
+ */
+class Send_Email_Completed_Order extends Flag_Action_Abstract {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array
+	 */
+	protected $flags = [
+		'send_email_completed_order',
+	];
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array
+	 */
+	protected $post_types = [
+		Order::POSTTYPE,
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle( Status_Interface $new_status, $old_status, \WP_Post $order ) {
+		if ( ! empty( $order->gateway ) && 'manual' === $order->gateway && empty( $order->events_in_order ) ) {
+			$order->events_in_order[] = $order;
+		}
+
+
+		if ( empty( $order->events_in_order ) || ! is_array( $order->events_in_order ) ) {
+			return;
+		}
+
+		// bail if tickets emails is not enabled.
+		if ( ! tec_tickets_emails_is_enabled() ) {
+			return;
+		}
+
+		$email_class = tribe( \TEC\Tickets\Emails\Email\Completed_Order::class );
+
+		if ( ! $email_class->is_enabled() ) {
+			return false;
+		}
+
+		// @todo @juanfra: See if we handle the placeholders here or not.
+		$placeholders = [
+			'{order_number}' => $order->ID,
+			'{order_id}'     => $order->ID,
+		];
+
+		$email_class->set_placeholders( $placeholders );
+
+		$to          = $email_class->get_recipient();
+		$subject     = $email_class->get_subject();
+		$content     = $email_class->get_content( [] );
+		$headers     = $email_class->get_headers();
+		$attachments = $email_class->get_attachments();
+
+		$sent = tribe( \TEC\Tickets\Emails\Email_Sender::class )->send( $to, $subject, $content, $headers, $attachments );
+	}
+}

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_Purchase_Receipt.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_Purchase_Receipt.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Flag_Actions;
+
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Status_Interface;
+
+/**
+ * Class Send_Email_Purchase_Receipt, normally triggered when an order is completed.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Commerce\Flag_Actions
+ */
+class Send_Email_Purchase_Receipt extends Flag_Action_Abstract {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array
+	 */
+	protected $flags = [
+		'send_email_purchase_receipt',
+	];
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array
+	 */
+	protected $post_types = [
+		Order::POSTTYPE,
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle( Status_Interface $new_status, $old_status, \WP_Post $order ) {
+		if ( ! empty( $order->gateway ) && 'manual' === $order->gateway && empty( $order->events_in_order ) ) {
+			$order->events_in_order[] = $order;
+		}
+
+
+		if ( empty( $order->events_in_order ) || ! is_array( $order->events_in_order ) ) {
+			return;
+		}
+
+		// bail if tickets emails is not enabled.
+		if ( ! tec_tickets_emails_is_enabled() ) {
+			return;
+		}
+
+		if ( ! isset( $order->purchaser['email'] ) ) {
+			return;
+		}
+
+		$email_class = tribe( \TEC\Tickets\Emails\Email\Purchase_Receipt::class );
+
+		if ( ! $email_class->is_enabled() ) {
+			return false;
+		}
+
+		// @todo @juanfra: See if we handle the placeholders here or not.
+		$placeholders = [
+			'{order_number}' => $order->ID,
+			'{order_id}'     => $order->ID,
+		];
+
+		$email_class->set_placeholders( $placeholders );
+
+		$to          = $order->purchaser['email'];
+		$subject     = $email_class->get_subject();
+		$content     = $email_class->get_content( [] );
+		$headers     = $email_class->get_headers();
+		$attachments = $email_class->get_attachments();
+
+		$sent = tribe( \TEC\Tickets\Emails\Email_Sender::class )->send( $to, $subject, $content, $headers, $attachments );
+	}
+}

--- a/src/Tickets/Commerce/Status/Completed.php
+++ b/src/Tickets/Commerce/Status/Completed.php
@@ -38,6 +38,8 @@ class Completed extends Status_Abstract {
 		'attendee_dispatch',
 		'stock_reduced',
 		'send_email',
+		'send_email_completed_order',
+		'send_email_purchase_receipt',
 		'count_attendee',
 		'count_completed',
 		'count_sales',

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -101,14 +101,13 @@ abstract class Email_Abstract {
 	 * @since 5.5.9
 	 */
 	public function hook() {
-		$this->placeholders = array_merge(
-			[
-				'{site_title}'   => $this->get_blogname(),
-				'{site_address}' => wp_parse_url( home_url(), PHP_URL_HOST ),
-				'{site_url}'     => wp_parse_url( home_url(), PHP_URL_HOST ),
-			],
-			$this->get_placeholders()
-		);
+		$default_placeholders = [
+			'{site_title}'   => $this->get_blogname(),
+			'{site_address}' => wp_parse_url( home_url(), PHP_URL_HOST ),
+			'{site_url}'     => wp_parse_url( home_url(), PHP_URL_HOST ),
+		];
+
+		$this->set_placeholders( $default_placeholders );
 	}
 
 	/**
@@ -309,6 +308,24 @@ abstract class Email_Abstract {
 		$attachments = apply_filters( 'tec_tickets_emails_attachments', $attachments, $this->id );
 
 		return $attachments;
+	}
+
+	/**
+	 * Set email placeholders.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $placeholders the placeholders to set.
+	 *
+	 * @return string
+	 */
+	public function set_placeholders( array $placeholders = [] ): array {
+		$this->placeholders = array_merge(
+			$placeholders,
+			$this->get_placeholders()
+		);
+
+		return $this->placeholders;
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Add flag actions and deliver the completed order and purchase receipt emails upon order completition.
- Add "set" method to the email abstract class to set placeholders on demand.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://user-images.githubusercontent.com/252415/227561101-ee5102fa-9f73-4436-b5cb-2c92fbc989d0.mov

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
