### PR TITLE
[ET-1698] Fix - Glance items attendee count performance issue.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -192,7 +192,6 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.5.11.1] 2023-05-09 =
 
-* Fix - Fatal error occuring for some Tickets Commerce users. [GTRIA-1001]
 * Fix - Admin Dashboard loading slowly while counting attendees. [ET-1698]
 * Fix - Resolve Fatal occurring for some Tickets Commerce users around Order Models and Cart usage. [ET-1735]
 

--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Fatal error occuring for some Tickets Commerce users. [GTRIA-1001]
+* Fix - Admin Dashboard loading slowly while counting attendees. [ET-1698]
 
 = [5.5.11] 2023-05-04 =
 

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -53,4 +53,20 @@ class Glance_Items {
 
 		return $items;
 	}
+
+	/**
+	 * Update the attendee count.
+	 *
+	 * @since TBD
+	 */
+	public function update_attendee_count() {
+		$results = Tribe__Tickets__Tickets::get_attendees_by_args( [] );
+		$total   = count( $results['attendees'] );
+
+		if ( empty( $total ) ) {
+			return;
+		}
+
+		set_transient( $this->attendee_count_key, $total, DAY_IN_SECONDS );
+	}
 }

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -14,6 +14,15 @@ use Tribe__Tickets__Tickets;
 class Glance_Items {
 
 	/**
+	 * The key for the transient that stores the attendee count.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private string $attendee_count_key = 'tec_tickets_glance_item_attendees_count';
+
+	/**
 	 * Method to register glance items related hooks.
 	 *
 	 * @since 5.5.10

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -20,7 +20,7 @@ class Glance_Items {
 	 *
 	 * @var string
 	 */
-	private string $attendee_count_key = 'tec_tickets_glance_item_attendees_count';
+	protected static string $attendee_count_key = 'tec_tickets_glance_item_attendees_count';
 
 	/**
 	 * Method to register glance items related hooks.
@@ -41,11 +41,11 @@ class Glance_Items {
 	 * @return array $items The maybe modified array of items to be displayed.
 	 */
 	public function custom_glance_items_attendees( $items = [] ): array {
-		$total = get_transient( $this->attendee_count_key );
+		$total = get_transient( static::$attendee_count_key );
 
 		if ( false === $total ) {
 			if ( ! wp_next_scheduled( 'tec_tickets_update_glance_item_attendee_counts' ) ) {
-				wp_schedule_single_event( time() + 60, 'tec_tickets_update_glance_item_attendee_counts' );
+				wp_schedule_single_event( time(), 'tec_tickets_update_glance_item_attendee_counts' );
 			}
 			return $items;
 		}
@@ -72,6 +72,6 @@ class Glance_Items {
 			return;
 		}
 
-		set_transient( $this->attendee_count_key, $total, DAY_IN_SECONDS );
+		set_transient( static::$attendee_count_key, $total, DAY_IN_SECONDS );
 	}
 }

--- a/src/Tickets/Admin/Provider.php
+++ b/src/Tickets/Admin/Provider.php
@@ -32,6 +32,8 @@ class Provider extends \tad_DI52_ServiceProvider {
 
 		// Register singleton classes.
 		$this->container->singleton( Upsell::class );
+		$this->container->singleton( Plugin_Action_Links::class );
+		$this->container->singleton( Glance_Items::class );
 
 	}
 
@@ -44,7 +46,7 @@ class Provider extends \tad_DI52_ServiceProvider {
 		$hooks = new Hooks( $this->container );
 		$hooks->register();
 
-		// Allow Hooks to be removed, by having the them registered to the container
+		// Allow Hooks to be removed, by having them registered to the container
 		$this->container->singleton( Hooks::class, $hooks );
 		$this->container->singleton( 'tickets.admin.hooks', $hooks );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1698] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Make use of WP Schedule Events to calculate the attendee count in the background and display it only from saved transients to avoid loading the dashboard for heavy queries.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
📷 screenshot(s):

<img width="1045" alt="et-1698" src="https://github.com/the-events-calendar/event-tickets/assets/7523321/c06f6001-1715-4c8a-9e61-5f955d20ae5b">


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1698]: https://theeventscalendar.atlassian.net/browse/ET-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ