### PR TITLE
Removing Comment to fix build process.

### DIFF
--- a/src/modules/elements/attendees-registration/style.pcss
+++ b/src/modules/elements/attendees-registration/style.pcss
@@ -1,4 +1,3 @@
-// We need to add 100% height to the div so that the Iframe will size properly.
 .components-modal__content {
 	& > div {
 		&:not(.components-modal__header) {


### PR DESCRIPTION
When building the plugin for testing it was failing at creating the proper CSS because of the error 

```
ERROR in ./src/modules/elements/attendees-registration/style.pcss (./node_modules/css-loader??ref--5-1!./node_modules/postcss-loader/lib??ref--5-2!./src/modules/elements/attendees-registration/style.pcss)
        Module build failed (from ./node_modules/postcss-loader/lib/index.js):
```


This removes the comment and fixes the build process.