### PR TITLE
[ET-1874] My Tickets Redesign: Move opt out checkbox after tickets list

### DIFF
--- a/src/resources/postcss/my-tickets/_orders.pcss
+++ b/src/resources/postcss/my-tickets/_orders.pcss
@@ -32,9 +32,13 @@
 			padding: 0;
 		}
 
+		.tec__tickets-my-tickets-order-tickets-list-wrapper {
+			margin: 0 0 var(--tec-spacer-8);
+		}
+
 		.tribe-tickets-list {
 			list-style: none;
-			margin: 0 0 var(--tec-spacer-8);
+			margin: 0 0 var(--tec-spacer-2);
 			padding: 0;
 
 			> .tribe-item {

--- a/src/resources/postcss/rsvp-v1.pcss
+++ b/src/resources/postcss/rsvp-v1.pcss
@@ -68,9 +68,13 @@
 	font-style: italic;
 }
 
+div.tec__tickets-my-tickets-rsvp-attendee-list-wrapper {
+	margin: 0 0 var(--tec-spacer-8);
+}
+
 .tribe-rsvp-list {
 	list-style: none;
-	margin: 0 0 var(--tec-spacer-8);
+	margin: 0 0 var(--tec-spacer-2);
 	padding: 0;
 
 	> .tribe-item {
@@ -326,15 +330,26 @@
 		font-size: 11px;
 	}
 
+
 	.tribe-tickets-attendees-list-optout {
+		align-items: center;
+		display: flex;
+		flex-flow: row wrap;
+
 		label {
 			color: var(--tec-color-text-secondary);
-			font-size: 13px;
 		}
 
 		input[type='radio'] + label,
 		input[type='checkbox'] + label {
 			display: inline-block;
+			font-size: var(--tec-font-size-2);
+			margin: 0;
+		}
+
+		input[type='checkbox'] {
+			height: var(--tec-spacer-3);
+			width: var(--tec-spacer-3);
 		}
 	}
 

--- a/src/resources/postcss/tpp.pcss
+++ b/src/resources/postcss/tpp.pcss
@@ -41,9 +41,13 @@
 	border-color: #c00;
 }
 
+.tec__tickets-my-tickets-rsvp-attendee-list-wrapper {
+	margin: 0 0 var(--tec-spacer-8);
+}
+
 .tribe-tpp-list {
 	list-style: none;
-	margin: 0 0 var(--tec-spacer-8);
+	margin: 0 0 var(--tec-spacer-2);
 	padding: 0;
 
 	> .tribe-item {

--- a/src/views/tickets/my-tickets/tickets-list.php
+++ b/src/views/tickets/my-tickets/tickets-list.php
@@ -14,37 +14,50 @@
  */
 
 ?>
-<ul class="tribe-tickets-list tribe-list">
-	<?php foreach ( $attendees as $i => $attendee ) : ?>
-		<li class="tribe-item" id="ticket-<?php echo esc_attr( $order_id ); ?>">
-			<input type="hidden" name="attendee[<?php echo esc_attr( $order_id ); ?>][attendees][]" value="<?php echo esc_attr( $attendee['attendee_id'] ); ?>">
-			<?php 
-				$this->template( 'tickets/my-tickets/attendee-label', [ 
-					'attendee_label' => sprintf( esc_html__( 'Attendee %d', 'event-tickets' ), $i + 1 )
-				] );
-			?>
-			<?php $this->template( 'tickets/my-tickets/ticket-information', [
-				'attendee' => $attendee,
-			] ); ?>
-			<?php
-			/**
-			 * Inject content into a Ticket's attendee block on the Tickets orders page.
-			 *
-			 * @param array   $attendee Attendee array.
-			 * @param WP_Post $post     Post object that the tickets are tied to.
-			 */
-			do_action( 'event_tickets_orders_attendee_contents', $attendee, $post );
-			
-			/**
-			 * Inject content into a Ticket's attendee block on the Tickets orders page.
-			 * 
-			 * @since TBD
-			 *
-			 * @param array   $attendee Attendee array.
-			 * @param WP_Post $post     Post object that the tickets are tied to.
-			 */
-			do_action( 'tec_tickets_orders_attendee_contents', $attendee, $post );
-			?>
-		</li>
-	<?php endforeach; ?>
-</ul>
+<div class="tec__tickets-my-tickets-order-tickets-list-wrapper">
+	<ul class="tribe-tickets-list tribe-list">
+		<?php foreach ( $attendees as $i => $attendee ) : ?>
+			<li class="tribe-item" id="ticket-<?php echo esc_attr( $order_id ); ?>">
+				<input type="hidden" name="attendee[<?php echo esc_attr( $order_id ); ?>][attendees][]" value="<?php echo esc_attr( $attendee['attendee_id'] ); ?>">
+				<?php 
+					$this->template( 'tickets/my-tickets/attendee-label', [ 
+						'attendee_label' => sprintf( esc_html__( 'Attendee %d', 'event-tickets' ), $i + 1 )
+					] );
+				?>
+				<?php $this->template( 'tickets/my-tickets/ticket-information', [
+					'attendee' => $attendee,
+				] ); ?>
+				<?php
+				/**
+				 * Inject content into a Ticket's attendee block on the Tickets orders page.
+				 *
+				 * @param array   $attendee Attendee array.
+				 * @param WP_Post $post     Post object that the tickets are tied to.
+				 */
+				do_action( 'event_tickets_orders_attendee_contents', $attendee, $post );
+				
+				/**
+				 * Inject content into a Ticket's attendee block on the Tickets orders page.
+				 * 
+				 * @since TBD
+				 *
+				 * @param array   $attendee Attendee array.
+				 * @param WP_Post $post     Post object that the tickets are tied to.
+				 */
+				do_action( 'tec_tickets_orders_attendee_contents', $attendee, $post );
+				?>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+	<?php
+	/**
+	 * Inject content after the Order Tickets List on the My Tickets page
+	 * 
+	 * @since TBD
+	 *
+	 * @param array   $attendees Attendee array.
+	 * @param WP_Post $post_id   Post object that the tickets are tied to.
+	 */
+	do_action( 'tec_tickets_my_tickets_after_tickets_list', $attendees, $post_id );
+	?>
+</div>

--- a/src/views/tickets/orders-pp-tickets.php
+++ b/src/views/tickets/orders-pp-tickets.php
@@ -69,40 +69,53 @@ $attendee_groups = $view->get_post_attendees_by_purchaser( $post_id, $user_id );
 				),
 			] );
 		?>
-		<ul class="tribe-tpp-list tribe-list">
-			<?php foreach ( $attendee_group as $i => $attendee ) : ?>
-				<?php $key = $attendee['order_id']; ?>
-				<li class="tribe-item<?php echo $view->is_tpp_ticket_restricted( $post_id, $attendee['product_id'] ) ? 'tribe-disabled' : ''; ?>" <?php echo $view->get_restriction_attr( $post_id, $attendee['product_id'] ); ?> id="attendee-<?php echo $attendee['order_id']; ?>">
-					<?php 
-						$this->template( 'tickets/my-tickets/attendee-label', [ 
-							// Translators: %d is the attendee number.
-							'attendee_label' => sprintf( esc_html__( 'Attendee %d', 'event-tickets' ), $i + 1 )
-						] );
-					?>
-					<div class="tribe-answer">
-						<!-- Wrapping <label> around both the text and the <select> will implicitly associate the text with the label. -->
-						<!-- See https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly -->
-						<label>
-							<?php echo esc_html_x( 'Payment status: ', 'order status label', 'event-tickets' ); ?>
-							<?php
-								$view->render_ticket_status( $attendee['order_status'] );
-							?>
-						</label>
-						<div class="ticket-type"><span class="type-label"><?php esc_html_e( 'Type: ', 'event-tickets' );?></span><?php esc_html_e( $attendee['ticket'] );?></div>
-					</div>
-					<?php
-					/**
-					 * Inject content into an RSVP attendee block on the RVSP orders page
-					 *
-					 * @since 4.7
-					 *
-					 * @param array $attendee Attendee array
-					 * @param WP_Post $post Post object that the tickets are tied to
-					 */
-					do_action( 'event_tickets_orders_attendee_contents', $attendee, $post );
-					?>
-				</li>
-			<?php endforeach; ?>
-		</ul>
+		<div class="tec__tickets-my-tickets-order-tickets-list-wrapper">
+			<ul class="tribe-tpp-list tribe-list">
+				<?php foreach ( $attendee_group as $i => $attendee ) : ?>
+					<?php $key = $attendee['order_id']; ?>
+					<li class="tribe-item<?php echo $view->is_tpp_ticket_restricted( $post_id, $attendee['product_id'] ) ? 'tribe-disabled' : ''; ?>" <?php echo $view->get_restriction_attr( $post_id, $attendee['product_id'] ); ?> id="attendee-<?php echo $attendee['order_id']; ?>">
+						<?php 
+							$this->template( 'tickets/my-tickets/attendee-label', [ 
+								// Translators: %d is the attendee number.
+								'attendee_label' => sprintf( esc_html__( 'Attendee %d', 'event-tickets' ), $i + 1 )
+							] );
+						?>
+						<div class="tribe-answer">
+							<!-- Wrapping <label> around both the text and the <select> will implicitly associate the text with the label. -->
+							<!-- See https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly -->
+							<label>
+								<?php echo esc_html_x( 'Payment status: ', 'order status label', 'event-tickets' ); ?>
+								<?php
+									$view->render_ticket_status( $attendee['order_status'] );
+								?>
+							</label>
+							<div class="ticket-type"><span class="type-label"><?php esc_html_e( 'Type: ', 'event-tickets' );?></span><?php esc_html_e( $attendee['ticket'] );?></div>
+						</div>
+						<?php
+						/**
+						 * Inject content into an RSVP attendee block on the RVSP orders page
+						 *
+						 * @since 4.7
+						 *
+						 * @param array $attendee Attendee array
+						 * @param WP_Post $post Post object that the tickets are tied to
+						 */
+						do_action( 'event_tickets_orders_attendee_contents', $attendee, $post );
+						?>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+			<?php
+			/**
+			 * Inject content after the Order Tickets List on the My Tickets page
+			 * 
+			 * @since TBD
+			 *
+			 * @param array   $attendees Attendee array.
+			 * @param WP_Post $post_id   Post object that the tickets are tied to.
+			 */
+			do_action( 'tec_tickets_my_tickets_after_tickets_list', $attendees, $post_id );
+			?>
+		</div>
 	<?php endforeach; ?>
 </div>

--- a/src/views/tickets/orders-rsvp.php
+++ b/src/views/tickets/orders-rsvp.php
@@ -59,52 +59,65 @@ $attendee_groups = $view->get_event_rsvp_attendees_by_purchaser( $post_id, $user
 				'title'  => tribe_get_rsvp_label_plural( basename( __FILE__ ) ),
 			] );
 		?>
-		<ul class="tribe-rsvp-list tribe-list">
-			<?php foreach ( $attendee_group as $i => $attendee ): ?>
-				<?php $key = $attendee['order_id']; ?>
-				<li class="tribe-item<?php echo $view->is_rsvp_restricted( $post_id, $attendee['product_id'] ) ? 'tribe-disabled' : ''; ?>" <?php echo $view->get_restriction_attr( $post_id, $attendee['product_id'] ); ?> id="attendee-<?php echo $attendee['order_id']; ?>">
-					<?php 
-						$this->template( 'tickets/my-tickets/attendee-label', [
-							// Translators: %d is the attendee number.
-							'attendee_label' => sprintf( esc_html__( 'Attendee %d', 'event-tickets' ), $i + 1 )
-						] );
-					?>
-					<div class="tribe-answer">
-						<!-- Wrapping <label> around both the text and the <select> will implicitly associate the text with the label. -->
-						<!-- See https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly -->
-						<label>
-							<?php echo esc_html_x( 'RSVP: ', 'order status label', 'event-tickets' ); ?>
-							<?php
-							if ( ! empty( $attendee['ticket_exists'] ) ) {
-								$view->render_rsvp_selector(
-									"attendee[{$key}][order_status]",
-									$attendee['order_status'],
-									$post_id,
-									$attendee['product_id']
-								);
-							} else {
-								$view->render_rsvp_status(
-									"attendee[{$key}][order_status]",
-									$attendee['order_status'],
-									$post_id,
-									$attendee['product_id']
-								);
-							}
-							?>
-						</label>
-						<div class="ticket-type"><span class="type-label"><?php esc_html_e( 'Type: ', 'event-tickets' );?></span><?php esc_html_e( $attendee['ticket'] );?></div>
-					</div>
-					<?php
-					/**
-					 * Inject content into an RSVP attendee block on the RVSP orders page
-					 *
-					 * @param array $attendee Attendee array
-					 * @param WP_Post $post Post object that the tickets are tied to
-					 */
-					do_action( 'event_tickets_orders_attendee_contents', $attendee, $post );
-					?>
-				</li>
-			<?php endforeach; ?>
-		</ul>
+		<div class="tec__tickets-my-tickets-rsvp-attendee-list-wrapper">
+			<ul class="tribe-rsvp-list tribe-list">
+				<?php foreach ( $attendee_group as $i => $attendee ): ?>
+					<?php $key = $attendee['order_id']; ?>
+					<li class="tribe-item<?php echo $view->is_rsvp_restricted( $post_id, $attendee['product_id'] ) ? 'tribe-disabled' : ''; ?>" <?php echo $view->get_restriction_attr( $post_id, $attendee['product_id'] ); ?> id="attendee-<?php echo $attendee['order_id']; ?>">
+						<?php 
+							$this->template( 'tickets/my-tickets/attendee-label', [
+								// Translators: %d is the attendee number.
+								'attendee_label' => sprintf( esc_html__( 'Attendee %d', 'event-tickets' ), $i + 1 )
+							] );
+						?>
+						<div class="tribe-answer">
+							<!-- Wrapping <label> around both the text and the <select> will implicitly associate the text with the label. -->
+							<!-- See https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly -->
+							<label>
+								<?php echo esc_html_x( 'RSVP: ', 'order status label', 'event-tickets' ); ?>
+								<?php
+								if ( ! empty( $attendee['ticket_exists'] ) ) {
+									$view->render_rsvp_selector(
+										"attendee[{$key}][order_status]",
+										$attendee['order_status'],
+										$post_id,
+										$attendee['product_id']
+									);
+								} else {
+									$view->render_rsvp_status(
+										"attendee[{$key}][order_status]",
+										$attendee['order_status'],
+										$post_id,
+										$attendee['product_id']
+									);
+								}
+								?>
+							</label>
+							<div class="ticket-type"><span class="type-label"><?php esc_html_e( 'Type: ', 'event-tickets' );?></span><?php esc_html_e( $attendee['ticket'] );?></div>
+						</div>
+						<?php
+						/**
+						 * Inject content into an RSVP attendee block on the RVSP orders page
+						 *
+						 * @param array $attendee Attendee array
+						 * @param WP_Post $post Post object that the tickets are tied to
+						 */
+						do_action( 'event_tickets_orders_attendee_contents', $attendee, $post );
+						?>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+			<?php
+			/**
+			 * Inject content after the RSVP Attendees List on the My Tickets page
+			 * 
+			 * @since TBD
+			 *
+			 * @param array   $attendee_group Attendee array.
+			 * @param WP_Post $post_id        Post object that the tickets are tied to.
+			 */
+			do_action( 'tec_tickets_my_tickets_after_rsvps_list', $attendee_group, $post_id );
+			?>
+		</div>
 	<?php endforeach; ?>
 </div>


### PR DESCRIPTION
### 🎫 Ticket

[ET-1874] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Design suggested moving the opt out checkbox to after the tickets list, so this PR makes that changes. It required adding a couple of new filters in the spot where the checkbox will be moved to.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/59278ca6-13f9-4e49-bf67-a6ee4d2b0625)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1874]: https://stellarwp.atlassian.net/browse/ET-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ