### PR TITLE
[ET-1579] Introduce filter for unavailable messages

### DIFF
--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -164,6 +164,35 @@ class Pending extends Status_Abstract {
 				} else {
 					$message = sprintf( __( 'There are no %s available at this time.', 'event-tickets' ), tribe_get_ticket_label_plural( 'unavailable_mixed' ) );
 				}
+
+				$tickets[] = $ticket;
+
+				/**
+				 * Filters the unavailability message for a ticket collection.
+				 * This function applies filters to modify the unavailability message for a collection of tickets.
+				 *
+				 * @since TBD
+				 *
+				 * @param string $message The unavailability message.
+				 * @param array $tickets The collection of tickets.
+				 *
+				 * @return string The modified unavailability message.
+				 */
+				$message = apply_filters( 'event_tickets_unavailable_message', $message, $tickets );
+
+				/**
+				 * Filters the unavailability message for a ticket collection.
+				 * This function applies filters to modify the unavailability message for a collection of tickets.
+				 *
+				 * @since TBD
+				 *
+				 * @param string $message The unavailability message.
+				 * @param array $tickets The collection of tickets.
+				 *
+				 * @return string The modified unavailability message.
+				 */
+				$message = apply_filters( 'tec_tickets_tickets_commerce_unavailable_message', $message, $tickets );
+
 				return new WP_Error(
 					'tec-tc-ticket-unavailable',
 					$message,


### PR DESCRIPTION
### 🎫 Ticket

[ET-1579] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
Per the original ticket the goal is to add a filter for the unavailable message.

We originally had a filter for unavailable within Tribe Commerce. However, that wasn't ported over to Tickets Commerce. The original filter was `event_tickets_unavailable_message`. 

Therefore, I added a cascading filter where we use `event_tickets_unavailable_message` first and then go through `tec_tickets_tickets_commerce_unavailable_message`.

<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1579]: https://theeventscalendar.atlassian.net/browse/ET-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ