### PR TITLE
Fix/abstract email tpl context

### DIFF
--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_Completed_Order.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_Completed_Order.php
@@ -62,6 +62,7 @@ class Send_Email_Completed_Order extends Flag_Action_Abstract {
 		];
 
 		$email_class->set_placeholders( $placeholders );
+		$email_class->__set( $order );
 
 		$to          = $email_class->get_recipient();
 		$subject     = $email_class->get_subject();

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_Purchase_Receipt.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_Purchase_Receipt.php
@@ -66,6 +66,7 @@ class Send_Email_Purchase_Receipt extends Flag_Action_Abstract {
 		];
 
 		$email_class->set_placeholders( $placeholders );
+		$email_class->__set( $order );
 
 		$to          = $order->purchaser['email'];
 		$subject     = $email_class->get_subject();

--- a/src/Tickets/Emails/Email/Completed_Order.php
+++ b/src/Tickets/Emails/Email/Completed_Order.php
@@ -191,6 +191,23 @@ class Completed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get default template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array $args The default arguments
+	 */
+	public function get_default_template_context(): array {
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		return $defaults;
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -202,14 +219,7 @@ class Completed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	public function get_content( $args = [] ): string {
 		// @todo: We need to grab the proper information that's going to be sent as context.
 		$is_preview = ! empty( $args['is_preview'] ) ? tribe_is_truthy( $args['is_preview'] ) : false;
-
-		$defaults = [
-			'title'              => $this->get_title(),
-			'heading'            => $this->get_heading(),
-			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
-		];
-
-		$args = wp_parse_args( $args, $defaults );
+		$args       = $this->get_template_context( $args );
 
 		$email_template = tribe( Email_Template::class );
 		$email_template->set_preview( $is_preview );

--- a/src/Tickets/Emails/Email/Completed_Order.php
+++ b/src/Tickets/Emails/Email/Completed_Order.php
@@ -202,6 +202,7 @@ class Completed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 			'title'              => $this->get_title(),
 			'heading'            => $this->get_heading(),
 			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+			'order'              => $this->__get( 'order' ),
 		];
 
 		return $defaults;

--- a/src/Tickets/Emails/Email/Failed_Order.php
+++ b/src/Tickets/Emails/Email/Failed_Order.php
@@ -191,6 +191,23 @@ class Failed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get default template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array $args The default arguments
+	 */
+	public function get_default_template_context(): array {
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		return $defaults;
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -202,14 +219,7 @@ class Failed_Order extends \TEC\Tickets\Emails\Email_Abstract {
 	public function get_content( $args = [] ): string {
 		// @todo: We need to grab the proper information that's going to be sent as context.
 		$is_preview = ! empty( $args['is_preview'] ) ? tribe_is_truthy( $args['is_preview'] ) : false;
-
-		$defaults = [
-			'title'              => $this->get_title(),
-			'heading'            => $this->get_heading(),
-			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
-		];
-
-		$args = wp_parse_args( $args, $defaults );
+		$args       = $this->get_template_context( $args );
 
 		$email_template = tribe( Email_Template::class );
 		$email_template->set_preview( $is_preview );

--- a/src/Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Tickets/Emails/Email/Purchase_Receipt.php
@@ -195,6 +195,23 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get default template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array $args The default arguments
+	 */
+	public function get_default_template_context(): array {
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		return $defaults;
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -206,14 +223,7 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 	public function get_content( $args = [] ): string {
 		// @todo: We need to grab the proper information that's going to be sent as context.
 		$is_preview = ! empty( $args['is_preview'] ) ? tribe_is_truthy( $args['is_preview'] ) : false;
-
-		$defaults = [
-			'title'              => $this->get_title(),
-			'heading'            => $this->get_heading(),
-			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
-		];
-
-		$args = wp_parse_args( $args, $defaults );
+		$args       = $this->get_template_context( $args );
 
 		$email_template = tribe( Email_Template::class );
 		$email_template->set_preview( $is_preview );

--- a/src/Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Tickets/Emails/Email/Purchase_Receipt.php
@@ -206,6 +206,7 @@ class Purchase_Receipt extends \TEC\Tickets\Emails\Email_Abstract {
 			'title'              => $this->get_title(),
 			'heading'            => $this->get_heading(),
 			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+			'order'              => $this->__get( 'order' ),
 		];
 
 		return $defaults;

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -335,6 +335,25 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get default template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array $args The default arguments
+	 */
+	public function get_default_template_context(): array {
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : $this->__get( 'tickets' ),
+			'post_id'            => $this->__get( 'post_id' ),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		return $defaults;
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -346,17 +365,7 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 	public function get_content( $args = [] ): string {
 		// @todo: Parse args, etc.
 		$is_preview = ! empty( $args['is_preview'] ) ? tribe_is_truthy( $args['is_preview'] ) : false;
-
-		// @todo @juanfra @codingmusician: we need to see if we initialize tickets.
-		$defaults = [
-			'title'              => $this->get_title(),
-			'heading'            => $this->get_heading(),
-			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : $this->__get( 'tickets' ),
-			'post_id'            => $this->__get( 'post_id' ),
-			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
-		];
-
-		$args = wp_parse_args( $args, $defaults );
+		$args       = $this->get_template_context( $args );
 
 		$email_template = tribe( Email_Template::class );
 		$email_template->set_preview( $is_preview );

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -345,7 +345,7 @@ class RSVP extends \TEC\Tickets\Emails\Email_Abstract {
 		$defaults = [
 			'title'              => $this->get_title(),
 			'heading'            => $this->get_heading(),
-			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : $this->__get( 'tickets' ),
+			'tickets'            => $this->__get( 'tickets' ),
 			'post_id'            => $this->__get( 'post_id' ),
 			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
 		];

--- a/src/Tickets/Emails/Email/RSVP_Not_Going.php
+++ b/src/Tickets/Emails/Email/RSVP_Not_Going.php
@@ -190,6 +190,23 @@ class RSVP_Not_Going extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get default template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array $args The default arguments
+	 */
+	public function get_default_template_context(): array {
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		return $defaults;
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -201,15 +218,7 @@ class RSVP_Not_Going extends \TEC\Tickets\Emails\Email_Abstract {
 	public function get_content( $args = [] ): string {
 		// @todo: Parse args, etc.
 		$is_preview = ! empty( $args['is_preview'] ) ? tribe_is_truthy( $args['is_preview'] ) : false;
-
-		// @todo @juanfra @codingmusician: we need to see if we initialize tickets.
-		$defaults = [
-			'title'              => $this->get_title(),
-			'heading'            => $this->get_heading(),
-			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
-		];
-
-		$args = wp_parse_args( $args, $defaults );
+		$args       = $this->get_template_context( $args );
 
 		$email_template = tribe( Email_Template::class );
 		$email_template->set_preview( $is_preview );

--- a/src/Tickets/Emails/Email/Ticket.php
+++ b/src/Tickets/Emails/Email/Ticket.php
@@ -329,7 +329,7 @@ class Ticket extends \TEC\Tickets\Emails\Email_Abstract {
 			'title'              => $this->get_title(),
 			'heading'            => $this->get_heading(),
 			'post_id'            => $this->__get( 'post_id' ),
-			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : $this->__get( 'tickets' ),
+			'tickets'            => $this->__get( 'tickets' ),
 			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
 		];
 

--- a/src/Tickets/Emails/Email/Ticket.php
+++ b/src/Tickets/Emails/Email/Ticket.php
@@ -318,6 +318,25 @@ class Ticket extends \TEC\Tickets\Emails\Email_Abstract {
 	}
 
 	/**
+	 * Get default template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array $args The default arguments
+	 */
+	public function get_default_template_context(): array {
+		$defaults = [
+			'title'              => $this->get_title(),
+			'heading'            => $this->get_heading(),
+			'post_id'            => $this->__get( 'post_id' ),
+			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : $this->__get( 'tickets' ),
+			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
+		];
+
+		return $defaults;
+	}
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -327,19 +346,8 @@ class Ticket extends \TEC\Tickets\Emails\Email_Abstract {
 	 * @return string The email content.
 	 */
 	public function get_content( $args = [] ): string {
-		// @todo: Parse args, etc.
 		$is_preview = ! empty( $args['is_preview'] ) ? tribe_is_truthy( $args['is_preview'] ) : false;
-
-		// @todo @juanfra @codingmusician: we need to see if we initialize tickets from a method.
-		$defaults = [
-			'title'              => $this->get_title(),
-			'heading'            => $this->get_heading(),
-			'tickets'            => ! empty( $args['tickets'] ) ? $args['tickets'] : $this->__get( 'tickets' ),
-			'post_id'            => $this->__get( 'post_id' ),
-			'additional_content' => $this->format_string( tribe_get_option( $this->get_option_key( 'add-content' ), '' ) ),
-		];
-
-		$args = wp_parse_args( $args, $defaults );
+		$args       = $this->get_template_context( $args );
 
 		$email_template = tribe( Email_Template::class );
 		$email_template->set_preview( $is_preview );

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -176,6 +176,15 @@ abstract class Email_Abstract {
 	abstract public function get_preview_context( $args ): array;
 
 	/**
+	 * Get the default template context.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template context.
+	 */
+	abstract public function get_default_template_context(): array;
+
+	/**
 	 * Get email content.
 	 *
 	 * @since 5.5.10
@@ -723,6 +732,46 @@ abstract class Email_Abstract {
 		$settings = apply_filters( "tec_tickets_emails_{$this->slug}_settings", $settings, $this->id, $this );
 
 		return $settings;
+	}
+
+	/**
+	 * Get template context for email.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The arguments.
+	 * @return array $args The modified arguments
+	 */
+	public function get_template_context( $args = [] ): array {
+		$defaults = $this->get_default_template_context();
+
+		$args = wp_parse_args( $args, $defaults );
+
+		/**
+		 * Allow filtering the template context globally.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $args     The email arguments.
+		 * @param string         $id       The email id.
+		 * @param string         $template Template name.
+		 * @param Email_Abstract $this     The email object.
+		 */
+		$args = apply_filters( 'tec_tickets_emails_template_args', $args, $this->id, $this->template, $this );
+
+		/**
+		 * Allow filtering the template context.
+		 *
+		* @since TBD
+		 *
+		 * @param array          $args     The email arguments.
+		 * @param string         $id       The email id.
+		 * @param string         $template Template name.
+		 * @param Email_Abstract $this     The email object.
+		 */
+		$subject = apply_filters( "tec_tickets_emails_{$this->slug}_template_args", $args, $this->id, $this->template, $this );
+
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Abstract the default context per email, and parse the get context function so that's filterable.
- Add `order` context to transactional emails.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
