### PR TITLE
[ET-1815] buttons styling overrides

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -203,6 +203,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Incorrect ticket count in Ticket email within the Tickets Emails feature. [ET-1832]
 * Fix - Added support for filtering attendees by TicketsCommerce order status. [ET-1863]
 * Fix - Prevent Fatal error around Promoter usage of Firebase\JWT\JWT for encryption. [ET-1876]
+* Fix - Prevent some button background styles from being overridden by theme editors. [ET-1815]
 
 = [5.6.4] 2023-08-16 =
 

--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -87,6 +87,7 @@
 	.tribe-tickets__commerce-checkout-cart-item-details-button--more,
 	.tribe-tickets__commerce-checkout-cart-item-details-button--less {
 		background-color: transparent;
+		background-image: none;
 		color: var(--tec-color-text-primary-light);
 		position: relative;
 		white-space: nowrap;
@@ -254,6 +255,7 @@
 	}
 
 	.tribe-tickets__commerce-checkout-gateway-toggle-button {
+		background-image: none;
 		color: var(--tec-color-text-primary-light);
 		font-family: var(--tec-font-family-sans-serif);
 		font-size: var(--tec-font-size-3);


### PR DESCRIPTION
### 🎫 Ticket

[ET-1815] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Some theme editors override the background styles for buttons. Some of our buttons shouldn't be overridden. This PR fixes a few of those that were found.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/ce64eb1d-8cbc-4135-92fb-6d0bdd2d0d55)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1815]: https://theeventscalendar.atlassian.net/browse/ET-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ