### PR TITLE
Fix/ET-1821 do not allow free tickets commerce

### DIFF
--- a/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
+++ b/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
@@ -256,11 +256,10 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 		}
 
 		$is_paypal_ticket = $provider instanceof Tribe__Tickets__Commerce__PayPal__Main || $provider instanceof \TEC\Tickets\Commerce\Module;
-		$price            = (float)$body['price'];
 
-		if ( $is_paypal_ticket && $price <= 0) {
+		if ( $is_paypal_ticket && ( ! is_numeric( $body['price'] ) || (float)$body['price'] <= 0 )) {
 			return new WP_Error(
-				'bad_request',
+				'invalid_price',
 				__( 'Invalid price', 'event-tickets' ),
 				[ 'status' => 400 ]
 			);

--- a/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
+++ b/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
@@ -263,7 +263,7 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 			&& $is_invalid_price
 		) {
 			return new WP_Error(
-				'invalid_price',
+				'tec-tickets-rest-invalid_price',
 				__( 'Invalid price', 'event-tickets' ),
 				[ 'status' => 400 ]
 			);

--- a/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
+++ b/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
@@ -205,6 +205,7 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 	 * @since  4.9
 	 * @since  4.10.9 Use customizable ticket name functions.
 	 * @since  4.12.3 Update detecting ticket provider to account for possibly inactive provider.
+	 * @since  TBD    Validates if price is grather than 0 when provider is PayPal or Tickets Commerce
 	 *
 	 * @param  WP_REST_Request $request
 	 * @param  $nonce_action
@@ -250,6 +251,17 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 			return new WP_Error(
 				'bad_request',
 				__( 'Commerce Module invalid', 'event-tickets' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$is_paypal_ticket = $provider instanceof Tribe__Tickets__Commerce__PayPal__Main || $provider instanceof \TEC\Tickets\Commerce\Module;
+		$price            = (float)$body['price'];
+
+		if ( $is_paypal_ticket && $price <= 0) {
+			return new WP_Error(
+				'bad_request',
+				__( 'Invalid price', 'event-tickets' ),
 				[ 'status' => 400 ]
 			);
 		}

--- a/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
+++ b/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
@@ -256,8 +256,12 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 		}
 
 		$is_paypal_ticket = $provider instanceof Tribe__Tickets__Commerce__PayPal__Main || $provider instanceof \TEC\Tickets\Commerce\Module;
+		$is_invalid_price = ( empty( $body['price']  ) || ! is_numeric( $body['price'] ) || (float) $body['price'] <= 0 );
 
-		if ( $is_paypal_ticket && ( ! is_numeric( $body['price'] ) || (float)$body['price'] <= 0 )) {
+		if (
+			$is_paypal_ticket
+			&& $is_invalid_price
+		) {
 			return new WP_Error(
 				'invalid_price',
 				__( 'Invalid price', 'event-tickets' ),

--- a/src/modules/blocks/ticket/container-header/price/container.js
+++ b/src/modules/blocks/ticket/container-header/price/container.js
@@ -17,6 +17,7 @@ const mapStateToProps = ( state, ownProps ) => ( {
 	currencySymbol: selectors.getTicketCurrencySymbol( state, ownProps ),
 	tempPrice: selectors.getTicketTempPrice( state, ownProps ),
 	price: selectors.getTicketPrice( state, ownProps ) || '0',
+	minDefaultPrice: selectors.isZeroPriceValid( state, ownProps ) ? 0 : 1,
 } );
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {

--- a/src/modules/blocks/ticket/container-header/price/template.js
+++ b/src/modules/blocks/ticket/container-header/price/template.js
@@ -22,6 +22,7 @@ const TicketContainerHeaderPriceInput = ( {
 	currencySymbol,
 	onTempPriceChange,
 	tempPrice,
+	minDefaultPrice,
 } ) => {
 	return (
 		<Fragment>
@@ -37,7 +38,7 @@ const TicketContainerHeaderPriceInput = ( {
 				onChange={ onTempPriceChange }
 				disabled={ isDisabled }
 				type="number"
-				min="0"
+				min={minDefaultPrice}
 			/>
 			{ currencyPosition === SUFFIX && (
 				<span className="tribe-editor__ticket__container-header-price-currency">
@@ -54,6 +55,7 @@ TicketContainerHeaderPriceInput.propTypes = {
 	currencySymbol: PropTypes.string,
 	onTempPriceChange: PropTypes.func,
 	tempPrice: PropTypes.string,
+	minDefaultPrice: PropTypes.string,
 };
 
 const TicketContainerHeaderPriceLabel = ( {
@@ -94,6 +96,7 @@ const TicketContainerHeaderPrice = ( {
 	onTempPriceChange,
 	tempPrice,
 	price,
+	minDefaultPrice,
 } ) => (
 	<div className="tribe-editor__ticket__container-header-price">
 		{ isSelected
@@ -104,6 +107,7 @@ const TicketContainerHeaderPrice = ( {
 					onTempPriceChange={ onTempPriceChange }
 					tempPrice={ tempPrice }
 					isDisabled={ isDisabled }
+					minDefaultPrice={ minDefaultPrice }
 				/>
 			)
 			: (
@@ -125,6 +129,7 @@ TicketContainerHeaderPrice.propTypes = {
 	onTempPriceChange: PropTypes.func,
 	tempPrice: PropTypes.string,
 	price: PropTypes.string,
+	minDefaultPrice: PropTypes.string,
 };
 
 export default TicketContainerHeaderPrice;

--- a/src/modules/data/blocks/ticket/__tests__/__snapshots__/constants.test.js.snap
+++ b/src/modules/data/blocks/ticket/__tests__/__snapshots__/constants.test.js.snap
@@ -47,7 +47,7 @@ exports[`Ticket Constants SUFFIX 1`] = `"postfix"`;
 
 exports[`Ticket Constants TC 1`] = `"tribe-commerce"`;
 
-exports[`Ticket Constants TC_CLASS 1`] = `"TEC\\\\Tickets\\\\Commerce\\\\Module"`;
+exports[`Ticket Constants TC_CLASS 1`] = `"Tribe__Tickets__Commerce__PayPal__Main"`;
 
 exports[`Ticket Constants TC_ORDERS 1`] = `"tpp-orders"`;
 
@@ -74,8 +74,6 @@ Array [
   "own",
 ]
 `;
-
-exports[`Ticket Constants TPP_CLASS 1`] = `"Tribe__Tickets__Commerce__PayPal__Main"`;
 
 exports[`Ticket Constants UNLIMITED 1`] = `"unlimited"`;
 

--- a/src/modules/data/blocks/ticket/__tests__/__snapshots__/constants.test.js.snap
+++ b/src/modules/data/blocks/ticket/__tests__/__snapshots__/constants.test.js.snap
@@ -47,7 +47,7 @@ exports[`Ticket Constants SUFFIX 1`] = `"postfix"`;
 
 exports[`Ticket Constants TC 1`] = `"tribe-commerce"`;
 
-exports[`Ticket Constants TC_CLASS 1`] = `"Tribe__Tickets__Commerce__PayPal__Main"`;
+exports[`Ticket Constants TC_CLASS 1`] = `"TEC\\\\Tickets\\\\Commerce\\\\Module"`;
 
 exports[`Ticket Constants TC_ORDERS 1`] = `"tpp-orders"`;
 
@@ -74,6 +74,8 @@ Array [
   "own",
 ]
 `;
+
+exports[`Ticket Constants TPP_CLASS 1`] = `"Tribe__Tickets__Commerce__PayPal__Main"`;
 
 exports[`Ticket Constants UNLIMITED 1`] = `"unlimited"`;
 

--- a/src/modules/data/blocks/ticket/constants.js
+++ b/src/modules/data/blocks/ticket/constants.js
@@ -4,13 +4,13 @@ export const WOO = 'woo';
 export const RSVP = 'rsvp';
 
 export const RSVP_CLASS = 'Tribe__Tickets__RSVP';
-export const TC_CLASS = 'TEC\\Tickets\\Commerce\\Module';
-export const TPP_CLASS = 'Tribe__Tickets__Commerce__PayPal__Main';
+export const TEC_TICKETS_COMMERCE_MODULE_CLASS = 'TEC\\Tickets\\Commerce\\Module';
+export const TC_CLASS = 'Tribe__Tickets__Commerce__PayPal__Main';
 export const EDD_CLASS = 'Tribe__Tickets_Plus__Commerce__EDD__Main';
 export const WOO_CLASS = 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main';
 
 export const PROVIDER_CLASS_TO_PROVIDER_MAPPING = {
-	[ TPP_CLASS ]: TC,
+	[ TC_CLASS ]: TC,
 	[ EDD_CLASS ]: EDD,
 	[ WOO_CLASS ]: WOO,
 };
@@ -23,7 +23,7 @@ export const WOO_ORDERS = 'tickets-orders';
 
 export const TICKET_ORDERS_PAGE_SLUG = {
 	[ EDD_CLASS ]: EDD_ORDERS,
-	[ TPP_CLASS ]: TC_ORDERS,
+	[ TC_CLASS ]: TC_ORDERS,
 	[ WOO_CLASS ]: WOO_ORDERS,
 };
 

--- a/src/modules/data/blocks/ticket/constants.js
+++ b/src/modules/data/blocks/ticket/constants.js
@@ -4,7 +4,7 @@ export const WOO = 'woo';
 export const RSVP = 'rsvp';
 
 export const RSVP_CLASS = 'Tribe__Tickets__RSVP';
-export const TEC_TICKETS_COMMERCE_MODULE_CLASS = 'TEC\\Tickets\\Commerce\\Module';
+export const TICKETS_COMMERCE_MODULE_CLASS = 'TEC\\Tickets\\Commerce\\Module';
 export const TC_CLASS = 'Tribe__Tickets__Commerce__PayPal__Main';
 export const EDD_CLASS = 'Tribe__Tickets_Plus__Commerce__EDD__Main';
 export const WOO_CLASS = 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main';

--- a/src/modules/data/blocks/ticket/constants.js
+++ b/src/modules/data/blocks/ticket/constants.js
@@ -4,12 +4,13 @@ export const WOO = 'woo';
 export const RSVP = 'rsvp';
 
 export const RSVP_CLASS = 'Tribe__Tickets__RSVP';
-export const TC_CLASS = 'Tribe__Tickets__Commerce__PayPal__Main';
+export const TC_CLASS = 'TEC\\Tickets\\Commerce\\Module';
+export const TPP_CLASS = 'Tribe__Tickets__Commerce__PayPal__Main';
 export const EDD_CLASS = 'Tribe__Tickets_Plus__Commerce__EDD__Main';
 export const WOO_CLASS = 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main';
 
 export const PROVIDER_CLASS_TO_PROVIDER_MAPPING = {
-	[ TC_CLASS ]: TC,
+	[ TPP_CLASS ]: TC,
 	[ EDD_CLASS ]: EDD,
 	[ WOO_CLASS ]: WOO,
 };
@@ -22,7 +23,7 @@ export const WOO_ORDERS = 'tickets-orders';
 
 export const TICKET_ORDERS_PAGE_SLUG = {
 	[ EDD_CLASS ]: EDD_ORDERS,
-	[ TC_CLASS ]: TC_ORDERS,
+	[ TPP_CLASS ]: TC_ORDERS,
 	[ WOO_CLASS ]: WOO_ORDERS,
 };
 

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -568,7 +568,7 @@ export const isZeroPriceValid = createSelector(
 	[ getTicketTempPrice, getTicketsProvider ],
 	( price, provider ) => {
 		return 0 < parseInt( price, 10 ) ||
-			! [constants.TC_CLASS, constants.TEC_TICKETS_COMMERCE_MODULE_CLASS].includes(provider)
+			! [constants.TC_CLASS, constants.TICKETS_COMMERCE_MODULE_CLASS].includes(provider)
 	},
 );
 

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -566,7 +566,7 @@ export const isTempSharedCapacityValid = createSelector(
 
 export const isZeroPriceValid = createSelector(
 	[ getTicketTempPrice, getTicketsProvider ],
-	( price, provider ) => 0 < parseInt( price, 10 ) || provider !== constants.TC_CLASS,
+	( price, provider ) => 0 < parseInt( price, 10 ) || ! [constants.TC_CLASS, constants.TPP_CLASS].includes(provider),
 );
 
 export const isTicketValid = createSelector(

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -566,7 +566,10 @@ export const isTempSharedCapacityValid = createSelector(
 
 export const isZeroPriceValid = createSelector(
 	[ getTicketTempPrice, getTicketsProvider ],
-	( price, provider ) => 0 < parseInt( price, 10 ) || ! [constants.TC_CLASS, constants.TPP_CLASS].includes(provider),
+	( price, provider ) => {
+		return 0 < parseInt( price, 10 ) ||
+			! [constants.TC_CLASS, constants.TEC_TICKETS_COMMERCE_MODULE_CLASS].includes(provider)
+	},
 );
 
 export const isTicketValid = createSelector(

--- a/tests/restv1/PayPal/SingleTicketCest.php
+++ b/tests/restv1/PayPal/SingleTicketCest.php
@@ -405,4 +405,128 @@ class SingleTicketCest extends BaseRestCest {
 		$I->seeResponseCodeIs( 401 );
 		$I->seeResponseIsJson();
 	}
+
+	/**
+	 * It should return 400 when trying to create a ticket with invalid price
+	 *
+	 * @test
+	 */
+	public function should_return_400_when_trying_to_create_a_ticket_ticket_with_invalid_price( Restv1Tester $I ) {
+		$I->generate_nonce_for_role('administrator');
+
+		$post_id = $I->havePostInDatabase();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name qwerty 555',
+			'description'      => 'Test description text',
+			'price'            => 0,
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-111',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+
+		$ticket_create_rest_url = $this->tickets_url . '/';
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => -5,
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-222',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+
+		$ticket_create_rest_url = $this->tickets_url . '/';
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name qwerty 555',
+			'description'      => 'Test description text',
+			'price'            => 0,
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-333',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+
+		$ticket_create_rest_url = $this->tickets_url . '/';
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => -5,
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+
+		$ticket_create_rest_url = $this->tickets_url . '/';
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+	}
 }

--- a/tests/restv1/PayPal/SingleTicketCest.php
+++ b/tests/restv1/PayPal/SingleTicketCest.php
@@ -415,6 +415,7 @@ class SingleTicketCest extends BaseRestCest {
 		$I->generate_nonce_for_role('administrator');
 
 		$post_id = $I->havePostInDatabase();
+		$ticket_create_rest_url = $this->tickets_url . '/';
 
 		$create_args = [
 			'post_id'          => $post_id,
@@ -435,9 +436,6 @@ class SingleTicketCest extends BaseRestCest {
 				'event_capacity' => 100
 			]
 		];
-
-
-		$ticket_create_rest_url = $this->tickets_url . '/';
 
 		$I->sendPOST( $ticket_create_rest_url, $create_args );
 
@@ -464,8 +462,130 @@ class SingleTicketCest extends BaseRestCest {
 			]
 		];
 
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
 
-		$ticket_create_rest_url = $this->tickets_url . '/';
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => '',
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-555',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => 0.0,
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-777',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => "0,0",
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => "000",
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => ' ',
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'TEC\Tickets\Commerce\Module',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
 
 		$I->sendPOST( $ticket_create_rest_url, $create_args );
 
@@ -492,9 +612,6 @@ class SingleTicketCest extends BaseRestCest {
 			]
 		];
 
-
-		$ticket_create_rest_url = $this->tickets_url . '/';
-
 		$I->sendPOST( $ticket_create_rest_url, $create_args );
 
 		$I->seeResponseCodeIs( 400 );
@@ -520,8 +637,130 @@ class SingleTicketCest extends BaseRestCest {
 			]
 		];
 
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
 
-		$ticket_create_rest_url = $this->tickets_url . '/';
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => '',
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-555',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => 0.0,
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-777',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => "0,0",
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => "000",
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => ' ',
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
 
 		$I->sendPOST( $ticket_create_rest_url, $create_args );
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1821] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
Bug fix: 
**Backend**
- Added a validation in `[POST]` `/tribe/tickets/v1/tickets/` endpoint to prevent create tickets with price equals or lower than 0  when provider is `Tribe__Tickets__Commerce__PayPal__Main` or `TEC\Tickets\Commerce\Module`

**Frontend**
- Added TEC\Tickets\Commerce\Module as constant
- Updated isZeroPriceValid selector
- Modified price input min value depending on provider

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/de7b944851c8435e8831f6e3c1256bbe
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1821]: https://theeventscalendar.atlassian.net/browse/ET-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ