### PR TITLE
[ET-1774] Ticketed events don't show up under Ticketed tab in Dashboard Events List

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Enhancement - Add notice about the availability of Paystack for Tickets Commerce [ET-1764]
 * Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made [ET-1736]
+* Fix - Ticketed Commerce events will now be accurately categorized and counted under the ticketed tab in the Dashboard Event List. [ET-1774]
 
 = [5.6.2] 2023-06-29 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -193,8 +193,8 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Enhancement - Add notice about the availability of Paystack for Tickets Commerce [ET-1764]
-* Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made [ET-1736]
+* Enhancement - Add notice about the availability of Paystack for Tickets Commerce. [ET-1764]
+* Enhancement - Improve performance in admin due to unnecessary Tickets Commerce calls being made. [ET-1736]
 * Enhancement - Refactored CSS for Tickets Emails to better conform to email client CSS standards. [ET-1802]
 * Fix - Ticketed Commerce events will now be accurately categorized and counted under the ticketed tab in the Dashboard Event List. [ET-1774]
 * Fix - The attendee export functionality for old converted recurring events has been improved to accurately export attendees. [ET-1739]

--- a/src/Tribe/Cache/Abstract_Cache.php
+++ b/src/Tribe/Cache/Abstract_Cache.php
@@ -88,7 +88,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 		 * under the status of `trash` or `auto-draft` shouldn't be in the list.
 		 */
 		$ids = implode( ',', $ids );
-		$query = "SELECT DISTINCT(ID)
+		$query = "SELECT DISTINCT(ID) 
 				FROM {$wpdb->posts}
 				WHERE ID IN ({$ids})
 				AND post_status NOT IN ('auto-draft', 'trash')";

--- a/src/Tribe/Cache/Abstract_Cache.php
+++ b/src/Tribe/Cache/Abstract_Cache.php
@@ -61,7 +61,8 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 				LEFT JOIN {$wpdb->posts} p
 				ON pm.meta_value = p.ID
 				WHERE p.post_type IN {$post_types}
-				AND pm.meta_key LIKE '\\_tribe\\_%\\_for\\_event'
+				AND (pm.meta_key LIKE '\\_tribe\\_%\\_for\\_event'
+				         OR pm.meta_key LIKE '\\_tec\\_%\\_event')
 				AND pm.meta_value IS NOT NULL";
 
 		if ( class_exists( 'Tribe__Events__Main' ) ) { // if events are among the supported post types then exclude past events
@@ -87,7 +88,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 		 * under the status of `trash` or `auto-draft` shouldn't be in the list.
 		 */
 		$ids = implode( ',', $ids );
-		$query = "SELECT DISTINCT(ID) 
+		$query = "SELECT DISTINCT(ID)
 				FROM {$wpdb->posts}
 				WHERE ID IN ({$ids})
 				AND post_status NOT IN ('auto-draft', 'trash')";

--- a/tests/wpunit/Tribe/Cache/AbstractCacheTest.php
+++ b/tests/wpunit/Tribe/Cache/AbstractCacheTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use Tribe__Tickets__Cache__Abstract_Cache;
+
+class AbstractCacheTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/**
+	 * Test fetch_posts_with_ticket_types method
+	 * Create multiple events & tickets with the meta_key of `_tribe_some_kind_of_ticket_for_event` and `_tec_some_kind_of_ticket_for_event`.
+	 *
+	 * @test
+	 */
+	public function fetch_posts_with_used_meta_keys() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		$posts_with_tribe_tickets = $this->factory()->post->create_many( 3, [ 'post_type' => 'post' ] );
+		$posts_with_tribe_tickets = array_merge( $posts_with_tribe_tickets, $this->factory()->post->create_many( 3, [ 'post_type' => 'page' ] ) );
+
+		$posts_with_tec_tickets = $this->factory()->post->create_many( 3, [ 'post_type' => 'post' ] );
+		$posts_with_tec_tickets = array_merge( $posts_with_tec_tickets, $this->factory()->post->create_many( 3, [ 'post_type' => 'page' ] ) );
+
+		// not relevant, any post type can be related to any other post type as "a ticket".
+		$ticket_post_type = 'ticket_type';
+		register_post_type( $ticket_post_type );
+
+		// create a ticket for each post and relate the ticket to the post.
+		foreach ( $posts_with_tribe_tickets as $id ) {
+			$ticket_id = $this->factory()->post->create( [ 'post_type' => $ticket_post_type ] );
+			update_post_meta( $ticket_id, '_tribe_some_kind_of_ticket_for_event', $id );
+		}
+
+		foreach ( $posts_with_tec_tickets as $id ) {
+			$ticket_id = $this->factory()->post->create( [ 'post_type' => $ticket_post_type ] );
+			update_post_meta( $ticket_id, '_tec_some_kind_of_ticket_for_event', $id );
+		}
+
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, null );
+
+		$this->assertCount( 6, $events );
+	}
+
+	/**
+	 * Test fetch_posts_with_ticket_types method with specific post types
+	 *
+	 * @test
+	 */
+	public function fetch_posts_with_ticket_types_with_post_types() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		// Create posts of specific types
+		$posts_with_tickets = $this->factory()->post->create_many( 3, [ 'post_type' => 'post' ] );
+		$posts_with_tickets = array_merge( $posts_with_tickets, $this->factory()->post->create_many( 3, [ 'post_type' => 'page' ] ) );
+
+		// Create a ticket for each post and relate the ticket to the post
+		foreach ( $posts_with_tickets as $id ) {
+			$ticket_id = $this->factory()->post->create( [ 'post_type' => 'ticket_type' ] );
+			update_post_meta( $ticket_id, '_tribe_some_kind_of_ticket_for_event', $id );
+		}
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, [ 'post', 'page' ] );
+
+		$this->assertCount( 6, $events );
+	}
+
+	/**
+	 * Test fetch_posts_with_ticket_types method with invalid post types
+	 *
+	 * @test
+	 */
+	public function fetch_posts_with_ticket_types_with_invalid_post_types() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, [ 'invalid_post_type' ] );
+
+		$this->assertEmpty( $events );
+	}
+
+	/**
+	 * Test fetch_posts_with_ticket_types method with no posts of the specified types
+	 *
+	 * @test
+	 */
+	public function fetch_posts_with_ticket_types_with_no_posts_of_specified_types() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, [ 'post_type_with_no_posts' ] );
+
+		$this->assertEmpty( $events );
+	}
+
+	/**
+	 * Test fetch_posts_with_ticket_types method with posts that have no tickets
+	 *
+	 * @test
+	 */
+	public function fetch_posts_with_ticket_types_with_posts_that_have_no_tickets() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		// Create posts of a specific type
+		$posts = $this->factory()->post->create_many( 3, [ 'post_type' => 'post' ] );
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, [ 'post' ] );
+
+		$this->assertEmpty( $events );
+	}
+
+	/**
+	 * Test fetch_posts_with_ticket_types method with posts that have tickets but are in 'trash' or 'auto-draft' status
+	 *
+	 * @test
+	 */
+	public function fetch_posts_with_ticket_types_with_trashed_or_auto_draft_posts() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		// Create posts of a specific type and status
+		$posts = $this->factory()->post->create_many( 3, [ 'post_type' => 'post', 'post_status' => 'trash' ] );
+		$posts = array_merge( $posts, $this->factory()->post->create_many( 3, [ 'post_type' => 'post', 'post_status' => 'auto-draft' ] ) );
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, [ 'post' ] );
+
+		$this->assertEmpty( $events );
+	}
+
+	/**
+	 * Test fetch_posts_with_ticket_types method with posts that have tickets but the tickets are not related to any
+	 * event
+	 *
+	 * @test
+	 */
+	public function fetch_posts_should_return_empty_when_post_has_no_tickets() {
+		// Create a mock of the abstract class
+		$mock_for_abstract_class = $this->getMockBuilder( Tribe__Tickets__Cache__Abstract_Cache::class )
+										->disableOriginalConstructor()
+										->getMockForAbstractClass();
+
+		$reflector = new \ReflectionObject( $mock_for_abstract_class );
+
+		$method = $reflector->getMethod( 'fetch_posts_with_ticket_types' );
+		$method->setAccessible( true );
+
+		// Create posts of a specific type
+		$posts = $this->factory()->post->create_many( 3, [ 'post_type' => 'post' ] );
+
+		// Generate filtered list of attendees.
+		$events = $method->invoke( $mock_for_abstract_class, [ 'post' ] );
+
+		$this->assertEmpty( $events );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1774] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
The original issue was that the count on the "Ticketed" tab for events was incorrect. It was only looking for the old format of the meta_key. Since tickets commerce introduced a new format we add that to the query. 
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[artifact-1774.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/15bc8580-8de4-4a92-87c8-b7b98872529b)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1774]: https://theeventscalendar.atlassian.net/browse/ET-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ