### PR TITLE
Wallet Plus: Move ETP App Settings Banner Template and CSS to ET

### DIFF
--- a/src/admin-views/settings/etp-app-banner.php
+++ b/src/admin-views/settings/etp-app-banner.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Event Tickets Plus App banner section.
+ *
+ * @since 5.6.2
+ *
+ * @var string $qr_src     URL for the connection QR code image.
+ * @var string $site_url   The website URL.
+ * @var string $api_key    The API key string.
+ * @var string $nonce      The nonce that will be used for regenerating the connector key.
+ * @var string $action_key The AJAX action key that will be used to regenerate the connector key.
+ *
+ */
+
+?>
+<div class="tec-tickets__admin-banner tec-tickets__admin-etp-app-settings-banner">
+	<h3 class="heading"><?php esc_html_e( 'Connect Your Event Tickets Plus App', 'event-tickets-plus' ); ?></h3>
+	<p class="tec-tickets__admin-etp-app-settings-banner__help-text"><?php esc_html_e( 'Scan the QR to connect with your tickets or manually enter the API key in your app settings.', 'event-tickets-plus' ); ?></p>
+
+	<div class="tec-tickets__admin-etp-app-settings-connection-wrapper">
+		<div class="tec-tickets__admin-etp-app-settings-qr-code">
+			<img id="connection_qr_code" alt="qr_code_image" src="<?php echo esc_attr( $qr_src ); ?>" data-tickets-qr-connector-image>
+		</div>
+		<div class="tec-tickets__admin-etp-app-settings-manual-options">
+			<label class="tec-tickets__admin-etp-app-settings-site-url-label"><?php esc_html_e( 'Website URL', 'event-tickets-plus' ) ?></label>
+			<p class="tec-tickets__admin-etp-app-settings-site-url"><?php echo esc_url( $site_url ) ?></p>
+			<label class="tec-tickets__admin-etp-app-settings-api-key-label"><?php esc_html_e( 'API Key', 'event-tickets-plus' ); ?></label>
+			<input
+				class="tec-tickets__admin-etp-app-settings-api-key"
+				type="text"
+				value="<?php echo esc_attr( $api_key ) ?>"
+				name="tickets-plus-qr-options-api-key"
+				disabled
+				data-tickets-qr-connector-input
+			/>
+			<a
+				class="tec-tickets__admin-etp-app-settings-generate-api-key"
+				data-tickets-qr-connector
+				data-tickets-qr-connector-nonce="<?php echo esc_attr( $nonce ) ?>"
+				data-tickets-qr-connector-action="<?php echo esc_attr( $action_key ) ?>"
+				data-tickets-qr-connector-container=".tec-tickets__admin-etp-app-settings-banner"
+			>
+				<?php esc_html_e( 'Refresh API Key', 'event-tickets-plus' ); ?>
+			</a>
+		</div>
+	</div>
+	<div
+		id="tec-tickets__admin-etp-app-settings-confirmation-text"
+		data-tickets-qr-connector-message
+		class="tribe-common-a11y-hidden"
+	>
+		<?php esc_html_e( 'Refreshing the API key will disconnect existing users until they add the new key in their app settings.', 'event-tickets-plus' ) ?>
+	</div>
+</div>

--- a/src/admin-views/settings/etp-app-banner.php
+++ b/src/admin-views/settings/etp-app-banner.php
@@ -2,7 +2,7 @@
 /**
  * Event Tickets Plus App banner section.
  *
- * @since TBD
+ * @since TBD Moved from ETP to ET to provide support for extensions.
  * @version TBD
  *
  * @var string $qr_src     URL for the connection QR code image.

--- a/src/admin-views/settings/etp-app-banner.php
+++ b/src/admin-views/settings/etp-app-banner.php
@@ -9,9 +9,7 @@
  * @var string $api_key    The API key string.
  * @var string $nonce      The nonce that will be used for regenerating the connector key.
  * @var string $action_key The AJAX action key that will be used to regenerate the connector key.
- *
  */
-
 ?>
 <div class="tec-tickets__admin-banner tec-tickets__admin-etp-app-settings-banner">
 	<h3 class="heading"><?php esc_html_e( 'Connect Your Event Tickets Plus App', 'event-tickets-plus' ); ?></h3>

--- a/src/admin-views/settings/etp-app-banner.php
+++ b/src/admin-views/settings/etp-app-banner.php
@@ -2,7 +2,8 @@
 /**
  * Event Tickets Plus App banner section.
  *
- * @since 5.6.2
+ * @since TBD
+ * @version TBD
  *
  * @var string $qr_src     URL for the connection QR code image.
  * @var string $site_url   The website URL.

--- a/src/resources/postcss/tickets-admin/settings/_banners.pcss
+++ b/src/resources/postcss/tickets-admin/settings/_banners.pcss
@@ -128,3 +128,82 @@ a.tec-tickets__admin-tc-banner-link {
 		text-decoration: none;
 	}
 }
+
+.tec-tickets__admin-banner {
+	&.tec-tickets__admin-etp-app-settings-banner {
+		background-color: #fff;
+
+		.heading {
+			background: none;
+		}
+	}
+}
+
+.tec-tickets__admin-etp-app-settings-banner-help-text {
+	max-width: 690px;
+}
+
+.tec-tickets__admin-etp-app-settings-connection-wrapper {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	max-width: 640px;
+	text-align: center;
+
+	@media (--viewport-medium) {
+		flex-direction: row;
+	}
+}
+
+.tec-tickets__admin-etp-app-settings-qr-code {
+	width: 246px;
+
+	img {
+		height: 100%;
+		width: 100%;
+	}
+}
+
+.tec-tickets__admin-etp-app-settings-manual-options {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	margin: 20px 20px;
+	padding: 10px;
+	text-align: center;
+
+	.tec-tickets__admin-etp-app-settings-api-key {
+		background: #efeff0;
+		border: 0;
+		border-radius: 0;
+		box-shadow: none;
+		color: #000;
+		font-family: monospace, roboto, arial;
+		font-size: var(--tec-font-size-5);
+		font-weight: var(--tec-font-weight-regular);
+		height: 36px;
+		line-height: var(--tec-line-height-3);
+		margin: 0.25em 0 0.75em;
+		text-align: center;
+		width: 160px;
+	}
+}
+
+.tec-tickets__admin-etp-app-settings-site-url {
+	font-size: var(--tec-font-size-2);
+	font-weight: var(--tec-font-weight-regular);
+	line-height: var(--tec-line-height-2);
+	margin: 0.25em 0 1.25em;
+}
+
+.tec-tickets__admin-etp-app-settings-api-key-label,
+.tec-tickets__admin-etp-app-settings-site-url-label {
+	color: #3c434a;
+	font-size: var(--tec-font-size-1);
+	font-weight: var(--tec-font-weight-bold);
+	line-height: var(--tec-line-height-2);
+}
+
+.tec-tickets__admin-etp-app-settings-generate-api-key {
+	cursor: pointer;
+}


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
Since the ETP App settings are being shared between ETP and ETWP, we need to move the ETP settings banner into ET.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/93835b58-6eb3-4745-8405-bde588f3ad19)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
