### PR TITLE
[ETP-864] Divi broken on AR page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - The Attendee Registration page will now display properly when using Divi with dynamic CSS enabled. [ETP-864]
+
 = [5.6.4] TBD =
 
 * Fix - Include Commerce tickets in cached results; correctly fetch posts without tickets. [ET-1808]

--- a/src/Tickets/Integrations/Provider.php
+++ b/src/Tickets/Integrations/Provider.php
@@ -29,5 +29,7 @@ class Provider extends Service_Provider {
 		$this->container->singleton( static::class, $this );
 
 		$this->container->register( Plugins\Yoast_Duplicate_Post\Duplicate_Post::class);
+
+		$this->container->register( Themes\Divi\Provider::class);
 	}
 }

--- a/src/Tickets/Integrations/Themes/Divi/Provider.php
+++ b/src/Tickets/Integrations/Themes/Divi/Provider.php
@@ -64,9 +64,10 @@ class Provider extends Integration_Abstract {
 	public function disable_static_css_generation(): void {
 		$is_on_ar_page = tribe( 'Tribe__Tickets__Attendee_Registration__Template' )->is_on_ar_page();
 
-		if ( $is_on_ar_page ) {
-			$this->divi_disable_dynamic_assets();
+		if ( ! $is_on_ar_page ) {
+			return;
 		}
+		$this->divi_disable_dynamic_assets();
 	}
 
 	/**

--- a/src/Tickets/Integrations/Themes/Divi/Provider.php
+++ b/src/Tickets/Integrations/Themes/Divi/Provider.php
@@ -81,12 +81,12 @@ class Provider extends Integration_Abstract {
 
 		$is_on_ar_page = tribe( 'Tribe__Tickets__Attendee_Registration__Template' )->is_on_ar_page();
 
-		if ( $is_on_ar_page ) {
-			// Return an empty title to hide the heading
-			return '';
+		if ( ! $is_on_ar_page ) {
+			// Return the original title for other pages/posts.
+			return $title;
 		}
 
-		// Return the original title for other pages/posts
-		return $title;
+		// Return an empty title to hide the heading.
+		return '';
 	}
 }

--- a/src/Tickets/Integrations/Themes/Divi/Provider.php
+++ b/src/Tickets/Integrations/Themes/Divi/Provider.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace TEC\Tickets\Integrations\Themes\Divi;
+
+use TEC\Common\Integrations\Traits\Theme_Integration;
+use TEC\Tickets\Integrations\Integration_Abstract;
+
+class Provider extends Integration_Abstract {
+
+	use Theme_Integration;
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return string The slug of the integration.
+	 */
+	public static function get_slug(): string {
+		return 'divi';
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return bool Whether or not integrations should load.
+	 */
+	public function load_conditionals(): bool {
+		$theme             = wp_get_theme();
+		$theme_name        = strtolower( $theme->get( 'Name' ) );
+		$parent_theme_name = strtolower( $theme->get( 'Parent Theme' ) );
+
+		return $theme_name === 'divi' || $parent_theme_name === 'divi';
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return void
+	 */
+	protected function load(): void {
+		add_action( 'wp', [ $this, 'disable_static_css_generation' ] );
+		add_filter( 'the_title', [ $this, 'hide_page_heading' ] );
+	}
+
+	/**
+	 * Disable dynamic assets for the Divi theme.
+	 *
+	 * @return void
+	 */
+	public function divi_disable_dynamic_assets(): void {
+		// Disable Feature: Dynamic Assets.
+		add_filter( 'et_disable_js_on_demand', '__return_true' );
+		add_filter( 'et_use_dynamic_css', '__return_false' );
+		add_filter( 'et_should_generate_dynamic_assets', '__return_false' );
+
+		// Disable Feature: Critical CSS.
+		add_filter( 'et_builder_critical_css_enabled', '__return_false' );
+	}
+
+	/**
+	 * Disable static CSS generation for specific posts in the Divi theme.
+	 *
+	 * @return void
+	 */
+	public function disable_static_css_generation(): void {
+		$is_on_ar_page = tribe( 'Tribe__Tickets__Attendee_Registration__Template' )->is_on_ar_page();
+
+		if ( $is_on_ar_page ) {
+			$this->divi_disable_dynamic_assets();
+		}
+	}
+
+	/**
+	 * Hide the page heading for specific posts in the Divi theme.
+	 *
+	 * @param string $title The current title.
+	 *
+	 * @return string The modified title or an empty string if the heading should be hidden.
+	 */
+	public function hide_page_heading( string $title ): string {
+
+		$is_on_ar_page = tribe( 'Tribe__Tickets__Attendee_Registration__Template' )->is_on_ar_page();
+
+		if ( $is_on_ar_page ) {
+			// Return an empty title to hide the heading
+			return '';
+		}
+
+		// Return the original title for other pages/posts
+		return $title;
+	}
+}

--- a/src/Tickets/Integrations/Themes/Divi/Provider.php
+++ b/src/Tickets/Integrations/Themes/Divi/Provider.php
@@ -57,7 +57,7 @@ class Provider extends Integration_Abstract {
 	}
 
 	/**
-	 * Disable static CSS generation for specific posts in the Divi theme.
+	 * Disable static CSS generation for the Attendee Registration page.
 	 *
 	 * @return void
 	 */
@@ -70,7 +70,7 @@ class Provider extends Integration_Abstract {
 	}
 
 	/**
-	 * Hide the page heading for specific posts in the Divi theme.
+	 * Hide the page heading for the Attendee Registration page.
 	 *
 	 * @param string $title The current title.
 	 *


### PR DESCRIPTION
### 🎫 Ticket

[ETP-864] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
When using the Divi theme on the Attendee registration page with `Dynamic CSS` and `Static CSS File Generation` enabled the page wasn't loading stylesheets correctly. I was able to find specific filters that disable all of the functionality that was breaking the page. 
 
With everything fixed we also had duplicate page titles on the page. So I disabled the one that displays via Divi by making it an empty string so that ours is the only heading on the page.

<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[artifact-etp-864.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/b81a4daf-b5be-4864-ba29-c513275c6910)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETP-864]: https://theeventscalendar.atlassian.net/browse/ETP-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ