### PR TITLE
Tickets Emails: RSVP should use Ticket context when applicable

### DIFF
--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -49,7 +49,7 @@ class RSVP extends Email_Abstract {
 	 * @var string
 	 */
 	public $template = 'rsvp';
-	
+
 	/**
 	 * Get email title.
 	 *
@@ -250,7 +250,6 @@ class RSVP extends Email_Abstract {
 	 * @return array $args The default arguments
 	 */
 	public function get_default_template_context(): array {
-		
 		$defaults = [
 			'email'              => $this,
 			'title'              => $this->get_title(),
@@ -260,7 +259,7 @@ class RSVP extends Email_Abstract {
 			'post_id'            => $this->get( 'post_id' ),
 			'json_ld'            => Reservation_Schema::build_from_email( $this ),
 		];
-		
+
 		if ( $this->is_using_ticket_email_settings() ) {
 			$ticket = tribe( Ticket::class );
 			$defaults['heading']            = $ticket->get_heading();

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -49,7 +49,7 @@ class RSVP extends Email_Abstract {
 	 * @var string
 	 */
 	public $template = 'rsvp';
-
+	
 	/**
 	 * Get email title.
 	 *
@@ -239,12 +239,6 @@ class RSVP extends Email_Abstract {
 	 */
 	public function get_default_template_context(): array {
 		
-		if ( $this->is_using_ticket_email_settings() ) {
-			$context = tribe( Ticket::class )->get_default_template_context();
-			$context['email'] = $this;
-			return $context;
-		}
-		
 		$defaults = [
 			'email'              => $this,
 			'title'              => $this->get_title(),
@@ -254,6 +248,12 @@ class RSVP extends Email_Abstract {
 			'post_id'            => $this->get( 'post_id' ),
 			'json_ld'            => Reservation_Schema::build_from_email( $this ),
 		];
+		
+		if ( $this->is_using_ticket_email_settings() ) {
+			$ticket = tribe( Ticket::class );
+			$defaults['heading']            = $ticket->get_heading();
+			$defaults['additional_content'] = $ticket->get_additional_content();
+		}
 
 		return $defaults;
 	}

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -104,6 +104,18 @@ class RSVP extends Email_Abstract {
 		// If they already had a subject set in Tickets Commerce, let's make it the default.
 		return tribe_get_option( Settings::$option_confirmation_email_subject, $default_subject );
 	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function get_subject(): ?string {
+		// Send ticket subject if using ticket settings.
+		if ( $this->is_using_ticket_email_settings() ) {
+			return tribe( Ticket::class )->get_subject();
+		}
+		
+		return parent::get_subject();
+	}
 
 	/**
 	 * Get email settings fields.

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -238,6 +238,11 @@ class RSVP extends Email_Abstract {
 	 * @return array $args The default arguments
 	 */
 	public function get_default_template_context(): array {
+		
+		if ( $this->is_using_ticket_email_settings() ) {
+			return tribe( Ticket::class )->get_default_template_context();
+		}
+		
 		$defaults = [
 			'email'              => $this,
 			'title'              => $this->get_title(),

--- a/src/Tickets/Emails/Email/RSVP.php
+++ b/src/Tickets/Emails/Email/RSVP.php
@@ -240,7 +240,9 @@ class RSVP extends Email_Abstract {
 	public function get_default_template_context(): array {
 		
 		if ( $this->is_using_ticket_email_settings() ) {
-			return tribe( Ticket::class )->get_default_template_context();
+			$context = tribe( Ticket::class )->get_default_template_context();
+			$context['email'] = $this;
+			return $context;
 		}
 		
 		$defaults = [

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -17,12 +17,13 @@
 		border: 0;
 		border-collapse: collapse;
 		border-spacing: 0;
+		margin-bottom: 30px;
 		width: 100%;
 	}
 
 	.tec-tickets__email-table-content-event-links-table-data,
 	td.tec-tickets__email-table-content-event-links-table-data {
-		padding: 30px 10px;
+		padding: 0 10px;
 		text-align: center;
 		width: 100%;
 	}
@@ -35,6 +36,7 @@
 	}
 
 	.tec-tickets__email-table-content-event-date {
+		color: #141827;
 		font-size: 14px;
 		font-weight: 400;
 		letter-spacing: 0px;
@@ -57,19 +59,22 @@
 		background: transparent;
 		color: #141827;
 		font-size: 16px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0;
 		padding: 0;
 	}
 	.tec-tickets__email-table-content-event-venue-container,
 	td.tec-tickets__email-table-content-event-venue-container {
 		border: 1px solid #d5d5d5;
+		display: block;
 		padding: 25px;
+		margin-bottom: 30px;
 	}
 	.tec-tickets__email-table-content-event-venue-name {
 		background: transparent;
+		color: #141827;
 		font-size: 18px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0; 
 		padding: 0;
 	}
@@ -112,6 +117,7 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-container,
 	td.tec-tickets__email-table-content-event-venue-address-container {
+		color: #141827;
 		padding: 0;
 		text-align: left;
 	}
@@ -141,6 +147,7 @@
 
 	.tec-tickets__email-table-content-event-venue-phone-container,
 	td.tec-tickets__email-table-content-event-venue-phone-container {
+		color: #141827;
 		padding: 0;
 	}
 
@@ -168,10 +175,12 @@
 
 	.tec-tickets__email-table-content-event-venue-website-container,
 	td.tec-tickets__email-table-content-event-venue-website-container {
+		color: #141827;
 		padding: 0;
 	}
 	
 	h3.tec-tickets__email-table-content-event-title a {
+		color: #141827;
 		text-decoration: none;
 	}
 </style><style type="text/css">

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -17,12 +17,13 @@
 		border: 0;
 		border-collapse: collapse;
 		border-spacing: 0;
+		margin-bottom: 30px;
 		width: 100%;
 	}
 
 	.tec-tickets__email-table-content-event-links-table-data,
 	td.tec-tickets__email-table-content-event-links-table-data {
-		padding: 30px 10px;
+		padding: 0 10px;
 		text-align: center;
 		width: 100%;
 	}
@@ -35,6 +36,7 @@
 	}
 
 	.tec-tickets__email-table-content-event-date {
+		color: #141827;
 		font-size: 14px;
 		font-weight: 400;
 		letter-spacing: 0px;
@@ -57,19 +59,22 @@
 		background: transparent;
 		color: #141827;
 		font-size: 16px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0;
 		padding: 0;
 	}
 	.tec-tickets__email-table-content-event-venue-container,
 	td.tec-tickets__email-table-content-event-venue-container {
 		border: 1px solid #d5d5d5;
+		display: block;
 		padding: 25px;
+		margin-bottom: 30px;
 	}
 	.tec-tickets__email-table-content-event-venue-name {
 		background: transparent;
+		color: #141827;
 		font-size: 18px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0; 
 		padding: 0;
 	}
@@ -112,6 +117,7 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-container,
 	td.tec-tickets__email-table-content-event-venue-address-container {
+		color: #141827;
 		padding: 0;
 		text-align: left;
 	}
@@ -141,6 +147,7 @@
 
 	.tec-tickets__email-table-content-event-venue-phone-container,
 	td.tec-tickets__email-table-content-event-venue-phone-container {
+		color: #141827;
 		padding: 0;
 	}
 
@@ -168,10 +175,12 @@
 
 	.tec-tickets__email-table-content-event-venue-website-container,
 	td.tec-tickets__email-table-content-event-venue-website-container {
+		color: #141827;
 		padding: 0;
 	}
 	
 	h3.tec-tickets__email-table-content-event-title a {
+		color: #141827;
 		text-decoration: none;
 	}
 </style><style type="text/css">

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -17,12 +17,13 @@
 		border: 0;
 		border-collapse: collapse;
 		border-spacing: 0;
+		margin-bottom: 30px;
 		width: 100%;
 	}
 
 	.tec-tickets__email-table-content-event-links-table-data,
 	td.tec-tickets__email-table-content-event-links-table-data {
-		padding: 30px 10px;
+		padding: 0 10px;
 		text-align: center;
 		width: 100%;
 	}
@@ -35,6 +36,7 @@
 	}
 
 	.tec-tickets__email-table-content-event-date {
+		color: #141827;
 		font-size: 14px;
 		font-weight: 400;
 		letter-spacing: 0px;
@@ -57,19 +59,22 @@
 		background: transparent;
 		color: #141827;
 		font-size: 16px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0;
 		padding: 0;
 	}
 	.tec-tickets__email-table-content-event-venue-container,
 	td.tec-tickets__email-table-content-event-venue-container {
 		border: 1px solid #d5d5d5;
+		display: block;
 		padding: 25px;
+		margin-bottom: 30px;
 	}
 	.tec-tickets__email-table-content-event-venue-name {
 		background: transparent;
+		color: #141827;
 		font-size: 18px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0; 
 		padding: 0;
 	}
@@ -112,6 +117,7 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-container,
 	td.tec-tickets__email-table-content-event-venue-address-container {
+		color: #141827;
 		padding: 0;
 		text-align: left;
 	}
@@ -141,6 +147,7 @@
 
 	.tec-tickets__email-table-content-event-venue-phone-container,
 	td.tec-tickets__email-table-content-event-venue-phone-container {
+		color: #141827;
 		padding: 0;
 	}
 
@@ -168,10 +175,12 @@
 
 	.tec-tickets__email-table-content-event-venue-website-container,
 	td.tec-tickets__email-table-content-event-venue-website-container {
+		color: #141827;
 		padding: 0;
 	}
 	
 	h3.tec-tickets__email-table-content-event-title a {
+		color: #141827;
 		text-decoration: none;
 	}
 </style><style type="text/css">

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -17,12 +17,13 @@
 		border: 0;
 		border-collapse: collapse;
 		border-spacing: 0;
+		margin-bottom: 30px;
 		width: 100%;
 	}
 
 	.tec-tickets__email-table-content-event-links-table-data,
 	td.tec-tickets__email-table-content-event-links-table-data {
-		padding: 30px 10px;
+		padding: 0 10px;
 		text-align: center;
 		width: 100%;
 	}
@@ -35,6 +36,7 @@
 	}
 
 	.tec-tickets__email-table-content-event-date {
+		color: #141827;
 		font-size: 14px;
 		font-weight: 400;
 		letter-spacing: 0px;
@@ -57,19 +59,22 @@
 		background: transparent;
 		color: #141827;
 		font-size: 16px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0;
 		padding: 0;
 	}
 	.tec-tickets__email-table-content-event-venue-container,
 	td.tec-tickets__email-table-content-event-venue-container {
 		border: 1px solid #d5d5d5;
+		display: block;
 		padding: 25px;
+		margin-bottom: 30px;
 	}
 	.tec-tickets__email-table-content-event-venue-name {
 		background: transparent;
+		color: #141827;
 		font-size: 18px;
-		font-weight: 700;
+		font-weight: 700 !important;
 		margin: 0; 
 		padding: 0;
 	}
@@ -112,6 +117,7 @@
 	}
 	.tec-tickets__email-table-content-event-venue-address-container,
 	td.tec-tickets__email-table-content-event-venue-address-container {
+		color: #141827;
 		padding: 0;
 		text-align: left;
 	}
@@ -141,6 +147,7 @@
 
 	.tec-tickets__email-table-content-event-venue-phone-container,
 	td.tec-tickets__email-table-content-event-venue-phone-container {
+		color: #141827;
 		padding: 0;
 	}
 
@@ -168,10 +175,12 @@
 
 	.tec-tickets__email-table-content-event-venue-website-container,
 	td.tec-tickets__email-table-content-event-venue-website-container {
+		color: #141827;
 		padding: 0;
 	}
 	
 	h3.tec-tickets__email-table-content-event-title a {
+		color: #141827;
 		text-decoration: none;
 	}
 </style><style type="text/css">


### PR DESCRIPTION
### 🎫 Ticket

TE-3389 <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
All of the RSVP settings were being used when the email was sent even when they should have been using the Ticket settings. I found that we weren't setting the context correctly.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/a170981e137440cb8cb82f55750afcd0

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
