### PR TITLE
[ET-1924] Fix order of attendees on success confirmation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Attendees listed on the `Your Tickets` section will now match the order they were entered in. [ET-1924]
+
 = [5.7.0] 2023-11-16 =
 
 * Version - Event Tickets 5.7.0 is only compatible with The Events Calendar 6.2.7 and higher.

--- a/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
@@ -40,6 +40,11 @@ class Success_Shortcode extends Shortcode_Abstract {
 			'gateway_order_id' => $order_id,
 		] )->first();
 
+		$attendees = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
+		// Sort the Attendees by ID.
+		$attendee_ids = array_column( $attendees, 'ID' );
+		array_multisort( $attendee_ids, SORT_ASC, $attendees );
+
 		$args = [
 			'provider_id'    => Module::class,
 			'provider'       => tribe( Module::class ),
@@ -47,7 +52,7 @@ class Success_Shortcode extends Shortcode_Abstract {
 			'order'          => $order,
 			'is_tec_active'  => defined( 'TRIBE_EVENTS_FILE' ) && class_exists( 'Tribe__Events__Main' ),
 			'payment_method' => tribe( Order::class )->get_gateway_label( $order ),
-			'attendees'      => tribe( Module::class )->get_attendees_by_order_id( $order->ID ),
+			'attendees'      => $attendees,
 		];
 
 		$this->template_vars = $args;

--- a/src/views/components/attendees-list/attendees.php
+++ b/src/views/components/attendees-list/attendees.php
@@ -26,6 +26,10 @@ if ( empty( $order ) || empty( $attendees ) ) {
 	return;
 }
 
+// Sort the Attendees by their ID.
+$attendee_ids = array_column($attendees, 'ID');
+array_multisort($attendee_ids, SORT_ASC, $attendees);
+
 $wrapper_classes = [
 	'tribe-common',
 	'tribe-common-b1',

--- a/src/views/components/attendees-list/attendees.php
+++ b/src/views/components/attendees-list/attendees.php
@@ -26,10 +26,6 @@ if ( empty( $order ) || empty( $attendees ) ) {
 	return;
 }
 
-// Sort the Attendees by their ID.
-$attendee_ids = array_column($attendees, 'ID');
-array_multisort($attendee_ids, SORT_ASC, $attendees);
-
 $wrapper_classes = [
 	'tribe-common',
 	'tribe-common-b1',


### PR DESCRIPTION
### 🎫 Ticket

[ET-1924]  <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
The attendees array being passed over to the `Your Tickets` section wasn't properly ordered by ID. Therefore, it was displaying the attendees out of order from how they were being added.

<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
For the artifact I followed the scenario listed in the original ticket -

When I visit the event page and I add 3 tickets to buy
- And for the attendee 1 I set the name to: Lionel Messi
- And for the attendee 2 I set the name to: Pablo Aimar
- And for the attendee 3 I set the name to: Enzo Fernandez
[artifact_et-1924.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/db08054b-2afc-41c1-8a5d-2e0d86fe6964)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1924]: https://stellarwp.atlassian.net/browse/ET-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ