### PR TITLE
[ET-1777] Tickets Emails: Sender Name Being Double-Escaped

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -204,6 +204,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Tweak - Remove some PHP 8.1 deprecation warnings. [ET-1830]
 * Fix - Prevention of creating tickets in Classic Editor for recurring events when using custom tables. [ET-1826]
 * Fix - Prevention of creating tickets in Block Editor for recurring events when using custom tables. [ET-1827]
+* Fix - Removal of double-escaped characters in Tickets Emails sender's name. [ET-1777]
 
 = [5.6.3] 2023-07-18 =
 

--- a/src/Tickets/Emails/Admin/Settings.php
+++ b/src/Tickets/Emails/Admin/Settings.php
@@ -215,7 +215,7 @@ class Settings {
 		}
 
 		// Return the site name as default.
-		return esc_attr( get_bloginfo( 'name', 'display' ) );
+		return get_bloginfo( 'name', 'display' );
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[ET-1777] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Sender name was being escaped twice, causing characters that were already entitized to be double-entitized which caused some crazy output in emails and attached event invites.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/b1994c00-459b-486f-81bd-506610c4897e)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1777]: https://theeventscalendar.atlassian.net/browse/ET-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ