### PR TITLE
Fix - Misc php notices fixed.

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Gateway.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Gateway.php
@@ -209,7 +209,7 @@ class Gateway extends Abstract_Gateway {
 	 */
 	public function get_order_details_link_by_order( $order ) : string {
 		$status          = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
-		$payload         = $order->gateway_payload[ $status::SLUG ];
+		$payload         = isset( $order->gateway_payload[ $status::SLUG ] ) ? $order->gateway_payload[ $status::SLUG ] : end( $order->gateway_payload );
 		$capture_payload = end( $payload );
 		$link            = $this->get_dashboard_url_from_payload( $capture_payload );
 

--- a/src/Tickets/Emails/Admin/Preview_Modal.php
+++ b/src/Tickets/Emails/Admin/Preview_Modal.php
@@ -241,6 +241,7 @@ class Preview_Modal {
 		}
 
 		$preview_context['add_event_links'] = tribe_is_truthy( Arr::get( $vars, 'eventLinks', '' ) );
+		$preview_context['add_ar_fields']   = tribe_is_truthy( Arr::get( $vars, 'arFields', '' ) );
 
 		$current_email = Arr::get( $vars, 'currentEmail', '' );
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -324,7 +324,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			'must_login' => ! is_user_logged_in() && $this->login_required(),
 			'login_url'  => self::get_login_url( $post_id ),
 			'threshold'  => $blocks_rsvp->get_threshold( $post_id ),
-			'going'      => tribe_get_request_var( 'going', '' ),
+			'going'      => tribe_get_request_var( 'going', 'yes' ),
 		];
 
 		/**

--- a/src/resources/js/admin/tickets-emails.js
+++ b/src/resources/js/admin/tickets-emails.js
@@ -177,6 +177,11 @@ tribe.tickets.emails = {};
 
 			context.eventLinks = eventLinks;
 
+			const arFields = $document
+				.find( 'input[name=' + currentEmailOptionPrefix + '-include-ar-fields]' ).is( ':checked' );
+
+			context.arFields = arFields;
+
 			let addContent = '';
 
 			if (

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set ari__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set ari__1.php
@@ -108,7 +108,7 @@
 		<div class="tribe-tickets__rsvp-ar-form">
 
 	<input type="hidden" name="tribe_tickets[TICKET_ID][ticket_id]" value="TICKET_ID">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][order_status]" value="">
+	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][order_status]" value="yes">
 	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][optout]" value="1">
 
 	


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Added a failsafe to avoid showing notices on RSVP submissions. [ET-1612]
* Solved showing notices on Gateway Order ID link generation for Stripe when order status is not valid.
* Add Live Preview handler for Attendee Registration Fields.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1612]: https://theeventscalendar.atlassian.net/browse/ET-1612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ