### PR TITLE
[ET-1696] 'No provider message' does not display properly when providers are disabled.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - When no providers are enabled, a warning will display above the `New Ticket` and `New RSVP` area explaining that at least one must be enabled. [ET-1696]
+
 = [5.5.11.1] 2023-05-09 =
 
 * Fix - Admin Dashboard loading slowly while counting attendees. [ET-1698]

--- a/src/Tribe/Editor/Warnings.php
+++ b/src/Tribe/Editor/Warnings.php
@@ -55,7 +55,7 @@ class Warnings {
 			return;
 		}
 
-		$this->render_notice( $this->get_recurring_event_warning_message(), 'info', '#tribe-recurrence-active', 'checked' );
+		$this->render_notice( $this->get_recurring_event_warning_message(), 'info', '#tribe-recurrence-active', 'checked', [ 'recurring_event_warning' ] );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Warnings {
 			return;
 		}
 
-		$this->render_notice( $this->get_commerce_provider_missing_warning_message() );
+		$this->render_notice( $this->get_commerce_provider_missing_warning_message(), 'info', '', '', [ 'provider-warning' ] );
 	}
 
 	/**
@@ -121,20 +121,28 @@ class Warnings {
 	/**
 	 * Render the notice block.
 	 *
+	 * @since TBD added the `$additionalClasses` attribute to allow customizing the notice.
 	 * @since 5.0.4
 	 *
-	 * @param string $message Tee message to show.
-	 * @param string $type    Type of message.
-	 * @param string $depends_on Dependency selector.
-	 * @param string $condition Dependency condition like 'checked' | 'not-checked' | 'numeric'.
+	 * @param string $message           The message to show.
+	 * @param string $type              Type of message. Default is 'info'.
+	 * @param string $depends_on        Dependency selector. Default is empty.
+	 * @param string $condition         Dependency condition like 'checked' | 'not-checked' | 'numeric'. Default is empty.
+	 * @param array  $additionalClasses Additional CSS classes to add to the notice block. Default is an empty array.
 	 */
-	public function render_notice( $message, $type = 'info', $depends_on = '', $condition = '' ) {
+	public function render_notice( $message, $type = 'info', $depends_on = '', $condition = '', $additionalClasses = [] ) {
 		$icon           = 'dashicons-' . $type;
 		$has_dependency = empty( $depends_on ) ? '' : 'tribe-dependent';
-		$classes        = $type . ' ' . $has_dependency;
 		$condition_attr = empty( $condition ) ? '' : 'data-condition-is-' . $condition;
+
+		$classes = [
+			'ticket-editor-notice',
+			$type . ' ' . $has_dependency,
+		];
+		$classes = array_merge( $classes, $additionalClasses );
+
 		?>
-		<div class="ticket-editor-notice <?php echo esc_attr( $classes ); ?>"
+		<div <?php tribe_classes( $classes ); ?>
 			<?php if ( $depends_on ) { ?>
 				data-depends="<?php echo esc_attr( $depends_on ); ?>"
 			<?php } ?>
@@ -145,4 +153,5 @@ class Warnings {
 		</div>
 		<?php
 	}
+
 }

--- a/src/Tribe/Editor/Warnings.php
+++ b/src/Tribe/Editor/Warnings.php
@@ -139,7 +139,8 @@ class Warnings {
 
 		$classes = [
 			'ticket-editor-notice',
-			$type . ' ' . $has_dependency,
+			$type,
+			$has_dependency
 		];
 		$classes = array_merge( $classes, $additionalClasses );
 

--- a/src/Tribe/Editor/Warnings.php
+++ b/src/Tribe/Editor/Warnings.php
@@ -25,6 +25,7 @@ class Warnings {
 	/**
 	 * Show the Recurring Event warning message.
 	 *
+	 * @since TBD Added 'recurring_event_warning' as an $additionalClasses.
 	 * @since 5.0.4
 	 *
 	 * @param int $post_id Post ID.
@@ -61,6 +62,7 @@ class Warnings {
 	/**
 	 * Add Provider missing warning for tickets.
 	 *
+	 * @since TBD Added 'provider_warning' as an $additionalClasses.
 	 * @since 5.0.4
 	 */
 	public function add_commerce_provider_warning() {

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -852,7 +852,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			$( ticket_button_selectors ).hide();
 			$( ticket_button_selectors ).
 					parent().
-					find( '.ticket-editor-notice' ).
+					find( '.ticket-editor-notice.recurring_event_warning' ).
 					show();
 		} );
 
@@ -863,7 +863,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			$( ticket_button_selectors ).show();
 			$( ticket_button_selectors ).
 					parent().
-					find( '.ticket-editor-notice' ).
+					find( '.ticket-editor-notice.recurring_event_warning' ).
 					hide();
 		} );
 

--- a/tests/wpunit/Tribe/Editor/WarningsTest.php
+++ b/tests/wpunit/Tribe/Editor/WarningsTest.php
@@ -20,7 +20,6 @@ class WarningsTest extends \Codeception\TestCase\WPTestCase {
 		$warnings->render_notice( $message, $type, $depends_on, $condition, $additionalClasses );
 
 		$rendered = ob_get_clean();
-		codecept_debug( $rendered );
 		$this->assertMatchesSnapshot( $rendered );
 	}
 

--- a/tests/wpunit/Tribe/Editor/WarningsTest.php
+++ b/tests/wpunit/Tribe/Editor/WarningsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Tribe\Tickets\Editor\Warnings;
+use Spatie\Snapshots\MatchesSnapshots;
+use tad\WP\Snapshots\WPHtmlOutputDriver;
+
+class WarningsTest extends \Codeception\TestCase\WPTestCase {
+
+	use MatchesSnapshots;
+
+
+	/**
+	 * @test
+	 * @dataProvider notice_data_provider
+	 */
+	public function render_notice_display_correctly( $message, $type, $depends_on, $condition, $additionalClasses ) {
+		$warnings = new Warnings();
+
+		ob_start();
+		$warnings->render_notice( $message, $type, $depends_on, $condition, $additionalClasses );
+
+		$rendered = ob_get_clean();
+		codecept_debug( $rendered );
+		$this->assertMatchesSnapshot( $rendered );
+	}
+
+	/**
+	 * Data provider for render_notice_display_correctly test.
+	 *
+	 * @return Generator
+	 */
+	public function notice_data_provider() {
+		yield 'Test with blank message' => [
+			'message' => '',
+			'type' => 'info',
+			'depends_on' => '',
+			'condition' => '',
+			'additionalClasses' => []
+		];
+
+		yield 'Test with blank type' => [
+			'message' => 'Test message',
+			'type' => '',
+			'depends_on' => '',
+			'condition' => '',
+			'additionalClasses' => []
+		];
+
+		yield 'Test with blank depends_on' => [
+			'message' => 'Test message',
+			'type' => 'info',
+			'depends_on' => '',
+			'condition' => '',
+			'additionalClasses' => []
+		];
+
+		yield 'Test with blank condition' => [
+			'message' => 'Test message',
+			'type' => 'info',
+			'depends_on' => '',
+			'condition' => '',
+			'additionalClasses' => []
+		];
+
+		yield 'Test with blank additionalClasses' => [
+			'message' => 'Test message',
+			'type' => 'info',
+			'depends_on' => '',
+			'condition' => '',
+			'additionalClasses' => []
+		];
+
+		yield 'Test with all values filled' => [
+			'message' => 'Another message',
+			'type' => 'warning',
+			'depends_on' => '#element-id',
+			'condition' => 'checked',
+			'additionalClasses' => [ 'class1', 'class2' ]
+		];
+
+	}
+}

--- a/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with all values filled__1.php
+++ b/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with all values filled__1.php
@@ -1,0 +1,6 @@
+<?php return '		<div  class="ticket-editor-notice warning tribe-dependent class1 class2" 							data-depends="#element-id"
+						data-condition-is-checked		>
+			<span class="dashicons dashicons-warning"></span>
+			<span class="message">Another message</span>
+		</div>
+		';

--- a/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank additionalClasses__1.php
+++ b/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank additionalClasses__1.php
@@ -1,0 +1,5 @@
+<?php return '		<div  class="ticket-editor-notice info" 								>
+			<span class="dashicons dashicons-info"></span>
+			<span class="message">Test message</span>
+		</div>
+		';

--- a/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank condition__1.php
+++ b/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank condition__1.php
@@ -1,0 +1,5 @@
+<?php return '		<div  class="ticket-editor-notice info" 								>
+			<span class="dashicons dashicons-info"></span>
+			<span class="message">Test message</span>
+		</div>
+		';

--- a/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank depends_on__1.php
+++ b/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank depends_on__1.php
@@ -1,0 +1,5 @@
+<?php return '		<div  class="ticket-editor-notice info" 								>
+			<span class="dashicons dashicons-info"></span>
+			<span class="message">Test message</span>
+		</div>
+		';

--- a/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank message__1.php
+++ b/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank message__1.php
@@ -1,0 +1,5 @@
+<?php return '		<div  class="ticket-editor-notice info" 								>
+			<span class="dashicons dashicons-info"></span>
+			<span class="message"></span>
+		</div>
+		';

--- a/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank type__1.php
+++ b/tests/wpunit/Tribe/Editor/__snapshots__/WarningsTest__render_notice_display_correctly with data set Test with blank type__1.php
@@ -1,0 +1,5 @@
+<?php return '		<div  class="ticket-editor-notice" 								>
+			<span class="dashicons dashicons-"></span>
+			<span class="message">Test message</span>
+		</div>
+		';


### PR DESCRIPTION
### 🎫 Ticket

[ET-1696] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
The original ticket outlined that the warning "no providers displayed" wasn't showing. Upon inspection I found that the Jquery code found within `tickets.js` was hiding anything with the class `.ticket-editor-notice`. The issue was that both notifications that we display have this class. 
I have gone ahead and added an `$additionalClass` parameters to the function so that we can further pinpoint which warning message we want to target.
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
Displaying the proper message - 
![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/a6887fb9-1224-4ab8-9ede-c1c788ba2382)

Showing the additional classes added - 
![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/66d1833b-473d-4f19-a242-36ea51572f9d)

Showing the messages when "Add More Events" for recurring events are clicked.
![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/32124606-11fd-4822-a64d-7a29b76bd0f9)


<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1696]: https://theeventscalendar.atlassian.net/browse/ET-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ