### PR TITLE
Wallet Plus: DQA Fix - Pass buttons overflowing on mobile after RSVP registration

### DIFF
--- a/src/resources/postcss/components/attendees-list/_attendees.pcss
+++ b/src/resources/postcss/components/attendees-list/_attendees.pcss
@@ -17,11 +17,17 @@
 		border-top: 1px solid var(--tec-color-border-secondary);
 		container-type: inline-size;
 		display: flex;
+		flex-direction: column;
+		gap: var(--tec-spacer-1);
 		margin: 0;
 		padding: var(--tec-spacer-4);
 
 		&:last-child {
 			border-bottom: 1px solid var(--tec-color-border-secondary);
+		}
+
+		@media (--viewport-medium) {
+			flex-direction: row;
 		}
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
DQA found that on mobile devices, after RSVP registration to an event, the pass buttons overflow out of the container. This fix stacks the buttons on small devices.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/ef3824b4-d1e2-4a34-9d26-61c7e412eebd)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
