### PR TITLE
[ET-1865] PayPal - Ticket names over 125 characters will now be truncated when sent to PayPal

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,6 +194,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Incorrect ticket count in Ticket email within the Tickets Emails feature. [ET-1832]
+* Tweak - Ticket names over 125 characters will now be truncated when being sent to Paypal. [ET-1865]
 
 = [5.6.4] 2023-08-16 =
 

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -121,8 +121,9 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 		foreach ( $order->items as $item ) {
 			$ticket          = \Tribe__Tickets__Tickets::load_ticket_object( $item['ticket_id'] );
 			$post_title      = get_the_title( $item['event_id'] );
+			$item_name       = sprintf( '%s - %s', $ticket->name, $post_title );
 			$unit['items'][] = [
-				'name'        => sprintf( '%s - %s', $ticket->name, $post_title ),
+				'name'        => $this->format_order_item_name( $item_name ),
 				'unit_amount' => [ 'value' => (string) $item['price'], 'currency_code' => $order->currency ],
 				'quantity'    => $item['quantity'],
 				'item_total'  => [ 'value' => (string) $item['sub_total'], 'currency_code' => $order->currency ],
@@ -489,5 +490,42 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 		 * @param array $messages Array of error messages.
 		 */
 		return apply_filters( 'tec_tickets_commerce_order_endpoint_error_messages', $messages );
+	}
+
+	/**
+	 * Formats the order item name by truncating it to a specified length.
+	 * If the text exceeds the maximum character length, it is truncated at the last space
+	 * within the limit and an ellipsis is added at the end.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $text The original order item name text.
+	 *
+	 * @return string The formatted order item name text.
+	 */
+	public function format_order_item_name( string $text ): string {
+		$max_character_length = 127;
+		$ellipsis             = '...';
+		$truncate_length      = $max_character_length - strlen( $ellipsis );
+
+		if ( strlen( $text ) <= $max_character_length ) {
+			return $text;
+		}
+
+		// Cut the text to the desired length
+		$truncatedText = substr( $text, 0, $truncate_length );
+
+		// Find the last space within the truncated text
+		$lastSpace = strrpos( $truncatedText, ' ' );
+
+		// Cut the text at the last space to avoid cutting in the middle of a word
+		if ( $lastSpace !== false ) {
+			$truncatedText = substr( $truncatedText, 0, $lastSpace );
+		}
+
+		// Add an ellipsis at the end
+		$truncatedText .= $ellipsis;
+
+		return $truncatedText;
 	}
 }

--- a/tests/wpunit/Tickets/Commerce/Gateways/PayPal/REST/OrderEndpointTest.php
+++ b/tests/wpunit/Tickets/Commerce/Gateways/PayPal/REST/OrderEndpointTest.php
@@ -7,7 +7,7 @@ use TEC\Tickets\Commerce\Gateways\PayPal\REST\Order_Endpoint;
 class OrderEndpointTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
-	 * @dataProvider textProvider
+	 * @dataProvider order_item_name_provider
 	 */
 	public function test_format_order_item_name( string $text, string $expected ): void {
 		$order_endpoint = new Order_Endpoint();
@@ -15,9 +15,12 @@ class OrderEndpointTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
-	public function textProvider() {
+	public function order_item_name_provider() {
 		yield "Short text should not be truncated" => [ "Short text", "Short text" ];
-		yield "Text with exact max length should not be truncated" => [ str_repeat( "A", 127 ), str_repeat( "A", 127 ) ];
+		yield "Text with exact max length should not be truncated" => [
+			str_repeat( "A", 127 ),
+			str_repeat( "A", 127 )
+		];
 		yield "Long text without spaces should be truncated at max length minus ellipsis" => [
 			str_repeat( "A", 137 ),
 			substr( str_repeat( "A", 137 ), 0, 124 ) . '...'

--- a/tests/wpunit/Tickets/Commerce/Gateways/PayPal/REST/OrderEndpointTest.php
+++ b/tests/wpunit/Tickets/Commerce/Gateways/PayPal/REST/OrderEndpointTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tribe\Tickets\Commerce\Gateways\PayPal\REST;
+
+use TEC\Tickets\Commerce\Gateways\PayPal\REST\Order_Endpoint;
+
+class OrderEndpointTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @dataProvider textProvider
+	 */
+	public function test_format_order_item_name( string $text, string $expected ): void {
+		$order_endpoint = new Order_Endpoint();
+		$result         = $order_endpoint->format_order_item_name( $text );
+		$this->assertSame( $expected, $result );
+	}
+
+	public function textProvider() {
+		yield "Short text should not be truncated" => [ "Short text", "Short text" ];
+		yield "Text with exact max length should not be truncated" => [ str_repeat( "A", 127 ), str_repeat( "A", 127 ) ];
+		yield "Long text without spaces should be truncated at max length minus ellipsis" => [
+			str_repeat( "A", 137 ),
+			substr( str_repeat( "A", 137 ), 0, 124 ) . '...'
+		];
+		yield "Long text with spaces should be truncated at the last space within limit" => [
+			"This is a very long text that exceeds the maximum character length and needs to be truncated. We need to extend the text a little bit longer.",
+			"This is a very long text that exceeds the maximum character length and needs to be truncated. We need to extend the text a..."
+		];
+		yield "Empty text should not be altered" => [ "", "" ];
+	}
+}


### PR DESCRIPTION
[ET-1865] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
PayPal has a max Item Name length of 127 characters. https://developer.paypal.com/docs/api/orders/v2/#definition-item This change adds the logic to truncate the logic when it's above 127 characters  and adds the ellipses. 

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/fd4a408d-4ab3-4a02-90dc-10282203c761)

![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/516a6305-55c0-4bad-a692-56f01b6aefa8)



### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1865]: https://theeventscalendar.atlassian.net/browse/ET-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ