### PR TITLE
[ET-1776] Tickets Emails: Capitalize Provider Names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -203,6 +203,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Tweak - Remove some PHP 8.1 deprecation warnings. [ET-1830]
 * Fix - Prevention of creating tickets in Classic Editor for recurring events when using custom tables. [ET-1826]
 * Fix - Prevention of creating tickets in Block Editor for recurring events when using custom tables. [ET-1827]
+* Tweak - Capitalize payment provider names in Tickets Emails. [ET-1776]
 
 = [5.6.3] 2023-07-18 =
 

--- a/src/Tickets/Emails/Admin/Preview_Data.php
+++ b/src/Tickets/Emails/Admin/Preview_Data.php
@@ -12,6 +12,7 @@ namespace TEC\Tickets\Emails\Admin;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Utils\Value;
 use TEC\Tickets\Emails\Email\Ticket;
+use TEC\Tickets\Commerce\Module;
 use WP_Post;
 
 /**
@@ -96,6 +97,7 @@ class Preview_Data {
 			'post_name'        => 'preview-order-test_cd7d068a5ef24c02',
 			'post_type'        => Order::POSTTYPE,
 			'filter'           => 'raw',
+			'provider'         => Module::class,
 		] );
 
 		return $order;

--- a/src/views/emails/template-parts/body/order/payment-info.php
+++ b/src/views/emails/template-parts/body/order/payment-info.php
@@ -12,6 +12,7 @@
  * @version 5.5.11
  *
  * @since 5.5.11
+ * @since TBD    Capitalize payment gateway name.
  *
  * @var Tribe__Template                    $this               Current template object.
  * @var \TEC\Tickets\Emails\Email_Abstract $email              The email object.
@@ -27,15 +28,21 @@ if ( empty( $order ) || empty( $order->provider ) ) {
 	return;
 }
 
+// Make sure payment gateway name is uppercase. If gateway is PayPal, ensure proper capitalization.
+$gateway_name = strtoupper( $order->gateway );
+if ( 'Paypal' === $gateway_name ) {
+	$gateway_name = esc_html__( 'PayPal', 'event-tickets' );
+}
+
 $payment_info = empty( $order->status ) || 'completed' !== strtolower( $order->status ) ?
 	sprintf(
 		// Translators: %s - Payment provider's name.
 		__( 'Payment unsuccessful with %s', 'event-tickets' ),
-		$order->gateway
+		$gateway_name
 	) : sprintf(
 		// Translators: %s - Payment provider's name.
 		__( 'Payment completed with %s', 'event-tickets' ),
-		$order->gateway
+		$gateway_name
 	);
 ?>
 <tr>

--- a/src/views/emails/template-parts/body/order/payment-info.php
+++ b/src/views/emails/template-parts/body/order/payment-info.php
@@ -29,7 +29,7 @@ if ( empty( $order ) || empty( $order->provider ) ) {
 }
 
 // Make sure payment gateway name is uppercase. If gateway is PayPal, ensure proper capitalization.
-$gateway_name = strtoupper( $order->gateway );
+$gateway_name = ucwords( $order->gateway );
 if ( 'Paypal' === $gateway_name ) {
 	$gateway_name = esc_html__( 'PayPal', 'event-tickets' );
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-1776] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
It was found that the "Completed Order" email was showing 'stripe' and 'paypal' as lower case. This PR formats them more formally. I also notices that the gateway info was not being shown within the preview, so I corrected that within the preview data.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/5f917f3d-0bc5-45f7-ba43-ded1171656af)

After:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/2be22d5c-797f-4076-9b98-172090fd5970)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
