### PR TITLE
Improvements to site_address and site_url placeholders for Emails.

### DIFF
--- a/src/Tickets/Emails/Admin/Preview_Data.php
+++ b/src/Tickets/Emails/Admin/Preview_Data.php
@@ -314,6 +314,7 @@ class Preview_Data {
 			'{attendee_name}'  => $tickets[0]['purchaser_name'],
 			'{attendee_email}' => $tickets[0]['purchaser_email'],
 			'{order_number}'   => $order->ID,
+			'{order_id}'       => $order->ID,
 		];
 		return wp_parse_args( $args, $default );
 	}

--- a/src/Tickets/Emails/Admin/Preview_Modal.php
+++ b/src/Tickets/Emails/Admin/Preview_Modal.php
@@ -271,6 +271,8 @@ class Preview_Modal {
 			$email_class->set( $key, $template_var_value );
 		}
 
+		$email_class->set( 'post_id', Preview_Data::get_post()->ID );
+
 		add_filter( 'tribe_is_event', '__return_true' );
 
 		$html  = $email_class->get_content();

--- a/src/Tickets/Emails/Admin/Preview_Modal.php
+++ b/src/Tickets/Emails/Admin/Preview_Modal.php
@@ -271,7 +271,12 @@ class Preview_Modal {
 			$email_class->set( $key, $template_var_value );
 		}
 
+		add_filter( 'tribe_is_event', '__return_true' );
+
 		$html  = $email_class->get_content();
+
+		remove_filter( 'tribe_is_event', '__return_true' );
+
 		$html .= $tickets_template->template( 'v2/components/loader/loader', [], false );
 		return $html;
 	}

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -118,7 +118,7 @@ abstract class Email_Abstract {
 
 		$default_placeholders = [
 			'{site_title}'   => $this->get_blogname(),
-			'{site_address}' => $url_parts['host'] . $url_parts['path'] ?: '/',
+			'{site_address}' => $url_parts['host'] . ! empty( $url_parts['path'] ) ? $url_parts['path'] : '',
 			'{site_url}'     => $home_url,
 		];
 

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -113,15 +113,17 @@ abstract class Email_Abstract {
 	 * @since 5.5.9
 	 */
 	public function hook() {
+		$home_url  = home_url();
+		$url_parts = wp_parse_url( $home_url );
+
 		$default_placeholders = [
 			'{site_title}'   => $this->get_blogname(),
-			'{site_address}' => wp_parse_url( home_url(), PHP_URL_HOST ),
-			'{site_url}'     => wp_parse_url( home_url(), PHP_URL_HOST ),
+			'{site_address}' => $url_parts['host'] . $url_parts['path'] ?: '/',
+			'{site_url}'     => $home_url,
 		];
 
 		$this->set_placeholders( $default_placeholders );
 	}
-
 
 
 	/**

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -118,7 +118,7 @@ abstract class Email_Abstract {
 
 		$default_placeholders = [
 			'{site_title}'   => $this->get_blogname(),
-			'{site_address}' => $url_parts['host'] . ! empty( $url_parts['path'] ) ? $url_parts['path'] : '',
+			'{site_address}' => $url_parts['host'] . ( ! empty( $url_parts['path'] ) ? $url_parts['path'] : '' ),
 			'{site_url}'     => $home_url,
 		];
 


### PR DESCRIPTION
Feedback from David from DQA, led me to find this problem.

* `{site_address}` = `example.com/my-site`
* `{site_url}` = `https://example.com/my-site`