### PR TITLE
Let ET add itself to the list of plugins that are loaded by Telemetry.

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -335,6 +335,8 @@ class Tribe__Tickets__Main {
 		 */
 		$this->init_autoloading();
 
+		add_filter( 'tec_common_parent_plugin_file', [ $this, 'include_parent_plugin_path_to_common' ] );
+
 		// Start Up Common.
 		Tribe__Main::instance();
 
@@ -342,6 +344,22 @@ class Tribe__Tickets__Main {
 
 		// Admin home.
 		tribe_register_provider( Tribe\Tickets\Admin\Home\Service_Provider::class );
+	}
+
+	/**
+	 * Adds our main plugin file to the list of paths.
+	 *
+	 * @since 6.1.0
+	 *
+	 *
+	 * @param array<string> $paths The paths to TCMN parent plugins.
+	 *
+	 * @return array<string>
+	 */
+	public function include_parent_plugin_path_to_common( $paths ): array {
+		$paths[] = EVENT_TICKETS_MAIN_PLUGIN_FILE;
+
+		return $paths;
 	}
 
 	/**


### PR DESCRIPTION
This prevents an empty 'tec' entry being saved.
This does not add ET as "itself" only a preventative measure. 
[Changes in Common](https://github.com/the-events-calendar/tribe-common/pull/1940) handle cleaning up the empty entry.

[BTRIA-1885]