### PR TITLE
[ETWP-46] Wallet Plus: Restyle My Tickets Page for Passes

### DIFF
--- a/src/resources/postcss/my-tickets/_orders.pcss
+++ b/src/resources/postcss/my-tickets/_orders.pcss
@@ -42,9 +42,13 @@
 			padding: 0;
 
 			> .tribe-item {
+				align-items: center;
 				background-color: var(--tec-color-background);
 				border: 1px solid var(--tec-color-border-default);
 				border-bottom: 0;
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: space-between;
 				margin: 0;
 				padding: var(--tec-spacer-5);
 
@@ -69,7 +73,6 @@
 					font-size: var(--tec-font-size-3);
 					font-weight: var(--tec-font-weight-regular);
 					line-height: var(--tec-line-height-0);
-					margin-bottom: var(--tec-spacer-5);
 				}
 
 				.tribe-answer {

--- a/src/resources/postcss/rsvp-v1.pcss
+++ b/src/resources/postcss/rsvp-v1.pcss
@@ -78,9 +78,13 @@ div.tec__tickets-my-tickets-rsvp-attendee-list-wrapper {
 	padding: 0;
 
 	> .tribe-item {
+		align-items: center;
 		background-color: var(--tec-color-background);
 		border: 1px solid var(--tec-color-border-default);
 		border-bottom: 0;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
 		margin: 0;
 		min-height: 105px;
 		padding: var(--tec-spacer-5);

--- a/src/views/tickets/my-tickets/attendee-label.php
+++ b/src/views/tickets/my-tickets/attendee-label.php
@@ -12,6 +12,6 @@
  */
  
 ?>
-<p class="list-attendee">
+<div class="list-attendee">
 	<?php echo esc_html( $attendee_label ); ?>
-</p>
+</div>


### PR DESCRIPTION
### 🎫 Ticket

[ETWP-46] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We are injecting the Wallet Plus passes into the My Tickets page, but it required a little bit of a makeover to make it look the way we wanted it. These changes along with changed in ETWP and ETP make it look perfect.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/04d6b4bf-d739-42bf-a2fc-89cc902c3892)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ETWP-46]: https://stellarwp.atlassian.net/browse/ETWP-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ