### PR TITLE
Restore possibility to move Tickets/Attendees to all Single Events

### DIFF
--- a/.github/workflows/tests-php-ct1.yml
+++ b/.github/workflows/tests-php-ct1.yml
@@ -1,4 +1,4 @@
-name: 'Codeception Tests'
+name: 'CT1 Codeception Tests'
 on: [ pull_request ]
 jobs:
   test:
@@ -6,14 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          # - acceptance
-          - functional
-          - integration
-          - restv1
-          - views_integration
-          - commerce_integration
-          - wpunit --group="capacity"
-          - wpunit --skip-group="capacity"
+          - ct1_integration
     runs-on: ubuntu-latest
     steps:
       # ------------------------------------------------------------------------------
@@ -130,6 +123,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         continue-on-error: true
+      - name: Fetch head branch from ECP
+        uses: octokit/request-action@v2.x
+        if: steps.skip.outputs.value != 1
+        id: fetch-ecp-head-branch
+        with:
+          route: GET /repos/{owner}/{repo}/branches/${{ github.head_ref }}
+          owner: the-events-calendar
+          repo: events-pro
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        continue-on-error: true
+      - name: Fetch base branch from ECP
+        uses: octokit/request-action@v2.x
+        id: fetch-ecp-base-branch
+        if: steps.skip.outputs.value != 1 && steps.fetch-ecp-head-branch.outcome != 'success'
+        with:
+          route: GET /repos/{owner}/{repo}/branches/${{ github.base_ref }}
+          owner: the-events-calendar
+          repo: events-pro
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        continue-on-error: true
       # ------------------------------------------------------------------------------
       # Set TEC branch
       # ------------------------------------------------------------------------------
@@ -159,14 +174,43 @@ jobs:
         if: steps.skip.outputs.value != 1
         run: |
           mv ${GITHUB_WORKSPACE}/the-events-calendar ${GITHUB_WORKSPACE}/../the-events-calendar
-          docker network prune -f
           ${SLIC_BIN} use the-events-calendar
           ${SLIC_BIN} composer install --no-dev
       - name: Set up TEC Common
         if: steps.skip.outputs.value != 1
         run: |
-          docker network prune -f
           ${SLIC_BIN} use the-events-calendar/common
+          ${SLIC_BIN} composer install --no-dev
+      # ------------------------------------------------------------------------------
+      # Set ECP branch
+      # ------------------------------------------------------------------------------
+      - name: Set ECP with head branch
+        if: steps.skip.outputs.value != 1 && steps.fetch-ecp-head-branch.outcome == 'success'
+        run: echo "ECP_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+      - name: Set ECP with base branch
+        if: steps.skip.outputs.value != 1 && steps.fetch-ecp-head-branch.outcome != 'success' && steps.fetch-ecp-base-branch.outcome == 'success'
+        run: echo "ECP_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
+      - name: Set ECP with master branch
+        if: steps.skip.outputs.value != 1 && steps.fetch-ecp-head-branch.outcome != 'success' && steps.fetch-ecp-base-branch.outcome != 'success'
+        run: echo "ECP_BRANCH=master" >> $GITHUB_ENV
+      # ------------------------------------------------------------------------------
+      # Clone and init ECP
+      # ------------------------------------------------------------------------------
+      - name: Clone ECP
+        uses: actions/checkout@v2
+        if: steps.skip.outputs.value != 1
+        with:
+          fetch-depth: 1
+          repository: the-events-calendar/events-pro
+          ref: ${{ env.ECP_BRANCH }}
+          token: ${{ secrets.GH_BOT_TOKEN }}
+          path: events-pro
+          submodules: recursive
+      - name: Init ECP
+        if: steps.skip.outputs.value != 1
+        run: |
+          mv ${GITHUB_WORKSPACE}/events-pro ${GITHUB_WORKSPACE}/../events-pro
+          ${SLIC_BIN} use events-pro
           ${SLIC_BIN} composer install --no-dev
       # ------------------------------------------------------------------------------
       # Set up ET Common
@@ -174,7 +218,6 @@ jobs:
       - name: Set up ET Common
         if: steps.skip.outputs.value != 1
         run: |
-          docker network prune -f
           ${SLIC_BIN} use event-tickets/common
           ${SLIC_BIN} composer install --no-dev
       # ------------------------------------------------------------------------------
@@ -215,7 +258,7 @@ jobs:
       # Install and activate TwentyTwenty
       # ------------------------------------------------------------------------------
       - name: Install and activate TwentyTwenty
-        if: steps.skip.outputs.value != 1 && matrix.suite == 'acceptance'
+        if: steps.skip.outputs.value != 1
         run:  ${SLIC_BIN} site-cli theme install twentytwenty --activate
       # ------------------------------------------------------------------------------
       # Run tests

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -13,6 +13,8 @@ params:
   # read dynamic configuration parameters from the .env file
   - .env
 extensions:
+    enabled:
+      - tad\WPBrowser\Extension\Events
     commands:
         - 'Codeception\Command\GenerateWPUnit'
         - 'Codeception\Command\GenerateWPRestApi'

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
     "fzaninotto/faker": "^1.8",
     "lucatume/wp-browser": "^3.1.4",
-    "lucatume/wp-snapshot-assertions": "^1.1.0",
+    "lucatume/wp-snaphot-assertions": "^1.1.0",
     "phpunit/phpunit": "^6.5.14",
     "spatie/phpunit-snapshot-assertions": "^1.4.2",
     "the-events-calendar/coding-standards": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1805027e2c2703237137287b47a22652",
+    "content-hash": "04c99ba5bf8213ef1a12738ba68502e3",
     "packages": [],
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.21",
+            "version": "2.1.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d"
+                "reference": "f2dae0851b2eae4c51969af740fdd0356d7f8f55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
-                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/f2dae0851b2eae4c51969af740fdd0356d7f8f55",
+                "reference": "f2dae0851b2eae4c51969af740fdd0356d7f8f55",
                 "shasum": ""
             },
             "require": {
@@ -51,34 +51,34 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.21"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.26"
             },
-            "time": "2022-02-07T07:28:34+00:00"
+            "time": "2023-09-18T08:18:37+00:00"
         },
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.1",
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
@@ -98,6 +98,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -105,7 +106,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2023-08-24T15:11:13+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -1178,23 +1179,40 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/master"
+                "source": "https://github.com/doctrine/instantiator/tree/1.0.5"
             },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "electrolinux/phpquery",
-            "version": "0.9.6",
+            "version": "0.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/electrolinux/phpquery.git",
-                "reference": "6cb8afcfe8cd4ce45f2f8c27d561383037c27a3a"
+                "reference": "90029e2acffebebdb6e309509c778fe34e8028ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/electrolinux/phpquery/zipball/6cb8afcfe8cd4ce45f2f8c27d561383037c27a3a",
-                "reference": "6cb8afcfe8cd4ce45f2f8c27d561383037c27a3a",
+                "url": "https://api.github.com/repos/electrolinux/phpquery/zipball/90029e2acffebebdb6e309509c778fe34e8028ba",
+                "reference": "90029e2acffebebdb6e309509c778fe34e8028ba",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
             },
             "type": "library",
             "autoload": {
@@ -1208,22 +1226,23 @@
             ],
             "authors": [
                 {
+                    "name": "didier Belot",
+                    "homepage": "https://github.com/electrolinux/phpquery",
+                    "role": "Packager, maintainer"
+                },
+                {
                     "name": "Tobiasz Cudnik",
                     "email": "tobiasz.cudnik@gmail.com",
                     "homepage": "https://github.com/TobiaszCudnik",
                     "role": "Developer"
-                },
-                {
-                    "name": "didier Belot",
-                    "role": "Packager"
                 }
             ],
             "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
             "homepage": "http://code.google.com/p/phpquery/",
             "support": {
-                "source": "https://github.com/electrolinux/phpquery/tree/0.9.6"
+                "source": "https://github.com/electrolinux/phpquery/tree/0.9.7"
             },
-            "time": "2013-03-21T12:39:33+00:00"
+            "time": "2023-05-02T18:27:16+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1446,16 +1465,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
                 "shasum": ""
             },
             "require": {
@@ -1465,11 +1484,6 @@
                 "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/functions_include.php"
@@ -1510,7 +1524,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/1.5.3"
             },
             "funding": [
                 {
@@ -1526,20 +1540,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2023-05-21T12:31:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "e98e3e6d4f86621a9b75f623996e6bbdeb4b9318"
+                "reference": "e4490cabc77465aaee90b20cfc9a770f8c04be6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/e98e3e6d4f86621a9b75f623996e6bbdeb4b9318",
-                "reference": "e98e3e6d4f86621a9b75f623996e6bbdeb4b9318",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/e4490cabc77465aaee90b20cfc9a770f8c04be6b",
+                "reference": "e4490cabc77465aaee90b20cfc9a770f8c04be6b",
                 "shasum": ""
             },
             "require": {
@@ -1558,11 +1572,6 @@
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/functions_include.php"
@@ -1620,7 +1629,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/1.9.1"
             },
             "funding": [
                 {
@@ -1636,7 +1645,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T21:43:03+00:00"
+            "time": "2023-04-17T16:00:37+00:00"
         },
         {
             "name": "illuminate/contracts",
@@ -1881,50 +1890,6 @@
             "time": "2020-04-07T20:44:10+00:00"
         },
         {
-            "name": "lucatume/args",
-            "version": "1.0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lucatume/args.git",
-                "reference": "9ab69f5c995813b2dfbb067100ada500ee2893e8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/args/zipball/9ab69f5c995813b2dfbb067100ada500ee2893e8",
-                "reference": "9ab69f5c995813b2dfbb067100ada500ee2893e8",
-                "shasum": ""
-            },
-            "require": {
-                "xrstf/composer-php52": "1.*"
-            },
-            "require-dev": {
-                "codeception/codeception": "*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Arg": "src/",
-                    "tad_": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Luca Tumedei",
-                    "email": "luca@theaveragedev.com"
-                }
-            ],
-            "description": "A PHP 5.2 compatible arguments handling library.",
-            "support": {
-                "issues": "https://github.com/lucatume/args/issues",
-                "source": "https://github.com/lucatume/args/tree/master"
-            },
-            "time": "2018-02-11T12:20:29+00:00"
-        },
-        {
             "name": "lucatume/codeception-snapshot-assertions",
             "version": "0.2.4",
             "source": {
@@ -1970,116 +1935,30 @@
             "time": "2020-02-05T20:17:49+00:00"
         },
         {
-            "name": "lucatume/function-mocker",
-            "version": "1.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lucatume/function-mocker.git",
-                "reference": "97dbec0d806dfa2745fd1f793a86bec9a852629e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/function-mocker/zipball/97dbec0d806dfa2745fd1f793a86bec9a852629e",
-                "reference": "97dbec0d806dfa2745fd1f793a86bec9a852629e",
-                "shasum": ""
-            },
-            "require": {
-                "antecedent/patchwork": "^2.0",
-                "lucatume/args": "^1.0",
-                "php": ">=5.6.0",
-                "phpunit/phpunit": ">=5.7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/shims.php",
-                    "src/functions.php"
-                ],
-                "psr-0": {
-                    "tad\\FunctionMocker": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "theAverageDev",
-                    "email": "luca@theaveragedev.com"
-                }
-            ],
-            "description": "Function mocking with Patchwork",
-            "support": {
-                "issues": "https://github.com/lucatume/function-mocker/issues",
-                "source": "https://github.com/lucatume/function-mocker/tree/1.3.8"
-            },
-            "time": "2018-04-18T15:25:42+00:00"
-        },
-        {
-            "name": "lucatume/function-mocker-le",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lucatume/function-mocker-le.git",
-                "reference": "20e12ae2e6350c5b11a6bdbe763c749f7f88603e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/function-mocker-le/zipball/20e12ae2e6350c5b11a6bdbe763c749f7f88603e",
-                "reference": "20e12ae2e6350c5b11a6bdbe763c749f7f88603e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.3"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/function-mocker-le.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "theAverageDev (Luca Tumedei)",
-                    "email": "luca@theaveragedev.com"
-                }
-            ],
-            "description": "A lightweight function mocking solution.",
-            "support": {
-                "issues": "https://github.com/lucatume/function-mocker-le/issues",
-                "source": "https://github.com/lucatume/function-mocker-le/tree/master"
-            },
-            "time": "2017-09-02T10:37:47+00:00"
-        },
-        {
             "name": "lucatume/wp-browser",
-            "version": "3.1.6",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "5cefdab50d16f69447c48e5a8668d67d4892d6ef"
+                "reference": "79d1956c8d753db1d0db3db119ea95f1d0dea1a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/5cefdab50d16f69447c48e5a8668d67d4892d6ef",
-                "reference": "5cefdab50d16f69447c48e5a8668d67d4892d6ef",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/79d1956c8d753db1d0db3db119ea95f1d0dea1a9",
+                "reference": "79d1956c8d753db1d0db3db119ea95f1d0dea1a9",
                 "shasum": ""
             },
             "require": {
                 "antecedent/patchwork": "^2.0",
                 "bordoni/phpass": "^0.3",
-                "codeception/codeception": "^2.5 || ^3.0 || ^4.0",
+                "codeception/codeception": "^4",
+                "codeception/module-asserts": "^1.0",
+                "codeception/module-cli": "^1.0",
+                "codeception/module-db": "^1.0",
+                "codeception/module-filesystem": "^1.0",
+                "codeception/module-phpbrowser": "^1.0",
+                "codeception/module-webdriver": "^1.0",
+                "codeception/util-universalframework": "^1.0",
                 "dg/mysql-dump": "^1.3",
                 "ext-fileinfo": "*",
                 "ext-json": "*",
@@ -2102,11 +1981,10 @@
             },
             "require-dev": {
                 "erusev/parsedown": "^1.7",
-                "ext-pcntl": "*",
-                "ext-sockets": "*",
                 "gumlet/php-image-resize": "^1.6",
                 "lucatume/codeception-snapshot-assertions": "^0.2",
                 "mikey179/vfsstream": "^1.6",
+                "symfony/translation": "^3.4",
                 "victorjonsson/markdowndocs": "dev-master",
                 "vlucas/phpdotenv": "^3.0",
                 "wp-cli/wp-cli-bundle": "*"
@@ -2157,7 +2035,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lucatume/wp-browser/issues",
-                "source": "https://github.com/lucatume/wp-browser/tree/3.1.6"
+                "source": "https://github.com/lucatume/wp-browser/tree/3.2.0"
             },
             "funding": [
                 {
@@ -2165,7 +2043,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-28T06:45:08+00:00"
+            "time": "2023-09-15T09:51:57+00:00"
         },
         {
             "name": "lucatume/wp-snaphot-assertions",
@@ -2218,16 +2096,16 @@
         },
         {
             "name": "mikehaertl/php-shellcommand",
-            "version": "1.6.4",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikehaertl/php-shellcommand.git",
-                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5"
+                "reference": "e79ea528be155ffdec6f3bf1a4a46307bb49e545"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikehaertl/php-shellcommand/zipball/3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
-                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
+                "url": "https://api.github.com/repos/mikehaertl/php-shellcommand/zipball/e79ea528be155ffdec6f3bf1a4a46307bb49e545",
+                "reference": "e79ea528be155ffdec6f3bf1a4a46307bb49e545",
                 "shasum": ""
             },
             "require": {
@@ -2258,9 +2136,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mikehaertl/php-shellcommand/issues",
-                "source": "https://github.com/mikehaertl/php-shellcommand/tree/1.6.4"
+                "source": "https://github.com/mikehaertl/php-shellcommand/tree/1.7.0"
             },
-            "time": "2021-03-17T06:54:33+00:00"
+            "time": "2023-04-19T08:25:22+00:00"
         },
         {
             "name": "mikemclin/laravel-wp-password",
@@ -3680,66 +3558,6 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
-            "name": "rmccue/requests",
-            "version": "v1.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress/Requests.git",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "php-parallel-lint/php-console-highlighter": "^0.5.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
-                "requests/test-server": "dev-master",
-                "squizlabs/php_codesniffer": "^3.5",
-                "wp-coding-standards/wpcs": "^2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Requests": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan McCue",
-                    "homepage": "http://ryanmccue.info"
-                }
-            ],
-            "description": "A HTTP library written in PHP, for human beings.",
-            "homepage": "http://github.com/WordPress/Requests",
-            "keywords": [
-                "curl",
-                "fsockopen",
-                "http",
-                "idna",
-                "ipv6",
-                "iri",
-                "sockets"
-            ],
-            "support": {
-                "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
-            },
-            "time": "2021-06-04T09:56:25+00:00"
-        },
-        {
             "name": "sebastian/code-unit-reverse-lookup",
             "version": "1.0.2",
             "source": {
@@ -4374,16 +4192,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.10",
+            "version": "v2.11.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "0f25a3766f26df91d6bdda0c8931303fc85499d7"
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/0f25a3766f26df91d6bdda0c8931303fc85499d7",
-                "reference": "0f25a3766f26df91d6bdda0c8931303fc85499d7",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
                 "shasum": ""
             },
             "require": {
@@ -4428,7 +4246,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-01-05T18:45:16+00:00"
+            "time": "2023-08-05T23:46:11+00:00"
         },
         {
             "name": "softcreatr/jsonpath",
@@ -4551,16 +4369,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -4596,14 +4414,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -6045,16 +5864,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.17",
+            "version": "v0.11.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "f6be76b7c4ee2ef93c9531b8a37bdb7ce42c3728"
+                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/f6be76b7c4ee2ef93c9531b8a37bdb7ce42c3728",
-                "reference": "f6be76b7c4ee2ef93c9531b8a37bdb7ce42c3728",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
+                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
                 "shasum": ""
             },
             "require": {
@@ -6062,7 +5881,7 @@
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
-                "wp-cli/wp-cli-tests": "^3.1.6"
+                "wp-cli/wp-cli-tests": "^4"
             },
             "type": "library",
             "extra": {
@@ -6102,29 +5921,28 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.17"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.20"
             },
-            "time": "2023-01-12T01:18:21+00:00"
+            "time": "2023-09-01T12:21:35+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.7.1",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76"
+                "reference": "5dd2340b9a01c3cfdbaf5e93a140759fdd190eee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76",
-                "reference": "1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/5dd2340b9a01c3cfdbaf5e93a140759fdd190eee",
+                "reference": "5dd2340b9a01c3cfdbaf5e93a140759fdd190eee",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "mustache/mustache": "^2.14.1",
                 "php": "^5.6 || ^7.0 || ^8.0",
-                "rmccue/requests": "^1.8",
                 "symfony/finder": ">2.7",
                 "wp-cli/mustangostang-spyc": "^0.6.3",
                 "wp-cli/php-cli-tools": "~0.11.2"
@@ -6148,7 +5966,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8.x-dev"
+                    "dev-main": "2.9.x-dev"
                 }
             },
             "autoload": {
@@ -6175,7 +5993,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2022-10-17T23:10:42+00:00"
+            "time": "2023-06-05T06:55:55+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -6227,41 +6045,6 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
-        },
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "670ac996f93792f8de0427605cfef342b3429ff3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/670ac996f93792f8de0427605cfef342b3429ff3",
-                "reference": "670ac996f93792f8de0427605cfef342b3429ff3",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "support": {
-                "issues": "https://github.com/composer-php52/composer-php52/issues",
-                "source": "https://github.com/composer-php52/composer-php52"
-            },
-            "time": "2022-06-08T03:23:46+00:00"
         },
         {
             "name": "zordius/lightncandy",

--- a/readme.txt
+++ b/readme.txt
@@ -202,6 +202,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Tweak - Implement new design for Attendees Page, Ticket Overview. [ET-1840]
 * Tweak - Added notice regarding the availability of Paystack for Tickets Commerce. [ET-1763]
 * Tweak - Improve performance of the post admin list. [ET-1870]
+* Fix - Restore possibility to move Tickets and Attendees to Single Events that are part of a Series. [ET-1862]
 
 = [5.6.4] 2023-08-16 =
 

--- a/src/Tickets/Provider.php
+++ b/src/Tickets/Provider.php
@@ -68,7 +68,7 @@ class Provider extends Service_Provider {
 		// Loads Integrations.
 		$this->container->register( Integrations\Provider::class);
 
-		// RBE only Providers here.
+		// CT1 only Providers here.
 		$this->container->register_on_action( 'tec_events_custom_tables_v1_fully_activated', ET_CT1_Provider::class );
 		$this->has_registered = true;
 

--- a/tests/_support/Traits/CT1/CT1_Fixtures.php
+++ b/tests/_support/Traits/CT1/CT1_Fixtures.php
@@ -227,7 +227,7 @@ trait CT1_Fixtures {
 
 	private function given_a_migrated_single_event() {
 		$post = $this->given_a_non_migrated_single_event();
-		Event::upsert( [ 'post_id' ], Event::data_from_post( $post ) );
+		Event::upsert( [ 'post_id' ], Event::data_from_post( $post->ID ) );
 		$event = Event::find( $post->ID, 'post_id' );
 		$this->assertInstanceOf( Event::class, $event );
 		$event->occurrences()->save_occurrences();

--- a/tests/ct1_integration.suite.dist.yml
+++ b/tests/ct1_integration.suite.dist.yml
@@ -17,7 +17,9 @@ modules:
         title: 'Event Tickets Tests'
         plugins:
           - the-events-calendar/the-events-calendar.php
+          - events-pro/events-calendar-pro.php
           - event-tickets/event-tickets.php
         activatePlugins:
           - the-events-calendar/the-events-calendar.php
+          - events-pro/events-calendar-pro.php
           - event-tickets/event-tickets.php

--- a/tests/ct1_integration/Tribe/Tickets/Admin/Move_TicketsTest.php
+++ b/tests/ct1_integration/Tribe/Tickets/Admin/Move_TicketsTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tribe\Tickets\Admin;
+
+use Closure;
+use Generator;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe__Tickets__Main as Tickets;
+use Tribe__Events__Main as TEC;
+
+class Move_TicketsTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
+	public function get_post_choices_provider(): Generator {
+		yield 'looking for posts' => [
+			function (): array {
+				$post_ids = static::factory()->post->create_many( 3 );
+
+				$ignore_id = array_shift( $post_ids );
+
+				$_POST['check']     = '1234567890';
+				$_POST['ignore']    = [ $ignore_id ];
+				$_POST['post_type'] = 'post';
+
+				return array_combine(
+					$post_ids,
+					array_map( fn( int $id ) => get_post_field( 'post_title', $id ), $post_ids )
+				);
+			}
+		];
+
+		yield 'looking for posts by string' => [
+			function (): array {
+				$post_ids_1 = static::factory()->post->create_many( 3, [ 'post_title' => 'Alice' ] );
+				$post_ids_2 = static::factory()->post->create_many( 3, [ 'post_title' => 'Bob' ] );
+
+				$ignore_id = array_shift( $post_ids_1 );
+
+				$_POST['check']        = '1234567890';
+				$_POST['ignore']       = [ $ignore_id ];
+				$_POST['post_type']    = 'post';
+				$_POST['search_terms'] = 'Bob';
+
+				return array_combine(
+					$post_ids_2,
+					array_map( fn( int $id ) => get_post_field( 'post_title', $id ), $post_ids_2 )
+				);
+			}
+		];
+
+		yield 'looking for events' => [
+			function (): array {
+				$event_ids = array_map( function ( int $k ) {
+					return tribe_events()->set_args( [
+						'title'      => 'Event ' . $k,
+						'status'     => 'publish',
+						'start_date' => '2220-01-01 00:00:00',
+						'duration'   => 2 * HOUR_IN_SECONDS,
+					] )->create()->ID;
+				}, range( 1, 3 ) );
+
+				$ignore_id = array_shift( $event_ids );
+
+				$_POST['check']     = '1234567890';
+				$_POST['ignore']    = [ $ignore_id ];
+				$_POST['post_type'] = TEC::POSTTYPE;
+
+				return array_combine(
+					$event_ids,
+					array_map( static function ( int $id ) {
+						return get_post_field( 'post_title', $id ) . ' (' . tribe_get_start_date( $id ) . ')';
+					}, $event_ids )
+				);
+			}
+		];
+
+		yield 'looking for events by string' => [
+			function (): array {
+				$event_ids_1 = array_map( function ( int $k ) {
+					return tribe_events()->set_args( [
+						'title'      => 'Alice Event ' . $k,
+						'status'     => 'publish',
+						'start_date' => '2220-01-01 00:00:00',
+						'duration'   => 2 * HOUR_IN_SECONDS,
+					] )->create()->ID;
+				}, range( 1, 3 ) );
+				$event_ids_2 = array_map( function ( int $k ) {
+					return tribe_events()->set_args( [
+						'title'      => 'Bob Event ' . $k,
+						'status'     => 'publish',
+						'start_date' => '2220-01-01 00:00:00',
+						'duration'   => 2 * HOUR_IN_SECONDS,
+					] )->create()->ID;
+				}, range( 1, 3 ) );
+
+				$ignore_id = array_shift( $event_ids_1 );
+
+				$_POST['check']        = '1234567890';
+				$_POST['ignore']       = [ $ignore_id ];
+				$_POST['post_type']    = TEC::POSTTYPE;
+				$_POST['search_terms'] = 'Bob';
+
+				return array_combine(
+					$event_ids_2,
+					array_map( static function ( int $id ) {
+						return get_post_field( 'post_title', $id ) . ' (' . tribe_get_start_date( $id ) . ')';
+					}, $event_ids_2 )
+				);
+			}
+		];
+
+		// ECP + CT1 is active.
+		yield 'recurring events' => [
+			function (): array {
+				$daily_event    = tribe_events()->set_args( [
+					'title'      => 'Daily Event',
+					'status'     => 'publish',
+					'start_date' => '2220-01-01 00:00:00',
+					'duration'   => 2 * HOUR_IN_SECONDS,
+					'recurrence' => 'RRULE:FREQ=DAILY;COUNT=3',
+				] )->create()->ID;
+				$weekly_event   = tribe_events()->set_args( [
+					'title'      => 'Weekly Event',
+					'status'     => 'publish',
+					'start_date' => '2220-01-01 00:00:00',
+					'duration'   => 2 * HOUR_IN_SECONDS,
+					'recurrence' => 'RRULE:FREQ=WEEKLY;COUNT=3',
+				] )->create()->ID;
+				$single_event_1 = tribe_events()->set_args( [
+					'title'      => 'Single Event',
+					'status'     => 'publish',
+					'start_date' => '2220-01-01 00:00:00',
+					'duration'   => 2 * HOUR_IN_SECONDS,
+				] )->create()->ID;
+				$single_event_2 = tribe_events()->set_args( [
+					'title'      => 'Single Event',
+					'status'     => 'publish',
+					'start_date' => '2220-01-02 00:00:00',
+					'duration'   => 2 * HOUR_IN_SECONDS,
+				] )->create()->ID;
+
+				$ignore_id = $daily_event;
+
+				$_POST['check']     = '1234567890';
+				$_POST['ignore']    = [ $ignore_id ];
+				$_POST['post_type'] = TEC::POSTTYPE;
+
+				$weekly_occurrence_2 = Occurrence::where( 'post_id', '=', $weekly_event )
+				                                 ->where( 'start_date', '=', '2220-01-08 00:00:00' )
+				                                 ->first()->provisional_id;
+				$weekly_occurrence_3 = Occurrence::where( 'post_id', '=', $weekly_event )
+				                                 ->where( 'start_date', '=', '2220-01-15 00:00:00' )
+				                                 ->first()->provisional_id;
+
+				return array_combine(
+					[ $single_event_1, $single_event_2 ],
+					array_map( static function ( int $id ) {
+						return get_post_field( 'post_title', $id ) . ' (' . tribe_get_start_date( $id ) . ')';
+					}, [ $single_event_1, $single_event_2 ] )
+				);
+			}
+		];
+	}
+
+	/**
+	 * @dataProvider get_post_choices_provider
+	 */
+	public function test_get_post_choices( Closure $fixture ): void {
+		$expected       = $fixture();
+		$_POST['check'] = 'not-relevant';
+		$this->set_fn_return( 'wp_verify_nonce', true );
+		$post_choices = null;
+		$this->set_fn_return( 'wp_send_json_success', function ( $data ) use ( &$post_choices ) {
+			$post_choices = $data['posts'];
+		}, true );
+
+		$move_tickets = Tickets::instance()->move_tickets();
+		$move_tickets->get_post_choices();
+
+		$this->assertEqualSets( $expected, $post_choices );
+	}
+}

--- a/tests/ct1_integration/_bootstrap.php
+++ b/tests/ct1_integration/_bootstrap.php
@@ -1,25 +1,70 @@
 <?php
 
-// Ensure the CT1 code branch is enabled.
-use TEC\Common\Monolog\Logger;
-use TEC\Events\Custom_Tables\V1\Activation;
-use TEC\Tickets\Provider;
+use Codeception\Events;
+use Codeception\Util\Autoload;
+use TEC\Common\StellarWP\DB\DB;
+use TEC\Events\Custom_Tables\V1\Activation as TEC_CT1_Activation;
+use TEC\Events\Custom_Tables\V1\Provider as TEC_CT1_Provider;
+use TEC\Events_Pro\Custom_Tables\V1\Provider as ECP_CT1_Provider;
+use TEC\Events\Custom_Tables\V1\Tables\Events as Events_Table;
+use TEC\Events\Custom_Tables\V1\Tables\Occurrences as Occurrences_Table;
+use TEC\Events_Pro\Custom_Tables\V1\Activation as ECP_CT1_Activation;
+use TEC\Events_Pro\Custom_Tables\V1\Series\Post_Type as Series_Post_Type;
+use TEC\Events_Pro\Custom_Tables\V1\Tables\Series_Relationships as Series_Relationships_Table;
+use TEC\Tickets\Commerce\Module as Commerce_Module;
+use TEC\Tickets\Commerce\Provider as Commerce_Provider;
+use function tad\WPBrowser\addListener;
 
+// Load utils from ECP
+$ecp_dir = dirname( __DIR__, 3 ) . '/events-pro';
+Autoload::addNamespace( 'Tribe\Events_Pro\Tests', $ecp_dir . '/tests/_support' );
 
-$tec_support = dirname( __DIR__, 3 ) . '/the-events-calendar/tests/_support';
-Codeception\Util\Autoload::addNamespace( 'Tribe\Events\Test', $tec_support );
-
-// Let's  make sure Views v2 are activated if not.
-putenv( 'TEC_TICKETS_COMMERCE=1' );
+// Ensure TEC CT1 Feature is active.
 putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 $_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
-add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
-tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
-tribe()->register( Provider::class );
-// Run the activation routine to ensure the tables will be set up independently of the previous state.
-Activation::activate();
-tribe()->register( TEC\Events\Custom_Tables\V1\Full_Activation_Provider::class );
-// The logger has already been set up at this point, remove all handlers to silence it.
-$logger = tribe( Logger::class );
-$logger->setHandlers( [] );
-tribe()->make(Provider::class)->register_ct1_providers();
+
+// Ensure Series are ticket-able, in most scenarios this is what we want.
+$ticketable_post_types   = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+$ticketable_post_types[] = Series_Post_Type::POSTTYPE;
+tribe_update_option( 'ticket-enabled-post-types', $ticketable_post_types );
+
+// Activate CT1
+tribe()->register( TEC_CT1_Provider::class );
+TEC_CT1_Activation::init();
+tribe()->register( ECP_CT1_Provider::class );
+ECP_CT1_Activation::init();
+
+if ( empty( tribe()->getVar( 'ct1_fully_activated' ) ) ) {
+	throw new Exception( 'TEC CT1 is not active' );
+}
+
+// Ensure Ticket Commerce is enabled.
+if ( ! tec_tickets_commerce_is_enabled() ) {
+	add_filter( 'tec_tickets_commerce_is_enabled', '__return_true', 100 );
+	tribe()->register( Commerce_Provider::class );
+}
+tribe( Commerce_Module::class );
+
+// Start the posts auto-increment from a high number to make it easier to replace the post IDs in HTML snapshots.
+global $wpdb;
+DB::query( "ALTER TABLE $wpdb->posts AUTO_INCREMENT = 5096" );
+
+// After each test truncate Event Ticket and TEC CT1 custom tables.
+addListener( Events::TEST_BEFORE, function () {
+
+	DB::query( 'SET FOREIGN_KEY_CHECKS=0' );
+	foreach (
+		[
+			Events_Table::table_name(),
+			Occurrences_Table::table_name(),
+			Series_Relationships_Table::table_name()
+		] as $table_name
+	) {
+		DB::query( "TRUNCATE TABLE {$table_name}" );
+	}
+	DB::query( 'SET FOREIGN_KEY_CHECKS=0' );
+} );
+
+// Deactivate logging.
+global $wp_filter;
+$wp_filter['tribe_log'] = new WP_Hook();


### PR DESCRIPTION
### 🎫 Ticket

[ET-1862](https://theeventscalendar.atlassian.net/browse/ET-1862) 

### 🗒️ Description

This PR restores the functionality to allow moving Attendees between any Single Event on the site, whether the Single Event belongs, in the context of CT1, to a Series or not.

A note on the fix: the exclusion of recurring events was previously done incorrectly by leveraging the support in ECP for the `post__not_in_series` query var.
That would exclude not just Recurring Events (part of a Series by default) but Single Events part of a Series as well. Herein lies the issue.
In the PR I'm setting the `post__not_recurring` query var, hinting at its future support; it's currently not part of ECP code.
Since there is not `post__not_recurring` support to leverage, and to deal with an ECP support that might come later than the shipping of ET, I've created a method that will handle the exclusion part of the `Tribe__Tickets__Admin__Move_Tickets` class, the `exclude_recurring_events` one. That method is meant to be a "bridge" to provide the Recurring Event  exclusion functionality while the support for `post__not_recurring` makes its way into ECP code, [see the ECP PR](https://github.com/the-events-calendar/events-pro/pull/2315) 

Lastly: the PR reintroduces the run of the `ct1_integration` suite in CI.

### 🎥 Artifacts <!-- if applicable-->
* [Screencast](https://share.cleanshot.com/T73qWKK8) 
* tests

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1862]: https://theeventscalendar.atlassian.net/browse/ET-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ