### PR TITLE
Fix deprecated notice

### DIFF
--- a/src/Tickets/Commerce/Gateways/Contracts/Abstract_Requests.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/Abstract_Requests.php
@@ -76,7 +76,7 @@ abstract class Abstract_Requests implements Requests_Interface {
 			// For all other methods we try to make the body into the correct type.
 			if (
 				! empty( $request_arguments['body'] )
-				&& 'application/json' === strtolower( $content_type )
+				&& 'application/json' === strtolower( $content_type ?? '' )
 			) {
 				$request_arguments['body'] = wp_json_encode( $request_arguments[ $key ] );
 			}

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -239,7 +239,7 @@ class Tickets implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): mixed {
 		$this->data = $this->fetch_data();
 
 		return $this->data[ $offset ] ?? null;


### PR DESCRIPTION
### 🎫 Ticket

- N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Fixing a deprecation notice on the TC checkout page. Saw it while testing on Romine's sandbox.

<img width="1643" alt="Screenshot 2023-11-09 at 10 37 38" src="https://github.com/the-events-calendar/event-tickets/assets/252415/c0951786-5b75-4b7d-92ee-3c42c54c097c">
