### PR TITLE
Fix PHP8.1 deprecation notices for `add_submenu_page` only taking stings as first param.

### DIFF
--- a/src/Tickets/Commerce/Reports/Attendees.php
+++ b/src/Tickets/Commerce/Reports/Attendees.php
@@ -83,7 +83,7 @@ class Attendees extends Report_Abstract {
 
 		$page_title           = __( 'Tickets Commerce Attendees', 'event-tickets' );
 		$this->attendees_page = add_submenu_page(
-			null,
+			'',
 			$page_title,
 			$page_title,
 			$cap,

--- a/src/Tickets/Commerce/Reports/Orders.php
+++ b/src/Tickets/Commerce/Reports/Orders.php
@@ -262,7 +262,7 @@ class Orders extends Report_Abstract {
 
 		$page_title        = __( 'Tickets Commerce Orders', 'event-tickets' );
 		$this->orders_page = add_submenu_page(
-			null,
+			'',
 			$page_title,
 			$page_title,
 			$cap,

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -292,7 +292,7 @@ class Tribe__Tickets__Attendees {
 		}
 
 		$this->page_id = add_submenu_page(
-			null,
+			'',
 			'Attendee list',
 			'Attendee list',
 			$cap,

--- a/src/Tribe/Editor/Attendee_Registration.php
+++ b/src/Tribe/Editor/Attendee_Registration.php
@@ -70,9 +70,9 @@ class Tribe__Tickets__Editor__Attendee_Registration {
 	 * @return void
 	 */
 	public function admin_menu() {
-		// Setup attendee registration
+		// Setup attendee registration.
 		add_submenu_page(
-			null, // attach to null so it doesn't appear in sidebar.
+			'',
 			'Attendee Registration',
 			'Attendee Registration', // hidden.
 			'edit_posts',


### PR DESCRIPTION
### 🎫 Ticket

N/A

### 🗒️ Description

Fix PHP8.1 deprecation notices for [add_submenu_page](https://developer.wordpress.org/reference/functions/add_submenu_page/) only taking stings as first param.

First param is $parent_slug, which should be string.
