### PR TITLE
Tickets Emails: Remove Plural Settings and Set New Defaults

### DIFF
--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -176,6 +176,7 @@ class RSVP extends Email_Abstract {
 				'type'                => 'wysiwyg',
 				'label'               => esc_html__( 'Additional content', 'event-tickets' ),
 				'default'             => '',
+				'size'                => 'large',
 				'tooltip'             => esc_html__( 'Additional content will be displayed below the RSVP information in your email.', 'event-tickets' ),
 				'validation_type'     => 'html',
 				'settings'        => [

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -80,65 +80,10 @@ class RSVP extends Email_Abstract {
 	 */
 	public function get_default_heading(): string {
 		return sprintf(
-			// Translators: %s Lowercase singular of ticket.
+			// Translators: %s Lowercase plural of ticket.
 			esc_html__( 'Here\'s your %s, {attendee_name}!', 'event-tickets' ),
-			tribe_get_ticket_label_singular_lowercase()
-		);
-	}
-
-	/**
-	 * Get default email heading for plural rsvps.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_default_heading_plural(): string {
-		return sprintf(
-			// Translators: %s Lowercase plural of tickets.
-			esc_html__( 'Here are your %s, {attendee_name}!', 'event-tickets' ),
 			tribe_get_ticket_label_plural_lowercase()
 		);
-	}
-
-	/**
-	 * Get heading for plural tickets.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_heading_plural(): string {
-		$option_key = $this->get_option_key( 'heading-plural' );
-		$heading    = tribe_get_option( $option_key, $this->get_default_heading_plural() );
-
-		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
-
-		/**
-		 * Allow filtering the email heading globally.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $heading  The email heading.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$heading = apply_filters( 'tec_tickets_emails_heading_plural', $heading, $this->id, $this->template, $this );
-
-		/**
-		 * Allow filtering the email heading.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $heading  The email heading.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$heading = apply_filters( "tec_tickets_emails_{$this->slug}_heading_plural", $heading, $this->id, $this->template, $this );
-
-		return $this->format_string( $heading );
 	}
 
 	/**
@@ -150,68 +95,13 @@ class RSVP extends Email_Abstract {
 	 */
 	public function get_default_subject(): string {
 		$default_subject = sprintf(
-			// Translators: %s - Lowercase singular of ticket.
+			// Translators: %s - Lowercase plural of ticket.
 			esc_html__( 'Your %s from {site_title}', 'event-tickets' ),
-			tribe_get_ticket_label_singular_lowercase()
+			tribe_get_ticket_label_plural_lowercase()
 		);
 
 		// If they already had a subject set in Tickets Commerce, let's make it the default.
 		return tribe_get_option( Settings::$option_confirmation_email_subject, $default_subject );
-	}
-
-	/**
-	 * Get default email subject for plural rsvps.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_default_subject_plural() {
-		return sprintf(
-			// Translators: %s - Lowercase plural of tickets.
-			esc_html__( 'Your %s from {site_title}', 'event-tickets' ),
-			tribe_get_ticket_label_plural_lowercase()
-		);
-	}
-
-	/**
-	 * Get subject for plural rsvps.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_subject_plural(): string {
-		$option_key = $this->get_option_key( 'subject-plural' );
-		$subject    = tribe_get_option( $option_key, $this->get_default_subject_plural() );
-
-		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
-
-		/**
-		 * Allow filtering the email subject globally.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $subject  The email subject.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$subject = apply_filters( 'tec_tickets_emails_subject_plural', $subject, $this->id, $this->template, $this );
-
-		/**
-		 * Allow filtering the email subject.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $subject  The email subject.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$subject = apply_filters( "tec_tickets_emails_{$this->slug}_subject_plural", $subject, $this->id, $this->template, $this );
-
-		return $this->format_string( $subject );
 	}
 
 	/**
@@ -274,27 +164,11 @@ class RSVP extends Email_Abstract {
 				'size'                => 'large',
 				'validation_callback' => 'is_string',
 			],
-			$this->get_option_key( 'subject-plural' ) => [
-				'type'                => 'text',
-				'label'               => esc_html__( 'Subject (plural)', 'event-tickets' ),
-				'default'             => $this->get_default_subject_plural(),
-				'placeholder'         => $this->get_default_subject_plural(),
-				'size'                => 'large',
-				'validation_callback' => 'is_string',
-			],
 			$this->get_option_key( 'heading' ) => [
 				'type'                => 'text',
 				'label'               => esc_html__( 'Heading', 'event-tickets' ),
 				'default'             => $this->get_default_heading(),
 				'placeholder'         => $this->get_default_heading(),
-				'size'                => 'large',
-				'validation_callback' => 'is_string',
-			],
-			$this->get_option_key( 'heading-plural' ) => [
-				'type'                => 'text',
-				'label'               => esc_html__( 'Heading (plural)', 'event-tickets' ),
-				'default'             => $this->get_default_heading_plural(),
-				'placeholder'         => $this->get_default_heading_plural(),
 				'size'                => 'large',
 				'validation_callback' => 'is_string',
 			],

--- a/src/Tickets/Emails/Email/Ticket.php
+++ b/src/Tickets/Emails/Email/Ticket.php
@@ -81,65 +81,10 @@ class Ticket extends Email_Abstract {
 	 */
 	public function get_default_heading(): string {
 		return sprintf(
-			// Translators: %s Lowercase singular of ticket.
+			// Translators: %s Lowercase plural of ticket.
 			esc_html__( 'Here\'s your %s, {attendee_name}!', 'event-tickets' ),
-			tribe_get_ticket_label_singular_lowercase()
-		);
-	}
-
-	/**
-	 * Get default email heading for plural tickets.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_default_heading_plural(): string {
-		return sprintf(
-			// Translators: %s Lowercase plural of tickets.
-			esc_html__( 'Here are your %s, {attendee_name}!', 'event-tickets' ),
 			tribe_get_ticket_label_plural_lowercase()
 		);
-	}
-
-	/**
-	 * Get heading for plural tickets.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_heading_plural(): string {
-		$option_key = $this->get_option_key( 'heading-plural' );
-		$heading    = tribe_get_option( $option_key, $this->get_default_heading_plural() );
-
-		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
-
-		/**
-		 * Allow filtering the email heading globally.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $heading  The email heading.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$heading = apply_filters( 'tec_tickets_emails_heading_plural', $heading, $this->id, $this->template, $this );
-
-		/**
-		 * Allow filtering the email heading.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $heading  The email heading.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$heading = apply_filters( "tec_tickets_emails_{$this->slug}_heading_plural", $heading, $this->id, $this->template, $this );
-
-		return $this->format_string( $heading );
 	}
 
 	/**
@@ -151,68 +96,13 @@ class Ticket extends Email_Abstract {
 	 */
 	public function get_default_subject(): string {
 		$default_subject = sprintf(
-			// Translators: %s - Lowercase singular of tickets.
+			// Translators: %s - Lowercase plural of ticket.
 			esc_html__( 'Your %s from {site_title}', 'event-tickets' ),
-			tribe_get_ticket_label_singular_lowercase()
+			tribe_get_ticket_label_plural_lowercase()
 		);
 
 		// If they already had a subject set in Tickets Commerce, let's make it the default.
 		return tribe_get_option( Settings::$option_confirmation_email_subject, $default_subject );
-	}
-
-	/**
-	 * Get default email subject for plural tickets.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_default_subject_plural() {
-		return sprintf(
-			// Translators: %s - Lowercase plural of tickets.
-			esc_html__( 'Your %s from {site_title}', 'event-tickets' ),
-			tribe_get_ticket_label_plural_lowercase()
-		);
-	}
-
-	/**
-	 * Get subject for plural tickets.
-	 *
-	 * @since 5.5.10
-	 *
-	 * @return string
-	 */
-	public function get_subject_plural(): string {
-		$option_key = $this->get_option_key( 'subject-plural' );
-		$subject    = tribe_get_option( $option_key, $this->get_default_subject_plural() );
-
-		// @todo: Probably we want more data parsed, or maybe move the filters somewhere else as we're always gonna
-
-		/**
-		 * Allow filtering the email subject globally.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $subject  The email subject.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$subject = apply_filters( 'tec_tickets_emails_subject_plural', $subject, $this->id, $this->template, $this );
-
-		/**
-		 * Allow filtering the email subject.
-		 *
-		 * @since 5.5.10
-		 *
-		 * @param string         $subject  The email subject.
-		 * @param string         $id       The email id.
-		 * @param string         $template Template name.
-		 * @param Email_Abstract $this     The email object.
-		 */
-		$subject = apply_filters( "tec_tickets_emails_{$this->slug}_subject_plural", $subject, $this->id, $this->template, $this );
-
-		return $this->format_string( $subject );
 	}
 
 	/**
@@ -261,27 +151,11 @@ class Ticket extends Email_Abstract {
 				'size'                => 'large',
 				'validation_callback' => 'is_string',
 			],
-			$this->get_option_key( 'subject-plural' ) => [
-				'type'                => 'text',
-				'label'               => esc_html__( 'Subject (plural)', 'event-tickets' ),
-				'default'             => $this->get_default_subject_plural(),
-				'placeholder'         => $this->get_default_subject_plural(),
-				'size'                => 'large',
-				'validation_callback' => 'is_string',
-			],
 			$this->get_option_key( 'heading' ) => [
 				'type'                => 'text',
 				'label'               => esc_html__( 'Heading', 'event-tickets' ),
 				'default'             => $this->get_default_heading(),
 				'placeholder'         => $this->get_default_heading(),
-				'size'                => 'large',
-				'validation_callback' => 'is_string',
-			],
-			$this->get_option_key( 'heading-plural' ) => [
-				'type'                => 'text',
-				'label'               => esc_html__( 'Heading (plural)', 'event-tickets' ),
-				'default'             => $this->get_default_heading_plural(),
-				'placeholder'         => $this->get_default_heading_plural(),
 				'size'                => 'large',
 				'validation_callback' => 'is_string',
 			],
@@ -324,11 +198,6 @@ class Ticket extends Email_Abstract {
 		$args['order'] = Preview_Data::get_order();
 		$args['tickets'] = Preview_Data::get_tickets();
 		$args['heading'] = $this->get_heading();
-
-		// If more than one ticket, use plural heading.
-		if ( count( $args['tickets'] ) > 1 ) {
-			$args['heading'] = $this->get_heading_plural();
-		}
 
 		return wp_parse_args( $args, $defaults );
 	}

--- a/src/Tickets/Emails/Email/Ticket.php
+++ b/src/Tickets/Emails/Email/Ticket.php
@@ -163,6 +163,7 @@ class Ticket extends Email_Abstract {
 				'type'                => 'wysiwyg',
 				'label'               => esc_html__( 'Additional content', 'event-tickets' ),
 				'default'             => '',
+				'size'                => 'large',
 				'tooltip'             => esc_html__( 'Additional content will be displayed below the tickets in your email.', 'event-tickets' ),
 				'validation_type'     => 'html',
 				'settings'        => [

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_rsvp_without_using_ticket_settings__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_rsvp_without_using_ticket_settings__1.php
@@ -31,14 +31,6 @@
     "tec-tickets-emails-rsvp-subject": {
         "type": "text",
         "label": "Subject",
-        "default": "Your ticket from {site_title}",
-        "placeholder": "Your ticket from {site_title}",
-        "size": "large",
-        "validation_callback": "is_string"
-    },
-    "tec-tickets-emails-rsvp-subject-plural": {
-        "type": "text",
-        "label": "Subject (plural)",
         "default": "Your tickets from {site_title}",
         "placeholder": "Your tickets from {site_title}",
         "size": "large",
@@ -47,16 +39,8 @@
     "tec-tickets-emails-rsvp-heading": {
         "type": "text",
         "label": "Heading",
-        "default": "Here&#039;s your ticket, {attendee_name}!",
-        "placeholder": "Here&#039;s your ticket, {attendee_name}!",
-        "size": "large",
-        "validation_callback": "is_string"
-    },
-    "tec-tickets-emails-rsvp-heading-plural": {
-        "type": "text",
-        "label": "Heading (plural)",
-        "default": "Here are your tickets, {attendee_name}!",
-        "placeholder": "Here are your tickets, {attendee_name}!",
+        "default": "Here&#039;s your tickets, {attendee_name}!",
+        "placeholder": "Here&#039;s your tickets, {attendee_name}!",
         "size": "large",
         "validation_callback": "is_string"
     },
@@ -64,6 +48,7 @@
         "type": "wysiwyg",
         "label": "Additional content",
         "default": "",
+        "size": "large",
         "tooltip": "Additional content will be displayed below the RSVP information in your email.",
         "validation_type": "html",
         "settings": {

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set ticket__1.php
@@ -24,14 +24,6 @@
     "tec-tickets-emails-ticket-subject": {
         "type": "text",
         "label": "Subject",
-        "default": "Your ticket from {site_title}",
-        "placeholder": "Your ticket from {site_title}",
-        "size": "large",
-        "validation_callback": "is_string"
-    },
-    "tec-tickets-emails-ticket-subject-plural": {
-        "type": "text",
-        "label": "Subject (plural)",
         "default": "Your tickets from {site_title}",
         "placeholder": "Your tickets from {site_title}",
         "size": "large",
@@ -40,16 +32,8 @@
     "tec-tickets-emails-ticket-heading": {
         "type": "text",
         "label": "Heading",
-        "default": "Here&#039;s your ticket, {attendee_name}!",
-        "placeholder": "Here&#039;s your ticket, {attendee_name}!",
-        "size": "large",
-        "validation_callback": "is_string"
-    },
-    "tec-tickets-emails-ticket-heading-plural": {
-        "type": "text",
-        "label": "Heading (plural)",
-        "default": "Here are your tickets, {attendee_name}!",
-        "placeholder": "Here are your tickets, {attendee_name}!",
+        "default": "Here&#039;s your tickets, {attendee_name}!",
+        "placeholder": "Here&#039;s your tickets, {attendee_name}!",
         "size": "large",
         "validation_callback": "is_string"
     },
@@ -57,6 +41,7 @@
         "type": "wysiwyg",
         "label": "Additional content",
         "default": "",
+        "size": "large",
         "tooltip": "Additional content will be displayed below the tickets in your email.",
         "validation_type": "html",
         "settings": {

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set completed-order__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set completed-order__1.php
@@ -39,6 +39,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -80,11 +82,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -95,9 +99,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -109,6 +114,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	.tec-tickets__email-table-content-event-title-container,
@@ -151,6 +211,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -192,11 +254,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -207,9 +271,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -221,6 +286,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	body {

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set purchase-receipt__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set purchase-receipt__1.php
@@ -39,6 +39,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -80,11 +82,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -95,9 +99,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -109,6 +114,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	.tec-tickets__email-table-content-event-title-container,
@@ -151,6 +211,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -192,11 +254,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -207,9 +271,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -221,6 +286,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	body {

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp-not-going__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp-not-going__1.php
@@ -39,6 +39,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -80,11 +82,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -95,9 +99,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -109,6 +114,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	.tec-tickets__email-table-content-event-title-container,
@@ -151,6 +211,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -192,11 +254,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -207,9 +271,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -221,6 +286,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	body {

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -39,6 +39,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -80,11 +82,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -95,9 +99,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -109,6 +114,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	.tec-tickets__email-table-content-event-title-container,
@@ -151,6 +211,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -192,11 +254,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -207,9 +271,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -221,6 +286,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	body {
@@ -557,7 +677,7 @@
 <tr>
 	<td>
 		<h1 class="tec-tickets__email-table-content-title">
-			Here&#039;s your ticket, John Doe!		</h1>
+			Here&#039;s your tickets, John Doe!		</h1>
 	</td>
 </tr>
 <tr>
@@ -632,22 +752,43 @@
 				</td>
 				<td class="tec-tickets__email-table-content-event-venue-phone-website-container">
 
-					<table role="presentation" style="width:100%;border-collapse:collapse;border:0;border-spacing:0;margin-bottom:18px">
+					<table role="presentation" class="tec-tickets__email-table-content-event-venue-address-table">
 	<tr>
-		<td style="display:inline-block;text-align:center;vertical-align:top;" valign="top" align="center">
+		<td class="tec-tickets__email-table-content-event-venue-phone-icon-container" valign="top" align="center">
 			<img
 				width="25"
 				height="24"
-				style="width:25px;height:24px;display:block;"
+				class="tec-tickets__email-table-content-event-venue-phone-icon-image"
 				src="http://wordpress.test/wp-content/plugins/the-events-calendar/src/resources/images/icons/bitmap/phone.png"
 			/>
 		</td>
-		<td style="padding:0;">
+		<td class="tec-tickets__email-table-content-event-venue-phone-container">
 			(555) 555-5555		</td>
 	</tr>
 </table>
 
-									</td>
+					<table role="presentation" class="tec-tickets__email-table-content-event-venue-website-table">
+	<tr>
+		<td class="tec-tickets__email-table-content-event-venue-website-icon-container" valign="top" align="center">
+			<img
+				width="24"
+				height="23"
+				class="tec-tickets__email-table-content-event-venue-website-icon-image"
+				src="http://wordpress.test/wp-content/plugins/the-events-calendar/src/resources/images/icons/bitmap/link.png"
+			/>
+		</td>
+		<td class="tec-tickets__email-table-content-event-venue-website-container">
+			<a
+				href="http://wordpress.test"
+				target="_blank"
+				rel="noopener noreferrer"
+				style="overflow-wrap: anywhere;"
+			>
+				http://wordpress.test			</a>
+		</td>
+	</tr>
+</table>
+				</td>
 			</tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -39,6 +39,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -80,11 +82,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -95,9 +99,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -109,6 +114,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	.tec-tickets__email-table-content-event-title-container,
@@ -151,6 +211,8 @@
 		font-weight: 400;
 		letter-spacing: 0px;
 		line-height: 23px;
+		margin: 0;
+		padding: 15px 0 0;
 		text-align: left;
 	}
 	.tec-tickets__email-table-content-event-image,
@@ -192,11 +254,13 @@
 	.tec-tickets__email-table-content-event-venue-address-table-container,
 	td.tec-tickets__email-table-content-event-venue-address-table-container {
 		padding: 12px 0 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-phone-website-container,
 	td.tec-tickets__email-table-content-event-venue-phone-website-container {
-		padding:0;
+		padding: 12px 0 0;
+		vertical-align: top;
 		width: 50%;
 	}
 	.tec-tickets__email-table-content-event-venue-address-table {
@@ -207,9 +271,10 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin-container,
 	td.tec-tickets__email-table-content-event-venue-address-pin-container {
-		display: inline-block;
-		text-align: center;
+		padding-right: 14px;
+		text-align: left;
 		vertical-align: top;
+		width: 20px;
 	}
 	.tec-tickets__email-table-content-event-venue-address-pin,
 	img.tec-tickets__email-table-content-event-venue-address-pin {
@@ -221,6 +286,61 @@
 	td.tec-tickets__email-table-content-event-venue-address-container {
 		padding: 0;
 		text-align: left;
+	}
+
+	.tec-tickets__email-table-content-event-venue-address-table,
+	table.tec-tickets__email-table-content-event-venue-address-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-container,
+	td.tec-tickets__email-table-content-event-venue-phone-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-icon-image {
+		display: block;
+		height: 24px;
+		width: 25px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-phone-container,
+	td.tec-tickets__email-table-content-event-venue-phone-container {
+		padding: 0;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-table,
+	table.tec-tickets__email-table-content-event-venue-website-table {
+		border: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-container,
+	td.tec-tickets__email-table-content-event-venue-website-icon-container {
+		padding-right: 14px;
+		text-align: left;
+		vertical-align: top;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-icon-image {
+		display: block;
+		height: 23px;
+		width: 24px;
+	}
+
+	.tec-tickets__email-table-content-event-venue-website-container,
+	td.tec-tickets__email-table-content-event-venue-website-container {
+		padding: 0;
 	}
 </style><style type="text/css">
 	body {
@@ -557,7 +677,7 @@
 <tr>
 	<td>
 		<h1 class="tec-tickets__email-table-content-title">
-			Here&#039;s your ticket, John Doe!		</h1>
+			Here&#039;s your tickets, John Doe!		</h1>
 	</td>
 </tr>
 <tr>
@@ -632,22 +752,43 @@
 				</td>
 				<td class="tec-tickets__email-table-content-event-venue-phone-website-container">
 
-					<table role="presentation" style="width:100%;border-collapse:collapse;border:0;border-spacing:0;margin-bottom:18px">
+					<table role="presentation" class="tec-tickets__email-table-content-event-venue-address-table">
 	<tr>
-		<td style="display:inline-block;text-align:center;vertical-align:top;" valign="top" align="center">
+		<td class="tec-tickets__email-table-content-event-venue-phone-icon-container" valign="top" align="center">
 			<img
 				width="25"
 				height="24"
-				style="width:25px;height:24px;display:block;"
+				class="tec-tickets__email-table-content-event-venue-phone-icon-image"
 				src="http://wordpress.test/wp-content/plugins/the-events-calendar/src/resources/images/icons/bitmap/phone.png"
 			/>
 		</td>
-		<td style="padding:0;">
+		<td class="tec-tickets__email-table-content-event-venue-phone-container">
 			(555) 555-5555		</td>
 	</tr>
 </table>
 
-									</td>
+					<table role="presentation" class="tec-tickets__email-table-content-event-venue-website-table">
+	<tr>
+		<td class="tec-tickets__email-table-content-event-venue-website-icon-container" valign="top" align="center">
+			<img
+				width="24"
+				height="23"
+				class="tec-tickets__email-table-content-event-venue-website-icon-image"
+				src="http://wordpress.test/wp-content/plugins/the-events-calendar/src/resources/images/icons/bitmap/link.png"
+			/>
+		</td>
+		<td class="tec-tickets__email-table-content-event-venue-website-container">
+			<a
+				href="http://wordpress.test"
+				target="_blank"
+				rel="noopener noreferrer"
+				style="overflow-wrap: anywhere;"
+			>
+				http://wordpress.test			</a>
+		</td>
+	</tr>
+</table>
+				</td>
 			</tr>
 		</table>
 	</td>


### PR DESCRIPTION
### 🎫 Ticket

N/A

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We're removing the 'plural' fields from both RSVP and Ticket emails. We're also setting the default subject and heading to use the plural word for tickets.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
- `TE-5808` - https://share.cleanshot.com/w4P1m3PP

Demo of fix: https://www.loom.com/share/61fefdcccc7548baacdb87cb0cd20153

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
