### PR TITLE
Tickets Emails Issue TE-DECF: Add Space Below Not Going Text

### DIFF
--- a/src/views/emails/rsvp-not-going/body.php
+++ b/src/views/emails/rsvp-not-going/body.php
@@ -30,7 +30,7 @@ $this->template( 'template-parts/body/title' );
 ?>
 
 <tr>
-	<td>
+	<td class="tec-tickets__email-table-content-not-going-confirmation-container">
 		<?php echo esc_html( __( 'Thank you for confirming that you will not be attending.', 'event-tickets' ) ); ?>
 	</td>
 </tr>

--- a/src/views/emails/template-parts/header/head/styles.php
+++ b/src/views/emails/template-parts/header/head/styles.php
@@ -352,4 +352,9 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set completed-order__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set completed-order__1.php
@@ -320,6 +320,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set purchase-receipt__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set purchase-receipt__1.php
@@ -320,6 +320,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp-not-going__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp-not-going__1.php
@@ -320,6 +320,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 
@@ -345,7 +350,7 @@
 </tr>
 
 <tr>
-	<td>
+	<td class="tec-tickets__email-table-content-not-going-confirmation-container">
 		Thank you for confirming that you will not be attending.	</td>
 </tr>
 

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -505,6 +505,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -505,6 +505,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set completed-order__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set completed-order__1.php
@@ -320,6 +320,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set purchase-receipt__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set purchase-receipt__1.php
@@ -320,6 +320,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp-not-going__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp-not-going__1.php
@@ -320,6 +320,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 
@@ -345,7 +350,7 @@
 </tr>
 
 <tr>
-	<td>
+	<td class="tec-tickets__email-table-content-not-going-confirmation-container">
 		Thank you for confirming that you will not be attending.	</td>
 </tr>
 

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -505,6 +505,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -505,6 +505,11 @@
 		font-size: 16px !important;
 		line-height: 1.5;
 	}
+
+	.tec-tickets__email-table-content-not-going-confirmation-container,
+	td.tec-tickets__email-table-content-not-going-confirmation-container {
+		padding-bottom: 30px;
+	}
 </style>
 <div class="tec-tickets__email-body">
 


### PR DESCRIPTION
### 🎫 Ticket/Issue

TE-DECF <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
The `RSVP Not Going` email got overlooked when working on this issue before. We just needed to add some padding below the 'Not Going' text, which appears above the Additional content.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

Before:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/295fe249-c89e-40aa-b03f-d24ad2aa9253)

After:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/3551bea5-a261-4265-aa29-e88c45af8593)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
