### PR TITLE
TE-7ACB Tickets Emails: Set Additional Content Field Sizes to Large

### DIFF
--- a/src/Tickets/Emails/Email/Completed_Order.php
+++ b/src/Tickets/Emails/Email/Completed_Order.php
@@ -174,6 +174,7 @@ class Completed_Order extends Email_Abstract {
 				'label'               => esc_html__( 'Additional content', 'event-tickets' ),
 				'default'             => $this->get_default_additional_content(),
 				'tooltip'             => esc_html__( 'Additional content will be displayed below the order details.', 'event-tickets' ),
+				'size'                => 'large',
 				'validation_type'     => 'html',
 				'settings'        => [
 					'media_buttons' => false,

--- a/src/Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Tickets/Emails/Email/Purchase_Receipt.php
@@ -156,6 +156,7 @@ class Purchase_Receipt extends Email_Abstract {
 				'label'               => esc_html__( 'Additional content', 'event-tickets' ),
 				'default'             => '',
 				'tooltip'             => esc_html__( 'Additional content will be displayed below the purchase receipt details in the email.', 'event-tickets' ),
+				'size'                => 'large',
 				'validation_type'     => 'html',
 				'settings'        => [
 					'media_buttons' => false,

--- a/src/Tickets/Emails/Email/RSVP_Not_Going.php
+++ b/src/Tickets/Emails/Email/RSVP_Not_Going.php
@@ -158,6 +158,7 @@ class RSVP_Not_Going extends Email_Abstract {
 				'label'           => esc_html__( 'Additional content', 'event-tickets' ),
 				'default'         => '',
 				'tooltip'         => esc_html__( 'Additional content will be displayed below the information in your email.', 'event-tickets' ),
+				'size'            => 'large',
 				'validation_type' => 'html',
 				'settings'        => [
 					'media_buttons' => false,

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set completed-order__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set completed-order__1.php
@@ -49,6 +49,7 @@
         "label": "Additional content",
         "default": "",
         "tooltip": "Additional content will be displayed below the order details.",
+        "size": "large",
         "validation_type": "html",
         "settings": {
             "media_buttons": false,

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set purchase-receipt__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set purchase-receipt__1.php
@@ -42,6 +42,7 @@
         "label": "Additional content",
         "default": "",
         "tooltip": "Additional content will be displayed below the purchase receipt details in the email.",
+        "size": "large",
         "validation_type": "html",
         "settings": {
             "media_buttons": false,

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set rsvp-not-going__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Emails_TabTest__it_should_match_stored_json_for_settings with data set rsvp-not-going__1.php
@@ -42,6 +42,7 @@
         "label": "Additional content",
         "default": "",
         "tooltip": "Additional content will be displayed below the information in your email.",
+        "size": "large",
         "validation_type": "html",
         "settings": {
             "media_buttons": false,


### PR DESCRIPTION
### 🎫 Ticket/Issue

TE-7ACB <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Only Ticket and RSVP had the additional content fields set to large. This PR sets them for the other 3 emails.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

Before:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/9b961fb1-e12b-4fe5-9533-98cb4ac0873f)

After:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/b5e34590-100e-4c13-a84a-2773749289e3)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
