### PR TITLE
Fix attendees list for RSVP block

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -327,6 +327,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			'login_url'  => self::get_login_url( $post_id ),
 			'threshold'  => $blocks_rsvp->get_threshold( $post_id ),
 			'going'      => tribe_get_request_var( 'going', 'yes' ),
+			'attendees'  => [],
 		];
 
 		/**

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1262,6 +1262,7 @@ class Tribe__Tickets__Tickets_View {
 			'doing_shortcode'     => $doing_shortcode,
 			'block_html_id'       => $block_html_id,
 			'going'               => tribe_get_request_var( 'going', '' ),
+			'attendees'           => [],
 		];
 
 		/**

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
@@ -66,21 +66,5 @@
 
 	</div>
 
-	<div class="tribe-tickets__rsvp-attendees-wrapper tribe-common-g-row">
-	<div class="tec-tickets__attendees-list-wrapper tribe-tickets__rsvp-attendees tribe-common-b1 tribe-common-g-col">
-		<h4 class="tribe-common-h4 tribe-common-h6--min-medium">
-	Your RSVPs</h4>
-		<div class="tec-tickets__attendees-list">
-							<div class="tec-tickets__attendees-list-item">
-					<div class="tec-tickets__attendees-list-item-attendee-details">
-	Test RSVP ticket for 287</div>
-				</div>
-							<div class="tec-tickets__attendees-list-item">
-					<div class="tec-tickets__attendees-list-item-attendee-details">
-	Test RSVP ticket for 287</div>
-				</div>
-					</div>
-	</div>
-</div>
-
+	
 ';


### PR DESCRIPTION
### 🎫 Ticket

N/A <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
WE found that the `$attendees` variable within the global context wasn't getting reset for the RSVP block and when the Attendee List block is placed on the same page, above the RSVP block, it causes issues.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/b2d2b789-cdf4-4c3a-af00-6ee3b4cea6f4)

After:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/899e7864-0539-44a6-a6d9-ca529358add6)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
