### PR TITLE
Invalidate Ticket Object caches correctly

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,6 +194,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Restore possibility to move Tickets and Attendees to Single Events that are part of a Series. [ET-1862]
+* Fix - Ticket property invalidation to ensure capacity, inventory and availability are correctly invalidated. [ET-xxx]
 
 = [5.6.5] 2023-09-13 =
 

--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -83,7 +83,7 @@ class Module extends \Tribe__Tickets__Tickets {
 	 *
 	 * @var string
 	 */
-	const ATTENDEE_PRODUCT_KEY = '_tec_tickets_commerce_product';
+	const ATTENDEE_PRODUCT_KEY = '_tec_tickets_commerce_ticket';
 
 	/**
 	 * Meta key that relates Attendees and Orders.
@@ -231,13 +231,6 @@ class Module extends \Tribe__Tickets__Tickets {
 		if ( $this->is_loaded ) {
 			return false;
 		}
-
-//		add_filter( 'post_updated_messages', [ $this, 'updated_messages' ] );
-
-//		add_action( 'init', tribe_callback( 'tickets.commerce.paypal.orders.report', 'hook' ) );
-//		add_action( 'tribe_tickets_attendees_page_inside', tribe_callback( 'tickets.commerce.paypal.orders.tabbed-view', 'render' ) );
-//		add_filter( 'tribe_tickets_stock_message_available_quantity', tribe_callback( 'tickets.commerce.paypal.orders.sales', 'filter_available' ), 10, 4 );
-//		add_action( 'admin_init', tribe_callback( 'tickets.commerce.paypal.oversell.request', 'handle' ) );```
 	}
 
 	/**
@@ -809,5 +802,4 @@ class Module extends \Tribe__Tickets__Tickets {
 
 		return $attendee;
 	}
-
 }

--- a/src/Tickets/Commerce/Provider.php
+++ b/src/Tickets/Commerce/Provider.php
@@ -78,6 +78,9 @@ class Provider extends Service_Provider {
 
 		// Register and add hooks for admin notices.
 		$this->container->register( Admin\Notices::class );
+
+		// Cache invalidation.
+		add_filter( 'tec_cache_listener_save_post_types', [ $this, 'filter_cache_listener_save_post_types' ] );
 	}
 
 	/**
@@ -131,5 +134,23 @@ class Provider extends Service_Provider {
 
 		$this->container->singleton( Legacy_Compat::class, $v1_compat );
 		$this->container->singleton( 'tickets.commerce.legacy-compat', $v1_compat );
+	}
+
+	/**
+	 * Filters the list of post types that should trigger a cache invalidation on `save_post` to add
+	 * all the ones modeling Commerce Tickets, Attendees and Orders.
+	 *
+	 * @since TBD
+	 *
+	 * @param string[] $post_types The list of post types that should trigger a cache invalidation on `save_post`.
+	 *
+	 * @return string[] The filtered list of post types that should trigger a cache invalidation on `save_post`.
+	 */
+	public function filter_cache_listener_save_post_types( array $post_types = [] ): array {
+		$post_types[] = Ticket::POSTTYPE;
+		$post_types[] = Attendee::POSTTYPE;
+		$post_types[] = Order::POSTTYPE;
+
+		return $post_types;
 	}
 }

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Class Tribe__Tickets__Commerce__PayPal__Main
  *
@@ -348,6 +349,9 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 
 		add_filter( 'tribe_tickets_cart_urls', [ $this, 'add_cart_url' ], 10, 2 );
 		add_filter( 'tribe_tickets_checkout_urls', [ $this, 'add_checkout_url' ], 10, 2 );
+
+		// Cache invalidation.
+		add_filter( 'tec_cache_listener_save_post_types', [ $this, 'filter_cache_listener_save_post_types' ] );
 	}
 
 	/**
@@ -3158,5 +3162,23 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		}
 
 		return $provider_obj;
+	}
+
+	/**
+	 * Filters the list of post types that should trigger a cache invalidation on `save_post` to add
+	 * all the ones modeling PayPal Tickets, Attendees and Orders.
+	 *
+	 * @since TBD
+	 *
+	 * @param string[] $post_types The list of post types that should trigger a cache invalidation on `save_post`.
+	 *
+	 * @return string[] The filtered list of post types that should trigger a cache invalidation on `save_post`.
+	 */
+	public function filter_cache_listener_save_post_types( array $post_types = [] ): array {
+		$post_types[] = $this->ticket_object;
+		$post_types[] = $this->order_object;
+		$post_types[] = $this->attendee_object;
+
+		return $post_types;
 	}
 }

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -245,6 +245,9 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		// Handle RSVP AJAX.
 		add_action( 'wp_ajax_nopriv_tribe_tickets_rsvp_handle', [ $this, 'ajax_handle_rsvp' ] );
 		add_action( 'wp_ajax_tribe_tickets_rsvp_handle', [ $this, 'ajax_handle_rsvp' ] );
+
+		// Cache invalidation.
+		add_filter( 'tec_cache_listener_save_post_types', [ $this, 'filter_cache_listener_save_post_types' ] );
 	}
 
 	/**
@@ -2935,5 +2938,22 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 */
 	public function is_not_going_enabled( $ticket_id ): bool {
 		return tribe_is_truthy( get_post_meta( $ticket_id, $this->show_not_going, true ) );
+	}
+
+	/**
+	 * Filters the list of post types that should trigger a cache invalidation on `save_post` to add
+	 * all the ones modeling RSVP Tickets and Attendees.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $post_types
+	 *
+	 * @return array
+	 */
+	public function filter_cache_listener_save_post_types( array $post_types = [] ): array {
+		$post_types[] = $this->ticket_object;
+		$post_types[] = $this->attendee_object;
+
+		return $post_types;
 	}
 }

--- a/src/Tribe/Service_Provider.php
+++ b/src/Tribe/Service_Provider.php
@@ -88,13 +88,4 @@ class Tribe__Tickets__Service_Provider extends \TEC\Common\Contracts\Service_Pro
 			tribe( 'tickets.admin.settings.display' );
 		}
 	}
-
-	/**
-	 * Binds and sets up implementations at boot time.
-	 *
-	 * @since 4.6
-	 */
-	public function boot() {
-		// no ops
-	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/CapacityTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/CapacityTest.php
@@ -15,15 +15,6 @@ class CapacityTest extends \Codeception\TestCase\WPTestCase {
 
 	use Ticket_Maker;
 
-	/**
-	 * @inheritDoc
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		add_filter( 'tribe_tickets_ticket_object_is_ticket_cache_enabled', '__return_false' );
-	}
-
 	public function test_if_provider_is_loaded() {
 		$provider = tribe( Module::class );
 
@@ -31,7 +22,6 @@ class CapacityTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function test_if_tickets_can_be_created_and_purchased() {
-
 		$maker = new Event();
 		$event_id = $maker->create();
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/EventStockTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/EventStockTest.php
@@ -19,15 +19,6 @@ class EventStockTest extends \Codeception\TestCase\WPTestCase {
 	use Order_Maker;
 	use RSVP_Ticket_Maker;
 
-	/**
-	 * @inheritDoc
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		add_filter( 'tribe_tickets_ticket_object_is_ticket_cache_enabled', '__return_false' );
-	}
-
 	public function test_if_provider_is_loaded() {
 		$provider = tribe( Module::class );
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/UpdateTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/UpdateTest.php
@@ -15,15 +15,6 @@ class UpdateTest extends \Codeception\TestCase\WPTestCase {
 	use Order_Maker;
 	use RSVP_Ticket_Maker;
 
-	/**
-	 * @inheritDoc
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		add_filter( 'tribe_tickets_ticket_object_is_ticket_cache_enabled', '__return_false' );
-	}
-
 	public function test_ticket_restock_after_attendee_deletion_with_individual_capacity() {
 		$maker = new Event();
 		$event_id = $maker->create();

--- a/tests/ct1_integration/Attendees_TableTest.php
+++ b/tests/ct1_integration/Attendees_TableTest.php
@@ -2,43 +2,62 @@
 
 namespace Tribe\Tickets;
 
+use Codeception\TestCase\WPTestCase;
+use TEC\Events\Custom_Tables\V1\Models\Event;
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Gateways\PayPal\Gateway;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\Tests\CT1_Integration_Test_Case;
+use Tribe\Events\Test\Traits\CT1\CT1_Fixtures;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
-use Tribe\Tickets\Test\Traits\CT1\CT1_Fixtures;
 use Tribe__Tickets__Attendees_Table as Attendees_Table;
 
-class Attendees_TableTest extends \Codeception\TestCase\WPTestCase {
+class Attendees_TableTest extends WPTestCase {
 	use CT1_Fixtures;
 	use Attendee_Maker;
 	use Ticket_Maker;
 
+	private $wp_screen_backup;
+
+	private function set_wp_screen(): void {
+		global $wp_screen, $hook_suffix;
+		$this->wp_screen_backup = $wp_screen;
+		$hook_suffix            = 'edit.php';
+		$wp_screen              = \WP_Screen::get();
+	}
+
 	public function _setUp() {
 		parent::_setUp();
-		$this->enable_provisional_id_normalizer();
+		$this->set_wp_screen();
 		$GLOBALS['hook_suffix'] = 'tribe_events_page_tickets-attendees';
 	}
 
 	public function _tearDown() {
+		$GLOBALS['wp_screen'] = $this->wp_screen_backup;
 		parent::_tearDown();
-		$this->disable_provisional_id_normalizer();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		add_filter( 'tribe_tickets_ticket_object_is_ticket_cache_enabled', '__return_false' );
 	}
 
 	private function make_instance() {
 		return new Attendees_Table();
+	}
+
+	/**
+	 * This method _should_ be provided by the base CT1 test utility, but it's currently bugged.
+	 *
+	 * @todo Remove this when the base CT1 test utility is fixed.
+	 */
+	private function given_a_migrated_single_event( $args = [] ) {
+		$post = $this->given_a_non_migrated_single_event( $args );
+		Event::upsert( [ 'post_id' ], Event::data_from_post( $post->ID ) );
+		$event = Event::find( $post->ID, 'post_id' );
+		$this->assertInstanceOf( Event::class, $event );
+		$event->occurrences()->save_occurrences();
+		$this->assertEquals( 1, Occurrence::where( 'post_id', '=', $post->ID )->count() );
+
+		return $post;
 	}
 
 	public function create_order_for_ticket( $ticket_id, $quantity = 5 ) {
@@ -72,7 +91,7 @@ class Attendees_TableTest extends \Codeception\TestCase\WPTestCase {
 		$occurrence = Occurrence::find_by_post_id( $post_id );
 
 		// Create a faux provisional id.
-		$provisional_id = $occurrence->occurrence_id + $this->get_provisional_id_base();
+		$provisional_id = $occurrence->provisional_id;
 		$ticket_a_id    = $this->create_tc_ticket( $post_id, 10 );
 
 		$this->create_order_for_ticket( $ticket_a_id, $quantity );

--- a/tests/ct1_integration/_bootstrap.php
+++ b/tests/ct1_integration/_bootstrap.php
@@ -1,70 +1,42 @@
 <?php
 
-use Codeception\Events;
+// Ensure the CT1 code branch is enabled.
 use Codeception\Util\Autoload;
-use TEC\Common\StellarWP\DB\DB;
+use TEC\Common\Monolog\Logger;
 use TEC\Events\Custom_Tables\V1\Activation as TEC_CT1_Activation;
-use TEC\Events\Custom_Tables\V1\Provider as TEC_CT1_Provider;
-use TEC\Events_Pro\Custom_Tables\V1\Provider as ECP_CT1_Provider;
-use TEC\Events\Custom_Tables\V1\Tables\Events as Events_Table;
-use TEC\Events\Custom_Tables\V1\Tables\Occurrences as Occurrences_Table;
+use TEC\Events\Custom_Tables\V1\Migration\State as CT1_State;
 use TEC\Events_Pro\Custom_Tables\V1\Activation as ECP_CT1_Activation;
-use TEC\Events_Pro\Custom_Tables\V1\Series\Post_Type as Series_Post_Type;
-use TEC\Events_Pro\Custom_Tables\V1\Tables\Series_Relationships as Series_Relationships_Table;
 use TEC\Tickets\Commerce\Module as Commerce_Module;
 use TEC\Tickets\Commerce\Provider as Commerce_Provider;
-use function tad\WPBrowser\addListener;
+use TEC\Tickets\Provider;
+use Tribe\Tickets\Promoter\Triggers\Dispatcher;
 
-// Load utils from ECP
+$tec_support = dirname( __DIR__, 3 ) . '/the-events-calendar/tests/_support';
+Codeception\Util\Autoload::addNamespace( 'Tribe\Events\Test', $tec_support );
 $ecp_dir = dirname( __DIR__, 3 ) . '/events-pro';
 Autoload::addNamespace( 'Tribe\Events_Pro\Tests', $ecp_dir . '/tests/_support' );
 
-// Ensure TEC CT1 Feature is active.
+// Let's  make sure Views v2 are activated if not.
+putenv( 'TEC_TICKETS_COMMERCE=1' );
 putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 $_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
-
-// Ensure Series are ticket-able, in most scenarios this is what we want.
-$ticketable_post_types   = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
-$ticketable_post_types[] = Series_Post_Type::POSTTYPE;
-tribe_update_option( 'ticket-enabled-post-types', $ticketable_post_types );
-
-// Activate CT1
-tribe()->register( TEC_CT1_Provider::class );
-TEC_CT1_Activation::init();
-tribe()->register( ECP_CT1_Provider::class );
-ECP_CT1_Activation::init();
-
-if ( empty( tribe()->getVar( 'ct1_fully_activated' ) ) ) {
-	throw new Exception( 'TEC CT1 is not active' );
-}
-
+add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
+$state = tribe( CT1_State::class );
+$state->set( 'phase', CT1_State::PHASE_MIGRATION_COMPLETE );
+$state->save();
+tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
+tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
+tribe()->register( Provider::class );
+// Run the activation routine to ensure the tables will be set up independently of the previous state.
+TEC_CT1_Activation::activate();
+ECP_CT1_Activation::activate();
+tribe()->register( TEC\Events\Custom_Tables\V1\Full_Activation_Provider::class );
+// The logger has already been set up at this point, remove all handlers to silence it.
+$logger = tribe( Logger::class );
+$logger->setHandlers( [] );
+// Disable the Promoter trigger to avoid Promoter-related errors.
+remove_action( 'tribe_tickets_promoter_trigger', [ tribe( Dispatcher::class ), 'trigger' ] );
 // Ensure Ticket Commerce is enabled.
-if ( ! tec_tickets_commerce_is_enabled() ) {
-	add_filter( 'tec_tickets_commerce_is_enabled', '__return_true', 100 );
-	tribe()->register( Commerce_Provider::class );
-}
+add_filter( 'tec_tickets_commerce_is_enabled', '__return_true', 100 );
+tribe()->register( Commerce_Provider::class );
 tribe( Commerce_Module::class );
-
-// Start the posts auto-increment from a high number to make it easier to replace the post IDs in HTML snapshots.
-global $wpdb;
-DB::query( "ALTER TABLE $wpdb->posts AUTO_INCREMENT = 5096" );
-
-// After each test truncate Event Ticket and TEC CT1 custom tables.
-addListener( Events::TEST_BEFORE, function () {
-
-	DB::query( 'SET FOREIGN_KEY_CHECKS=0' );
-	foreach (
-		[
-			Events_Table::table_name(),
-			Occurrences_Table::table_name(),
-			Series_Relationships_Table::table_name()
-		] as $table_name
-	) {
-		DB::query( "TRUNCATE TABLE {$table_name}" );
-	}
-	DB::query( 'SET FOREIGN_KEY_CHECKS=0' );
-} );
-
-// Deactivate logging.
-global $wp_filter;
-$wp_filter['tribe_log'] = new WP_Hook();

--- a/tests/integration/RSVP_Tickets_Test.php
+++ b/tests/integration/RSVP_Tickets_Test.php
@@ -8,8 +8,6 @@ class RSVP_Tickets_Test extends \Codeception\TestCase\WPTestCase {
 	 * the in-stock values
 	 */
 	public function test_ticket_with_stock() {
-		add_filter( 'tribe_tickets_ticket_object_is_ticket_cache_enabled', '__return_false' );
-
 		$post_id = $this->factory->post->create();
 		$start = strtotime( date( 'Y-m-d H:00:00' ) );
 		$end = strtotime( date( 'Y-m-d H:00:00', strtotime( '+5 days' ) ) );
@@ -67,8 +65,6 @@ class RSVP_Tickets_Test extends \Codeception\TestCase\WPTestCase {
 	 * the in-stock values
 	 */
 	public function test_ticket_without_stock() {
-		add_filter( 'tribe_tickets_ticket_object_is_ticket_cache_enabled', '__return_false' );
-
 		$start = strtotime( date( 'Y-m-d H:00:00' ) );
 		$end = strtotime( date( 'Y-m-d H:00:00', strtotime( '+5 days' ) ) );
 		$post_id = $this->factory->post->create();

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Attendees_TableTest__test_display__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Attendees_TableTest__test_display__0.snapshot.html
@@ -1,0 +1,73 @@
+<input type="hidden" id="_wpnonce" name="_wpnonce" value="1234567890" /><input type="hidden" name="_wp_http_referer" value="" />	<div class="tablenav top">
+
+				<div class="alignleft actions bulkactions">
+					</div>
+			<div class='tablenav-pages one-page'><span class="displaying-num">4 items</span>
+<span class='pagination-links'><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>
+<span class="paging-input"><label for="current-page-selector" class="screen-reader-text">Current Page</label><input class='current-page' id='current-page-selector' type='text' name='paged' value='1' size='1' aria-describedby='table-paging' /><span class='tablenav-paging-text'> of <span class='total-pages'>1</span></span></span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&rsaquo;</span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&raquo;</span></span></div>
+		<br class="clear" />
+	</div>
+		<table class="wp-list-table widefat striped attendees tribe-attendees tec-tickets__admin-table-attendees">
+	<thead>
+	<tr>
+		<td  id='cb' class='manage-column column-cb check-column'><label class="screen-reader-text" for="cb-select-all-1">Select All</label><input id="cb-select-all-1" type="checkbox" /></td><th scope="col" id='ticket' class='manage-column column-ticket column-primary sortable desc'><a href="http://wordpress.test?orderby=id&#038;order=asc"><span>Ticket</span><span class="sorting-indicator"></span></a></th><th scope="col" id='primary_info' class='manage-column column-primary_info'>Primary Information</th><th scope="col" id='security' class='manage-column column-security sortable desc'><a href="http://wordpress.test?orderby=security_code&#038;order=asc"><span>Security Code</span><span class="sorting-indicator"></span></a></th><th scope="col" id='status' class='manage-column column-status'>Status</th><th scope="col" id='check_in' class='manage-column column-check_in sortable desc'><a href="http://wordpress.test?orderby=check_in&#038;order=asc"><span>Check in</span><span class="sorting-indicator"></span></a></th>	</tr>
+	</thead>
+
+	<tbody id="the-list"
+		 data-wp-lists='list:attendee'		>
+		<tr class="completed"><th scope="row" class="check-column"><input type="checkbox" name="attendee[]" value="POST_ID|Tribe__Tickets__Commerce__PayPal__Main" /></th><td class='ticket column-ticket has-row-actions column-primary' data-colname="Ticket">		<div class="event-tickets-ticket-name">
+			[#POST_ID] &ndash; 			Test PayPal ticket for POST_ID		</div>
+
+		<button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class='primary_info column-primary_info' data-colname="Primary Information">
+				<div class="purchaser_name tec-tickets__admin-table-attendees-purchaser-name">ATTENDEE_DATA</div>
+				<div class="purchaser_email tec-tickets__admin-table-attendees-purchaser-email">
+					<a class="tec-tickets__admin-table-attendees-purchaser-email-link" href="mailto:ATTENDEE_DATA">ATTENDEE_DATA</a>
+				</div>
+			</td><td class='security column-security' data-colname="Security Code">ATTENDEE_DATA</td><td class='status column-status' data-colname="Status"><div class="tec-tickets__admin-table-attendees-order-status tec-tickets__admin-table-attendees-order-status--completed"><span>Completed</span></div></td><td class='check_in column-check_in' data-colname="Check in"></td></tr><tr class="completed"><th scope="row" class="check-column"><input type="checkbox" name="attendee[]" value="POST_ID|Tribe__Tickets__Commerce__PayPal__Main" /></th><td class='ticket column-ticket has-row-actions column-primary' data-colname="Ticket">		<div class="event-tickets-ticket-name">
+			[#POST_ID] &ndash; 			Test PayPal ticket for POST_ID		</div>
+
+		<button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class='primary_info column-primary_info' data-colname="Primary Information">
+				<div class="purchaser_name tec-tickets__admin-table-attendees-purchaser-name">ATTENDEE_DATA</div>
+				<div class="purchaser_email tec-tickets__admin-table-attendees-purchaser-email">
+					<a class="tec-tickets__admin-table-attendees-purchaser-email-link" href="mailto:ATTENDEE_DATA">ATTENDEE_DATA</a>
+				</div>
+			</td><td class='security column-security' data-colname="Security Code">ATTENDEE_DATA</td><td class='status column-status' data-colname="Status"><div class="tec-tickets__admin-table-attendees-order-status tec-tickets__admin-table-attendees-order-status--completed"><span>Completed</span></div></td><td class='check_in column-check_in' data-colname="Check in"></td></tr><tr class="yes"><th scope="row" class="check-column"><input type="checkbox" name="attendee[]" value="POST_ID|Tribe__Tickets__RSVP" /></th><td class='ticket column-ticket has-row-actions column-primary' data-colname="Ticket">		<div class="event-tickets-ticket-name">
+			[#POST_ID] &ndash; 			Test RSVP ticket for POST_ID		</div>
+
+		<button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class='primary_info column-primary_info' data-colname="Primary Information">
+				<div class="purchaser_name tec-tickets__admin-table-attendees-purchaser-name">ATTENDEE_DATA</div>
+				<div class="purchaser_email tec-tickets__admin-table-attendees-purchaser-email">
+					<a class="tec-tickets__admin-table-attendees-purchaser-email-link" href="mailto:ATTENDEE_DATA">ATTENDEE_DATA</a>
+				</div>
+			</td><td class='security column-security' data-colname="Security Code">ATTENDEE_DATA</td><td class='status column-status' data-colname="Status"><div class="tec-tickets__admin-table-attendees-order-status tec-tickets__admin-table-attendees-order-status--yes"><span>Going</span></div></td><td class='check_in column-check_in' data-colname="Check in"></td></tr><tr class="yes"><th scope="row" class="check-column"><input type="checkbox" name="attendee[]" value="POST_ID|Tribe__Tickets__RSVP" /></th><td class='ticket column-ticket has-row-actions column-primary' data-colname="Ticket">		<div class="event-tickets-ticket-name">
+			[#POST_ID] &ndash; 			Test RSVP ticket for POST_ID		</div>
+
+		<button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button></td><td class='primary_info column-primary_info' data-colname="Primary Information">
+				<div class="purchaser_name tec-tickets__admin-table-attendees-purchaser-name">ATTENDEE_DATA</div>
+				<div class="purchaser_email tec-tickets__admin-table-attendees-purchaser-email">
+					<a class="tec-tickets__admin-table-attendees-purchaser-email-link" href="mailto:ATTENDEE_DATA">ATTENDEE_DATA</a>
+				</div>
+			</td><td class='security column-security' data-colname="Security Code">ATTENDEE_DATA</td><td class='status column-status' data-colname="Status"><div class="tec-tickets__admin-table-attendees-order-status tec-tickets__admin-table-attendees-order-status--yes"><span>Going</span></div></td><td class='check_in column-check_in' data-colname="Check in"></td></tr>	</tbody>
+
+	<tfoot>
+	<tr>
+		<td   class='manage-column column-cb check-column'><label class="screen-reader-text" for="cb-select-all-2">Select All</label><input id="cb-select-all-2" type="checkbox" /></td><th scope="col"  class='manage-column column-ticket column-primary sortable desc'><a href="http://wordpress.test?orderby=id&#038;order=asc"><span>Ticket</span><span class="sorting-indicator"></span></a></th><th scope="col"  class='manage-column column-primary_info'>Primary Information</th><th scope="col"  class='manage-column column-security sortable desc'><a href="http://wordpress.test?orderby=security_code&#038;order=asc"><span>Security Code</span><span class="sorting-indicator"></span></a></th><th scope="col"  class='manage-column column-status'>Status</th><th scope="col"  class='manage-column column-check_in sortable desc'><a href="http://wordpress.test?orderby=check_in&#038;order=asc"><span>Check in</span><span class="sorting-indicator"></span></a></th>	</tr>
+	</tfoot>
+
+</table>
+			<div class="tablenav bottom">
+
+				<div class="alignleft actions bulkactions">
+					</div>
+			<div class='tablenav-pages one-page'><span class="displaying-num">4 items</span>
+<span class='pagination-links'><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>
+<span class="screen-reader-text">Current Page</span><span id="table-paging" class="paging-input"><span class="tablenav-paging-text">1 of <span class='total-pages'>1</span></span></span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&rsaquo;</span>
+<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&raquo;</span></span></div>
+		<br class="clear" />
+	</div>
+		


### PR DESCRIPTION
### 🎫 Ticket

[ET-1887](https://theeventscalendar.atlassian.net/browse/ET-1887)

### 🗒️ Description

This PR builds on the [Commmon PR](https://github.com/the-events-calendar/tribe-common/pull/1980) to add the Ticket, Attendee and Order post types managed by Event Tickets to the list of post types that should trigger a cache invalidation.

### 🎥 Artifacts

* [Screencast explaining the issue](https://share.cleanshot.com/JV1fySbn)
* Tests - there were already tests covering the cache invalidation issue or, rather, working around it invalidating cache to work. I've removed those work-arounds to make sure correct cache invalidation is correctly tested along with other functionality.

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1887]: https://theeventscalendar.atlassian.net/browse/ET-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ