### PR TITLE
[ET-760] Add Duplicate Post logic into ET/ET+

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -196,7 +196,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Enhancement - Add notice about the availability of Paystack for Tickets Commerce. [ET-1764]
 * Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made. [ET-1736]
 * Enhancement - Refactored CSS for Tickets Emails to better conform to email client CSS standards. [ET-1802]
-* Enhancement - Integrated Yoast Duplicate Post for seamless duplication of events, including ticket cloning. [ET-760]
+* Enhancement - Integrated Yoast Duplicate Post for seamless duplication of tickets, while cloning events. [ET-760]
 * Fix - Ticketed Commerce events will now be accurately categorized and counted under the ticketed tab in the Dashboard Event List. [ET-1774]
 * Fix - The attendee export functionality for old converted recurring events has been improved to accurately export attendees. [ET-1739]
 * Fix - The Attendee List will now be correctly displayed when the 'Show attendees list on event page' option is enabled within the classic editor.  [ETP-623]

--- a/readme.txt
+++ b/readme.txt
@@ -193,7 +193,6 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-
 * Enhancement - Add notice about the availability of Paystack for Tickets Commerce. [ET-1764]
 * Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made. [ET-1736]
 * Enhancement - Refactored CSS for Tickets Emails to better conform to email client CSS standards. [ET-1802]

--- a/readme.txt
+++ b/readme.txt
@@ -193,9 +193,11 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+
+* Enhancement - Add notice about the availability of Paystack for Tickets Commerce. [ET-1764]
+* Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made. [ET-1736]
+* Enhancement - Refactored CSS for Tickets Emails to better conform to email client CSS standards. [ET-1802]
 * Enhancement - Integrated Yoast Duplicate Post for seamless duplication of events, including ticket cloning. [ET-760]
-* Enhancement - Add notice about the availability of Paystack for Tickets Commerce [ET-1764]
-* Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made [ET-1736]
 
 = [5.6.2] 2023-06-29 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -193,7 +193,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-
+* Enhancement - Integrated Yoast Duplicate Post for seamless duplication of events, including ticket cloning. [ET-760]
 
 = [5.6.2] 2023-06-29 =
 

--- a/src/Tickets/Integrations/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Duplicate_Post.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Class Duplicate_Post
+ *
+ * Handles the duplication of tickets to new posts.
+ */
+
+namespace TEC\Tickets\Integrations;
+
+use \TEC\Common\Contracts\Service_Provider;
+use TEC\Tickets\Commerce\Module;
+use Tribe__Tickets__Tickets;
+
+class Duplicate_Post extends Service_Provider {
+
+	/**
+	 * Binds and sets up implementations.
+	 *
+	 * @since TBD
+	 */
+	public function register() {
+		$this->hooks();
+	}
+
+	/**
+	 * Hook into actions for duplicating posts and pages.
+	 *
+	 * @since TBD
+	 */
+	public function hooks() {
+		add_action( 'dp_duplicate_post', [ $this, 'duplicate_tickets_to_new_post' ], 10, 3 );
+		add_action( 'dp_duplicate_page', [ $this, 'duplicate_tickets_to_new_post' ], 10, 3 );
+	}
+
+	/**
+	 * Duplicate tickets to a new post.
+	 *
+	 * @param int    $new_post_id ID of the new post.
+	 * @param object $post        Original post object.
+	 * @param string $status      Duplicate status.
+	 *
+	 * @return int|WP_Error $new_post_id New post ID or WP_Error object on failure.
+	 */
+	public function duplicate_tickets_to_new_post( $new_post_id, $post, $status ) {
+		/**
+		 * @todo Fix this logic, maybe it will be possible to find the provider straight from the post instead of getting the first ticket the way I'm doing it now.
+		 *  I should also try to figure out the best way for ET+ to hook into this for when woo/EDD is being used instead.
+		 */
+// For Tickets Commerce
+		$ticket_ids = (array)tribe( Module::class )->get_tickets_ids( $post );
+// For WooCommerce
+		$ticket_ids = tribe( 'tickets-plus.commerce.woo' )->get_tickets_ids( $post->ID );
+// For EDD
+		$ticket_ids = tribe( 'tickets-plus.commerce.edd' )->get_tickets_ids( $post->ID );
+
+		// If we have no tickets, return the new post ID.
+		if ( empty( $ticket_ids ) ) {
+			return $new_post_id;
+		}
+
+		// Since all providers for tickets should be the same, we check the first provider.
+		$provider = tribe_tickets_get_ticket_provider( $ticket_ids[ 0 ] );
+
+
+
+
+		if ( empty( $provider ) || ! $provider instanceof Tribe__Tickets__Tickets ) {
+			return new WP_Error(
+				'bad_request',
+				__( 'Commerce Module invalid', 'event-tickets' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$new_ticket_ids = [];
+
+		foreach ( $ticket_ids as $ticket_id ) {
+			$duplicate_ticket_id = $provider->clone_ticket_to_new_post( $post->ID, $new_post_id, $ticket_id );
+
+			if ( false===$duplicate_ticket_id ) {
+				// Handle failure to create duplicate ticket for this specific ticket.
+				$new_ticket_ids[] = new WP_Error(
+					'bad_request',
+					__( 'Failed to create duplicate ticket for ticket ID: ', 'event-tickets' ) . $ticket_id,
+					[ 'status' => 400 ]
+				);
+			} else {
+				$new_ticket_ids[] = $duplicate_ticket_id;
+			}
+		}
+
+		return $new_post_id;
+	}
+}

--- a/src/Tickets/Integrations/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Duplicate_Post.php
@@ -36,6 +36,8 @@ class Duplicate_Post extends Service_Provider {
 	/**
 	 * Duplicate tickets to a new post.
 	 *
+	 * @since TBD
+	 *
 	 * @param int    $new_post_id ID of the new post.
 	 * @param object $post        Original post object.
 	 *

--- a/src/Tickets/Integrations/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Duplicate_Post.php
@@ -29,8 +29,8 @@ class Duplicate_Post extends Service_Provider {
 	 * @since TBD
 	 */
 	public function hooks() {
-		add_action( 'dp_duplicate_post', [ $this, 'duplicate_tickets_to_new_post' ], 10, 3 );
-		add_action( 'dp_duplicate_page', [ $this, 'duplicate_tickets_to_new_post' ], 10, 3 );
+		add_action( 'dp_duplicate_post', [ $this, 'duplicate_tickets_to_new_post' ], 10, 2 );
+		add_action( 'dp_duplicate_page', [ $this, 'duplicate_tickets_to_new_post' ], 10, 2 );
 	}
 
 	/**
@@ -38,11 +38,10 @@ class Duplicate_Post extends Service_Provider {
 	 *
 	 * @param int    $new_post_id ID of the new post.
 	 * @param object $post        Original post object.
-	 * @param string $status      Duplicate status.
 	 *
 	 * @return int|WP_Error $new_post_id New post ID or WP_Error object on failure.
 	 */
-	public function duplicate_tickets_to_new_post( $new_post_id, $post, $status ) {
+	public function duplicate_tickets_to_new_post( $new_post_id, $post ) {
 
 		$tickets = Tribe__Tickets__Tickets::get_all_event_tickets( $post->ID );
 

--- a/src/Tickets/Integrations/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Duplicate_Post.php
@@ -43,16 +43,8 @@ class Duplicate_Post extends Service_Provider {
 	 * @return int|WP_Error $new_post_id New post ID or WP_Error object on failure.
 	 */
 	public function duplicate_tickets_to_new_post( $new_post_id, $post, $status ) {
-		/**
-		 * @todo Fix this logic, maybe it will be possible to find the provider straight from the post instead of getting the first ticket the way I'm doing it now.
-		 *  I should also try to figure out the best way for ET+ to hook into this for when woo/EDD is being used instead.
-		 */
-// For Tickets Commerce
-		$ticket_ids = (array)tribe( Module::class )->get_tickets_ids( $post );
-// For WooCommerce
-		$ticket_ids = tribe( 'tickets-plus.commerce.woo' )->get_tickets_ids( $post->ID );
-// For EDD
-		$ticket_ids = tribe( 'tickets-plus.commerce.edd' )->get_tickets_ids( $post->ID );
+
+		$ticket_ids = Tribe__Tickets__Tickets::get_all_event_tickets( $post->ID );
 
 		// If we have no tickets, return the new post ID.
 		if ( empty( $ticket_ids ) ) {
@@ -60,10 +52,7 @@ class Duplicate_Post extends Service_Provider {
 		}
 
 		// Since all providers for tickets should be the same, we check the first provider.
-		$provider = tribe_tickets_get_ticket_provider( $ticket_ids[ 0 ] );
-
-
-
+		$provider = tribe_tickets_get_ticket_provider( $ticket_ids[ 0 ]->ID );
 
 		if ( empty( $provider ) || ! $provider instanceof Tribe__Tickets__Tickets ) {
 			return new WP_Error(

--- a/src/Tickets/Integrations/Integration_Abstract.php
+++ b/src/Tickets/Integrations/Integration_Abstract.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TEC\Tickets\Integrations;
+
+use TEC\Common\Integrations\Integration_Abstract as Common_Integration_Abstract;
+
+/**
+ * Class Integration_Abstract
+ *
+ * @since	TBD
+ *
+ * @link    https://docs.theeventscalendar.com/apis/integrations/including-new-integrations/
+ *
+ * @package TEC\Events\Integrations
+ */
+abstract class Integration_Abstract extends Common_Integration_Abstract {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_parent(): string {
+		return 'tickets';
+	}
+
+	/**
+	 * Filters whether the integration should load.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $value Whether the integration should load.
+	 *
+	 * @return bool
+	 */
+	protected function filter_should_load( bool $value ): bool {
+		$value = parent::filter_should_load( $value );
+
+		$slug   = static::get_slug();
+		$type   = static::get_type();
+		$parent = static::get_parent();
+
+
+		return (bool)$value;
+	}
+}

--- a/src/Tickets/Integrations/Integration_Abstract.php
+++ b/src/Tickets/Integrations/Integration_Abstract.php
@@ -11,7 +11,7 @@ use TEC\Common\Integrations\Integration_Abstract as Common_Integration_Abstract;
  *
  * @link    https://docs.theeventscalendar.com/apis/integrations/including-new-integrations/
  *
- * @package TEC\Events\Integrations
+ * @package TEC\Tickets\Integrations
  */
 abstract class Integration_Abstract extends Common_Integration_Abstract {
 

--- a/src/Tickets/Integrations/Integration_Abstract.php
+++ b/src/Tickets/Integrations/Integration_Abstract.php
@@ -7,7 +7,7 @@ use TEC\Common\Integrations\Integration_Abstract as Common_Integration_Abstract;
 /**
  * Class Integration_Abstract
  *
- * @since	TBD
+ * @since TBD
  *
  * @link    https://docs.theeventscalendar.com/apis/integrations/including-new-integrations/
  *

--- a/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
@@ -2,7 +2,7 @@
 
 namespace TEC\Tickets\Integrations\Plugins\Yoast_Duplicate_Post;
 
-use TEC\Events\Integrations\Integration_Abstract;
+use TEC\Tickets\Integrations\Integration_Abstract;
 use TEC\Common\Integrations\Traits\Plugin_Integration;
 use Tribe__Tickets__Tickets;
 use WP_Error;

--- a/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
@@ -13,7 +13,7 @@ use WP_Error;
  * Extends the cloning capability introduced by Yoast Duplicate Post plugin to also handle the duplication of tickets
  * to new posts.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Integrations\Plugins\Yoast_Duplicate_Post
  */

--- a/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Class Duplicate_Post
- *
- * Handles the duplication of tickets to new posts.
- */
-
 namespace TEC\Tickets\Integrations\Plugins\Yoast_Duplicate_Post;
 
 use TEC\Events\Integrations\Integration_Abstract;
@@ -13,6 +7,16 @@ use TEC\Common\Integrations\Traits\Plugin_Integration;
 use Tribe__Tickets__Tickets;
 use WP_Error;
 
+/**
+ * Class Duplicate_Post
+ *
+ * Extends the cloning capability introduced by Yoast Duplicate Post plugin to also handle the duplication of tickets
+ * to new posts.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Yoast_Duplicate_Post
+ */
 class Duplicate_Post extends Integration_Abstract {
 
 	use Plugin_Integration;

--- a/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
@@ -6,29 +6,38 @@
  * Handles the duplication of tickets to new posts.
  */
 
-namespace TEC\Tickets\Integrations;
+namespace TEC\Tickets\Integrations\Plugins\Yoast_Duplicate_Post;
 
-use \TEC\Common\Contracts\Service_Provider;
+use TEC\Events\Integrations\Integration_Abstract;
+use TEC\Common\Integrations\Traits\Plugin_Integration;
 use Tribe__Tickets__Tickets;
 use WP_Error;
 
-class Duplicate_Post extends Service_Provider {
+class Duplicate_Post extends Integration_Abstract {
+
+	use Plugin_Integration;
+
 
 	/**
-	 * Binds and sets up implementations.
-	 *
-	 * @since TBD
+	 * @inheritDoc
 	 */
-	public function register() {
-		$this->hooks();
+	public static function get_slug(): string {
+		return 'yoast-duplicate-post';
 	}
 
 	/**
-	 * Hook into actions for duplicating posts and pages.
+	 * @inheritDoc
 	 *
-	 * @since TBD
+	 * @return bool Whether or not integrations should load.
 	 */
-	public function hooks() {
+	public function load_conditionals(): bool {
+		return defined( 'DUPLICATE_POST_FILE' ) && ! empty( DUPLICATE_POST_FILE );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function load(): void {
 		add_action( 'dp_duplicate_post', [ $this, 'duplicate_tickets_to_new_post' ], 10, 2 );
 		add_action( 'dp_duplicate_page', [ $this, 'duplicate_tickets_to_new_post' ], 10, 2 );
 	}

--- a/src/Tickets/Integrations/Provider.php
+++ b/src/Tickets/Integrations/Provider.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Handles The Event Tickets integration.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Integrations
+ */
+namespace TEC\Tickets\Integrations;
+
+use TEC\Common\Contracts\Service_Provider;
+
+
+/**
+ * Class Provider
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Integrations
+ */
+class Provider extends Service_Provider {
+
+	/**
+	 * Binds and sets up implementations.
+	 *
+	 * @since TBD
+	 */
+	public function register() {
+		$this->container->singleton( static::class, $this );
+
+		$this->container->register( Plugins\Yoast_Duplicate_Post\Duplicate_Post::class);
+	}
+}

--- a/src/Tickets/Provider.php
+++ b/src/Tickets/Provider.php
@@ -66,7 +66,7 @@ class Provider extends Service_Provider {
 		$this->container->register( Telemetry\Provider::class );
 
 		// Loads Integrations.
-		$this->container->register( Integrations\Plugins\Yoast_Duplicate_Post\Duplicate_Post::class);
+		$this->container->register( Integrations\Provider::class);
 
 		// RBE only Providers here.
 		$this->register_ct1_providers();

--- a/src/Tickets/Provider.php
+++ b/src/Tickets/Provider.php
@@ -65,6 +65,9 @@ class Provider extends Service_Provider {
 		// Loads admin area.
 		$this->container->register( Telemetry\Provider::class );
 
+		// Loads Integrations.
+		$this->container->register( Integrations\Duplicate_Post::class);
+
 		// RBE only Providers here.
 		$this->register_ct1_providers();
 		$this->has_registered = true;

--- a/src/Tickets/Provider.php
+++ b/src/Tickets/Provider.php
@@ -11,7 +11,7 @@ namespace TEC\Tickets;
 use TEC\Common\Contracts\Service_Provider;
 use TEC\Events\Custom_Tables\V1\Provider as TEC_CT1_Provider;
 use TEC\Tickets\Custom_Tables\V1\Provider as ET_CT1_Provider;
-use \Tribe__Tickets__Main as Tickets_Plugin;
+use Tribe__Tickets__Main as Tickets_Plugin;
 
 /**
  * Class Provider for all the Tickets loading.
@@ -66,7 +66,7 @@ class Provider extends Service_Provider {
 		$this->container->register( Telemetry\Provider::class );
 
 		// Loads Integrations.
-		$this->container->register( Integrations\Duplicate_Post::class);
+		$this->container->register( Integrations\Plugins\Yoast_Duplicate_Post\Duplicate_Post::class);
 
 		// RBE only Providers here.
 		$this->register_ct1_providers();

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3827,6 +3827,52 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		/**
+		 * Clones a ticket to a new post.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $original_post_id ID of the original "event" post.
+		 * @param int $new_post_id      ID of the new "event" post.
+		 * @param int $ticket_id        ID of ticket to duplicate.
+		 *
+		 * @return int|boolean $duplicate_ticket_id New ticket ID or false, if unable to create duplicate.
+		 */
+		public function clone_ticket_to_new_post( $original_post_id, $new_post_id, $ticket_id ) {
+			// Get ticket data.
+			$ticket = $this->get_ticket( $original_post_id, $ticket_id );
+
+			if ( ! $ticket instanceof Tribe__Tickets__Ticket_Object ) {
+				return false;
+			}
+
+			// Create data for duplicate ticket.
+			$data = [
+				'ticket_name'             => $ticket->name,
+				'ticket_description'      => $ticket->description,
+				'ticket_price'            => $ticket->price,
+				'ticket_show_description' => $ticket->show_description,
+				'ticket_start_date'       => $ticket->start_date,
+				'ticket_start_time'       => $ticket->start_time,
+				'ticket_end_date'         => $ticket->end_date,
+				'ticket_end_time'         => $ticket->end_time,
+				'tribe-ticket'            => [
+					'capacity' => $ticket->capacity(),
+					'mode'     => $ticket->global_stock_mode(),
+				]
+			];
+
+			// Add the ticket.
+			$duplicate_ticket_id = $this->ticket_add( $new_post_id, $data );
+
+			if ( ! $duplicate_ticket_id ) {
+				return false;
+			}
+
+			return $duplicate_ticket_id;
+		}
+
+
+		/**
 		 * Creates a ticket object and calls the child save_ticket function
 		 *
 		 * @param int $post_id ID of parent "event" post


### PR DESCRIPTION
### 🎫 Ticket

[ET-760] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
This pull request aims to enhance the existing functionality provided by the `Yoast Duplicate Post` plugin. In order to achieve this, we have made modifications to the `dp_duplicate_post` and `dp_duplicate_page hooks`, allowing for the tickets to be cloned into a new post. Additionally, we have introduced a new method called `clone_ticket_to_new_post`, which is essentially a modified version of the existing `duplicate_ticket` method.
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[artifact-760.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/19757582-5773-4086-920b-a23cf55be56a)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-760]: https://theeventscalendar.atlassian.net/browse/ET-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ