### PR TITLE
Emails: Backwards compatibility fix for QA

### DIFF
--- a/src/Tickets/Emails/Admin/Settings.php
+++ b/src/Tickets/Emails/Admin/Settings.php
@@ -337,7 +337,7 @@ class Settings {
 	 * @return array $fields Filtered array of Tickets Emails settings fields.
 	 */
 	public function maybe_add_upgrade_field( array $fields ): array {
-		$upgrade_option_available = tribe_installed_before( 'Tribe__Tickets__Main', '5.6.0' );
+		$upgrade_option_available = tribe_installed_before( 'Tribe__Tickets__Main', '5.6.0-dev' );
 
 		if ( ! $upgrade_option_available ) {
 			return $fields;

--- a/src/functions/emails/provider.php
+++ b/src/functions/emails/provider.php
@@ -20,7 +20,7 @@ function tec_tickets_emails_is_enabled(): bool {
 	}
 
 	// The version in which Tickets Emails was introduced.
-	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '5.6.0' );
+	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '5.6.0-dev' );
 
 	// Check for settings UI option.
 	$enabled = (bool) tribe_get_option( TEC\Tickets\Emails\Admin\Settings::$option_enabled, $should_default_to_on );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1617] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- QA is using zips with the `-dev` postfix and the check for `tribe_installed_before` wasn't accounting for that.



[ET-1617]: https://theeventscalendar.atlassian.net/browse/ET-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ