### PR TITLE
[ET-1579] Fix - Ensure TC unavailable messages are filtered using event_tickets_unavailable_message filter.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,9 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= TBD =
+* Enhancement - Ensure TC unavailable messages are filtered using event_tickets_unavailable_message filter. [ET-1579]
+
 = [5.5.10] 2023-04-03 =
 
 * Enhancement - Added functionality to properly restock deleted attendee ticket for Tickets Commerce. [ETP-860]

--- a/readme.txt
+++ b/readme.txt
@@ -191,7 +191,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 == Changelog ==
 
 = TBD =
-* Enhancement - Ensure TC unavailable messages are filtered using event_tickets_unavailable_message filter. [ET-1579]
+* Enhancement - Ensure Tickets Commerce unavailable messages are filtered using event_tickets_unavailable_message filter. [ET-1579]
 
 = [5.5.10] 2023-04-03 =
 

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -171,6 +171,8 @@ class Pending extends Status_Abstract {
 				/**
 				 * Filters the unavailability message for a ticket collection
 				 *
+				 * @since TBD
+				 *
 				 * @param string Unavailability message
 				 * @param array Collection of tickets
 				 */

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -166,8 +166,6 @@ class Pending extends Status_Abstract {
 					$message = sprintf( __( 'There are no %s available at this time.', 'event-tickets' ), tribe_get_ticket_label_plural( 'unavailable_mixed' ) );
 				}
 
-				$tickets = tribe( Module::class )->get_tickets( $post->ID );
-
 				/**
 				 * Filters the unavailability message for a ticket collection
 				 *
@@ -176,7 +174,7 @@ class Pending extends Status_Abstract {
 				 * @param string Unavailability message
 				 * @param array Collection of tickets
 				 */
-				$message = apply_filters( 'event_tickets_unvailable_message', $message, $tickets );
+				$message = (string) apply_filters( 'event_tickets_unvailable_message', $message, array( $ticket ) );
 
 				return new WP_Error(
 					'tec-tc-ticket-unavailable',

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -16,6 +16,7 @@ use WP_Error;
  * form and then gone to Gateway for payment.  We have the record of sale, but they haven't completed their payment yet.
  *
  * @since   5.1.9
+ * @since TBD Added event_tickets_unvailable_message filter for unavailable messages.
  *
  * @package TEC\Tickets\Commerce\Status
  */

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -165,6 +165,16 @@ class Pending extends Status_Abstract {
 					$message = sprintf( __( 'There are no %s available at this time.', 'event-tickets' ), tribe_get_ticket_label_plural( 'unavailable_mixed' ) );
 				}
 
+				$tickets = tribe( Module::class )->get_tickets( $post->ID );
+
+				/**
+				 * Filters the unavailability message for a ticket collection
+				 *
+				 * @param string Unavailability message
+				 * @param array Collection of tickets
+				 */
+				$message = apply_filters( 'event_tickets_unvailable_message', $message, $tickets );
+
 				return new WP_Error(
 					'tec-tc-ticket-unavailable',
 					$message,

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3453,6 +3453,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				/**
 				 * Filters the unavailability message for a ticket collection
 				 *
+				 * @since TBD
+				 *
 				 * @param string Unavailability message
 				 * @param array Collection of tickets
 				 */

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3443,7 +3443,19 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			self::$currently_unavailable_tickets[ (int) $post_id ] = array_merge( $existing_tickets, $tickets );
 
+			if ( ! empty( self::$currently_unavailable_tickets ) ) {
+				$message = sprintf(
+					__( 'There are no %s available at this time.', 'event-tickets' ), tribe_get_ticket_label_plural( 'unavailable_mixed' )
+				);
 
+				/**
+				 * Filters the unavailability message for a ticket collection
+				 *
+				 * @param string Unavailability message
+				 * @param array Collection of tickets
+				 */
+				echo apply_filters( 'event_tickets_unvailable_message', $message, $tickets );
+			}
 		}
 
 		/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3458,7 +3458,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				 * @param string Unavailability message
 				 * @param array Collection of tickets
 				 */
-				echo apply_filters( 'event_tickets_unvailable_message', $message, $tickets );
+				echo (string) apply_filters( 'event_tickets_unvailable_message', $message, $tickets );
 			}
 		}
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3427,6 +3427,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * event are currently unavailable and unless a different ticket provider reports differently
 		 * the "tickets unavailable" message should be displayed.
 		 *
+		 * @since TBD Added event_tickets_unvailable_message filter for unavailable messages.
+		 *
 		 * @param array $tickets
 		 * @param int $post_id ID of parent "event" post (defaults to the current post)
 		 */


### PR DESCRIPTION
  ### 🎫 Ticket

[1579](https://theeventscalendar.atlassian.net/browse/ET-1579)

### 🗒️ Description

Users are currently able to filter the unavailability message for a collection of tickets using the **event_tickets_unvailable_message** filter but unfortunately, this is not possible for Users using the Tickets Commerce provider. I have added logic so that those filters apply when TC is used.

### 🎥 Artifacts <!-- if applicable-->

### ✔️ Checklist
- [X] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).