### PR TITLE
[ET-1631] When no providers are enabled "New Tickets" button HTML is broken

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - When no providers are enabled, a warning will display above the `New Ticket` and `New RSVP` area explaining that at least one must be enabled. [ET-1696]
+* Fix - Corrected an issue with the `New ticket` button having invalid HTML. [ET-1631]
 
 = [5.5.11.1] 2023-05-09 =
 

--- a/src/admin-views/editor/panel/list.php
+++ b/src/admin-views/editor/panel/list.php
@@ -71,7 +71,7 @@ $add_new_ticket_label = count( $ticket_providing_modules ) > 0
 			id="ticket_form_toggle"
 			class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 			aria-label="<?php echo $add_new_ticket_label ?>"
-			"<?php echo disabled( count( $ticket_providing_modules ) === 0 ) ?>"
+			<?php echo disabled( count( $ticket_providing_modules ) === 0 ) ?>
 		>
 		<?php
 		echo esc_html(


### PR DESCRIPTION
### 🎫 Ticket

[ET-1631] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
When no providers are enabled the HTML on the "New Tickets" button is broken. This was because the `disabled` method automatically adds the correct double quotes. So the extra set was unneeded.
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/924c9e5f-fcd3-4a56-bf05-e85dad77fcb8)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
