### PR TITLE
[ET-1875] Tickets Emails: Fix Status showing incorrectly in other languages

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,7 +195,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Restore possibility to move Tickets and Attendees to Single Events that are part of a Series. [ET-1862]
 * Fix - Ticket property invalidation to ensure capacity, inventory and availability are correctly invalidated. [ET-xxx]
-* Fix - Fix order status sometime showing incorrectly for sites in languages other than English. [ET-1875]
+* Fix - Fix order status sometimes showing incorrectly for sites in languages other than English. [ET-1875]
 
 = [5.6.5] 2023-09-13 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - Restore possibility to move Tickets and Attendees to Single Events that are part of a Series. [ET-1862]
 * Fix - Ticket property invalidation to ensure capacity, inventory and availability are correctly invalidated. [ET-xxx]
+* Fix - Fix order status sometime showing incorrectly for sites in languages other than English. [ET-1875]
 
 = [5.6.5] 2023-09-13 =
 

--- a/src/Tickets/Commerce/Models/Order_Model.php
+++ b/src/Tickets/Commerce/Models/Order_Model.php
@@ -64,6 +64,7 @@ class Order_Model extends Base {
 				'status_log'          => $status_log,
 				'status_obj'          => $status,
 				'status'              => $status->get_name(),
+				'status_slug'         => $status->get_slug(),
 				'gateway'             => $gateway_slug,
 				'gateway_order_id'    => $gateway_order_id,
 				'gateway_payload'     => $gateway_payload,

--- a/src/Tickets/Emails/Admin/Preview_Data.php
+++ b/src/Tickets/Emails/Admin/Preview_Data.php
@@ -87,6 +87,7 @@ class Preview_Data {
 			'purchaser_email'  => 'john@doe.com',
 			'gateway'          => Gateway::get_key(),
 			'status'           => 'completed',
+			'status_slug'      => 'completed',
 			'tickets'          => self::get_tickets(),
 			'post_author'      => 1,
 			'post_date'        => '2023-04-17 17:06:56',

--- a/src/Tickets/Emails/Admin/Preview_Data.php
+++ b/src/Tickets/Emails/Admin/Preview_Data.php
@@ -86,7 +86,7 @@ class Preview_Data {
 			'purchaser_name'   => __( 'John Doe', 'event-tickets' ),
 			'purchaser_email'  => 'john@doe.com',
 			'gateway'          => Gateway::get_key(),
-			'status'           => 'completed',
+			'status'           => __( 'Completed', 'event-tickets' ),
 			'status_slug'      => 'completed',
 			'tickets'          => self::get_tickets(),
 			'post_author'      => 1,

--- a/src/views/emails/template-parts/body/order/payment-info.php
+++ b/src/views/emails/template-parts/body/order/payment-info.php
@@ -30,7 +30,7 @@ if ( empty( $order ) || empty( $order->provider ) ) {
 
 $gateway_name = tribe( TEC\Tickets\Commerce\Order::class )->get_gateway_label( $order );
 
-$payment_info = empty( $order->status ) || 'completed' !== strtolower( $order->status ) ?
+$payment_info = empty( $order->status_slug ) || 'completed' !== strtolower( $order->status_slug ) ?
 	sprintf(
 		// Translators: %s - Payment provider's name.
 		__( 'Payment unsuccessful with %s', 'event-tickets' ),


### PR DESCRIPTION
### 🎫 Ticket

[ET-1875] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We were checking the status on a translatable string, which causes the status within some of the order emails to appear incorrectly. This fix adds a `status_slug` param to the order which isn't translatable and changes the logic to use the slug, instead.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/c65d920af6f44594a35e9df4c86d05a9?sid=3dffeda2-298a-4069-86f1-8c455e712b25

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1875]: https://theeventscalendar.atlassian.net/browse/ET-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ