### PR TITLE
[ET-1935] PHP 8+ compatibility for Implode in REST Endpoint

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak -  Prevented Single Attendee endpoint from throwing a notice on PHP 8+.
+
 = [5.7.0] 2023-11-16 =
 
 * Version - Event Tickets 5.7.0 is only compatible with The Events Calendar 6.2.7 and higher.

--- a/readme.txt
+++ b/readme.txt
@@ -197,7 +197,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Tweak -  Prevented Single Attendee endpoint from throwing a notice on PHP 8+. [ET-1935]
+* Tweak - Prevented Single Attendee endpoint from throwing a notice on PHP 8+. [ET-1935]
 * Tweak - Attendees listed on the `Your Tickets` section will now match the order they were entered in. [ET-1924]
 
 = [5.7.0] 2023-11-16 =

--- a/readme.txt
+++ b/readme.txt
@@ -197,7 +197,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Tweak -  Prevented Single Attendee endpoint from throwing a notice on PHP 8+.
+* Tweak -  Prevented Single Attendee endpoint from throwing a notice on PHP 8+. [ET-1935]
 
 = [5.7.0] 2023-11-16 =
 

--- a/src/Tribe/REST/V1/Endpoints/Single_Attendee.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Attendee.php
@@ -359,7 +359,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Single_Attendee
 				$error_message  = sprintf(
 					// Translators: %s - List of valid statuses.
 					__( 'Supported statuses for this attendee are: %s', 'event-tickets' ),
-					implode( $statuses, ' | ' )
+					implode( ' | ', $statuses )
 				);
 				return new WP_Error( 'invalid-attendee-status', $error_message, [ 'status' => 400 ] );
 			}


### PR DESCRIPTION
### 🎫 Ticket

[ET-1935] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
Fixed compatability issue with php 8+.


[ET-1935]: https://stellarwp.atlassian.net/browse/ET-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ