### PR TITLE
[TE-31DB] Fix - Apply contrast text color for live preview.

### DIFF
--- a/src/Tickets/Emails/Admin/Preview_Modal.php
+++ b/src/Tickets/Emails/Admin/Preview_Modal.php
@@ -189,7 +189,8 @@ class Preview_Modal {
 		$ticket_bg_color = Arr::get( $vars, 'ticketBgColor', '' );
 
 		if ( ! empty( $ticket_bg_color ) ) {
-			$preview_context['ticket_bg_color'] = wp_kses( $ticket_bg_color, [] );
+			$preview_context['ticket_bg_color']   = wp_kses( $ticket_bg_color, [] );
+			$preview_context['ticket_text_color'] = \Tribe__Utils__Color::get_contrast_color( $preview_context['ticket_bg_color'] );
 		}
 
 		$footer_content = Arr::get( $vars, 'footerContent', '' );
@@ -207,7 +208,8 @@ class Preview_Modal {
 		$header_bg_color = Arr::get( $vars, 'headerBgColor', '' );
 
 		if ( ! empty( $header_bg_color ) ) {
-			$preview_context['header_bg_color'] = wp_kses( $header_bg_color, [] );
+			$preview_context['header_bg_color']   = wp_kses( $header_bg_color, [] );
+			$preview_context['header_text_color'] = \Tribe__Utils__Color::get_contrast_color( $preview_context['header_bg_color'] );
 		}
 
 		$header_img_url = Arr::get( $vars, 'headerImageUrl', '' );


### PR DESCRIPTION
### 🎫 Ticket

[TE-31DB] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Live preview was not showing the adjusted contrast Text Color, but in the real email it shows up. Now the live preview matches with real email.
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
