### PR TITLE
[ET-760] Provider issue with RSVP and Ticket

### DIFF
--- a/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Yoast_Duplicate_Post/Duplicate_Post.php
@@ -65,18 +65,18 @@ class Duplicate_Post extends Integration_Abstract {
 			return $new_post_id;
 		}
 
-		$provider = tribe( $tickets[ 0 ]->provider_class );
-
-		if ( empty( $provider ) || ! $provider instanceof Tribe__Tickets__Tickets ) {
-			return new WP_Error(
-				'bad_request',
-				__( 'Commerce Module invalid', 'event-tickets' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-
 		foreach ( $tickets as $ticket ) {
+
+			$provider = tribe( $ticket->provider_class );
+
+			if ( empty( $provider ) || ! $provider instanceof Tribe__Tickets__Tickets ) {
+				return new WP_Error(
+					'bad_request',
+					__( 'Commerce Module invalid', 'event-tickets' ),
+					[ 'status' => 400 ]
+				);
+			}
+
 			$provider->clone_ticket_to_new_post( $post->ID, $new_post_id, $ticket->ID );
 		}
 


### PR DESCRIPTION
[ET-760]

During testing an issue was found when the event had a ticket and an RSVP. I moved the provider logic into the foreach so that when this scenario occurs it grabs the correct provider to clone the tickets.

Original PR - https://github.com/the-events-calendar/event-tickets/pull/2717

[ET-760]: https://theeventscalendar.atlassian.net/browse/ET-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ