### PR TITLE
Tickets Emails > Use `get_placeholders` on the format string method to use filtered values

### DIFF
--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -218,6 +218,17 @@ abstract class Email_Abstract {
 		 */
 		$from_email = apply_filters( 'tec_tickets_emails_from_email', $from_email, $this->id, $this );
 
+		/**
+		 * Filter the from email for the particular email.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $from_email The "from" email.
+		 * @param string         $id         The email ID.
+		 * @param Email_Abstract $this       The email object.
+		 */
+		$from_email = apply_filters( "tec_tickets_emails_{$this->slug}_from_email", $from_email, $this->id, $this );
+
 		return $from_email;
 	}
 
@@ -241,6 +252,17 @@ abstract class Email_Abstract {
 		 * @param Email_Abstract $this       The email object.
 		 */
 		$from_name = apply_filters( 'tec_tickets_emails_from_name', $from_name, $this->id, $this );
+
+		/**
+		 * Filter the from name for the particular email.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $from_email The "from" name.
+		 * @param string         $id         The email ID.
+		 * @param Email_Abstract $this       The email object.
+		 */
+		$from_name = apply_filters( "tec_tickets_emails_{$this->slug}_from_name", $from_name, $this->id, $this );
 
 		return $from_name;
 	}
@@ -295,6 +317,17 @@ abstract class Email_Abstract {
 		 */
 		$headers = apply_filters( 'tec_tickets_emails_headers', $headers, $this->id, $this );
 
+		/**
+		 * Filter the headers for the particular email.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $headers The headers.
+		 * @param string         $id      The email ID.
+		 * @param Email_Abstract $this    The email object.
+		 */
+		$headers = apply_filters( "tec_tickets_emails_{$this->slug}_headers", $headers, $this->id, $this );
+
 		return $headers;
 	}
 
@@ -308,7 +341,6 @@ abstract class Email_Abstract {
 	 * @return array
 	 */
 	public function get_attachments( $attachments = [] ): array {
-
 		/**
 		 * Filter the attachments.
 		 *
@@ -319,6 +351,17 @@ abstract class Email_Abstract {
 		 * @param Email_Abstract $this        The email object.
 		 */
 		$attachments = apply_filters( 'tec_tickets_emails_attachments', $attachments, $this->id, $this );
+
+		/**
+		 * Filter the attachments for the particular email.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $attachments The attachments.
+		 * @param string         $id          The email ID.
+		 * @param Email_Abstract $this        The email object.
+		 */
+		$attachments = apply_filters( "tec_tickets_emails_{$this->slug}_attachments", $attachments, $this->id, $this );
 
 		return $attachments;
 	}
@@ -359,6 +402,17 @@ abstract class Email_Abstract {
 		 * @param Email_Abstract $this         The email object.
 		 */
 		$placeholders = apply_filters( 'tec_tickets_emails_placeholders', $this->placeholders, $this->id, $this );
+
+		/**
+		 * Filter the placeholders for the particular email.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $placeholders The placeholders.
+		 * @param string         $id           The email ID.
+		 * @param Email_Abstract $this         The email object.
+		 */
+		$placeholders = apply_filters( "tec_tickets_emails_{$this->slug}_placeholders", $placeholders, $this->id, $this );
 
 		return $placeholders;
 	}

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -370,8 +370,9 @@ abstract class Email_Abstract {
 	 * @return string
 	 */
 	public function format_string( $string ): string {
-		$find    = array_keys( $this->placeholders );
-		$replace = array_values( $this->placeholders );
+		$placeholders = $this->get_placeholders();
+		$find         = array_keys( $placeholders );
+		$replace      = array_values( $placeholders );
 
 		/**
 		 * Filter the formatted email string.


### PR DESCRIPTION
### 🎫 Ticket

[ET-1636] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Use the `get_placeholders` method for the format string method, so that we make use of the filtered value.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="884" alt="Screenshot 2023-03-29 at 13 00 03" src="https://user-images.githubusercontent.com/252415/228513885-cc9b0446-630c-4d4c-aec6-774014c0aea9.png">

^ Test with the TEC integration.

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1636]: https://theeventscalendar.atlassian.net/browse/ET-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ