### PR TITLE
Make $tickets a Lazy_Collection in the Order_Model

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fatal error occuring for some Tickets Commerce users. [GTRIA-1001]
+
 = [5.5.11] 2023-05-04 =
 
 * Enhancement - Add Ticket data with attendee data as checkin response. [ET-1694]

--- a/src/Tickets/Commerce/Models/Order_Model.php
+++ b/src/Tickets/Commerce/Models/Order_Model.php
@@ -87,7 +87,6 @@ class Order_Model extends Base {
 				'events_in_order'     => $events_in_order,
 				'tickets_in_order'    => $tickets_in_order,
 				'flag_action_markers' => $flag_action_markers,
-				'tickets'             => ( new Lazy_Collection( $this->get_ticket_data_callback( $items ) ) )->on_resolve( $cache_this ),
 			];
 		} catch ( \Exception $e ) {
 			return [];
@@ -170,45 +169,5 @@ class Order_Model extends Base {
 	 */
 	protected function get_cache_slug() {
 		return 'tc_orders';
-	}
-
-	/**
-	 * Returns a callback that will return the ticket data for the order items.
-	 *
-	 * @since TBD
-	 *
-	 * @param $items array The order items.
-	 *
-	 * @return \Closure
-	 */
-	public function get_ticket_data_callback( $items ): \Closure {
-		/**
-		 * Filters the callback that will return the ticket data for the order items.
-		 *
-		 * Returning a non `null` value here will skip the default logic.
-		 *
-		 * @since TBD
-		 *
-		 * @param null|\Closure $callback The callback that will return the ticket data for the order items.
-		 * @param array $items The order items.
-		 */
-		$callback = apply_filters( 'tec_tickets_order_items_ticket_data_callback', null, $items );
-
-		if ( null !== $callback ) {
-			return $callback;
-		}
-
-		return static function() use ( $items ) {
-			return array_reduce( $items, function( $tickets, $item ) {
-				// @todo @rafsuntaskin should be updated later to make use of `tec_tc_get_ticket` function, once Ticket Model is updated.
-				$post = get_post( $item['ticket_id'] );
-				if ( ! $post instanceof WP_Post ) {
-					return $tickets;
-				}
-				$post->ticket_data = $item;
-				$tickets[] = $post;
-				return $tickets;
-			}, []);
-		};
 	}
 }

--- a/src/Tickets/Commerce/Models/Order_Model.php
+++ b/src/Tickets/Commerce/Models/Order_Model.php
@@ -59,31 +59,6 @@ class Order_Model extends Base {
 			$events_in_order  = (array) Arr::get( $post_meta, [ Order::$events_in_order_meta_key ] );
 			$tickets_in_order = (array) Arr::get( $post_meta, [ Order::$tickets_in_order_meta_key ] );
 
-			$tickets = new Lazy_Collection( static function () use ( $items ) {
-				if ( empty( $items ) ) {
-					return [];
-				}
-
-				$tickets = [];
-
-				foreach ( $items as $item ) {
-					if ( empty( $item['ticket_id'] ) ) {
-						continue;
-					}
-
-					$post = get_post( $item['ticket_id'] );
-
-					if ( ! $post instanceof WP_Post ) {
-						continue;
-					}
-
-					$post->ticket_data = $item;
-					$tickets[]         = $post;
-				}
-
-				return $tickets;
-			} );
-
 			$properties = [
 				'order_id'            => $post_id,
 				'provider'            => Module::class,
@@ -112,7 +87,7 @@ class Order_Model extends Base {
 				'events_in_order'     => $events_in_order,
 				'tickets_in_order'    => $tickets_in_order,
 				'flag_action_markers' => $flag_action_markers,
-				'tickets'             => $tickets,
+				'tickets'             => ( new Lazy_Collection( $this->get_ticket_data_callback( $items ) ) )->on_resolve( $cache_this ),
 			];
 		} catch ( \Exception $e ) {
 			return [];
@@ -197,4 +172,43 @@ class Order_Model extends Base {
 		return 'tc_orders';
 	}
 
+	/**
+	 * Returns a callback that will return the ticket data for the order items.
+	 *
+	 * @since TBD
+	 *
+	 * @param $items array The order items.
+	 *
+	 * @return \Closure
+	 */
+	public function get_ticket_data_callback( $items ): \Closure {
+		/**
+		 * Filters the callback that will return the ticket data for the order items.
+		 *
+		 * Returning a non `null` value here will skip the default logic.
+		 *
+		 * @since TBD
+		 *
+		 * @param null|\Closure $callback The callback that will return the ticket data for the order items.
+		 * @param array $items The order items.
+		 */
+		$callback = apply_filters( 'tec_tickets_order_items_ticket_data_callback', null, $items );
+
+		if ( null !== $callback ) {
+			return $callback;
+		}
+
+		return static function() use ( $items ) {
+			return array_reduce( $items, function( $tickets, $item ) {
+				// @todo @rafsuntaskin should be updated later to make use of `tec_tc_get_ticket` function, once Ticket Model is updated.
+				$post = get_post( $item['ticket_id'] );
+				if ( ! $post instanceof WP_Post ) {
+					return $tickets;
+				}
+				$post->ticket_data = $item;
+				$tickets[] = $post;
+				return $tickets;
+			}, []);
+		};
+	}
 }

--- a/src/Tickets/Commerce/Models/Order_Model.php
+++ b/src/Tickets/Commerce/Models/Order_Model.php
@@ -14,10 +14,8 @@ use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Handler;
 use Tribe\Models\Post_Types\Base;
-use Tribe\Utils\Lazy_Collection;
 use Tribe__Date_Utils as Dates;
 use Tribe__Utils__Array as Arr;
-use WP_Post;
 
 /**
  * Class Order.


### PR DESCRIPTION
Turning the `tickets` element of the `Order_Model` into a `Lazy_Collection` for performance reasons.

Additionally, adding some checks to protect against unexpected values and return types.

@codingmusician - this is in draft mode because I am not sure how/where to test this. This code is the gist of what we'll probably want based on the error that was reported. I'll let you take it from here!

:ticket: [GTRIA-1001](https://theeventscalendar.atlassian.net/browse/GTRIA-1001)

[GTRIA-1001]: https://theeventscalendar.atlassian.net/browse/GTRIA-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ