### PR TITLE
Fix/gtria 1126 available tickets

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correct the counting logic for the total available number of tickets on the Attendees page. [GTRIA-1126]
+
 = [5.7.0] 2023-11-16 =
 
 * Version - Event Tickets 5.7.0 is only compatible with The Events Calendar 6.2.7 and higher.

--- a/src/admin-views/attendees/attendees-event/overview.php
+++ b/src/admin-views/attendees/attendees-event/overview.php
@@ -34,8 +34,9 @@ foreach ( $tickets as $ticket ) {
 	$tickets_by_types[ $type ][] = $ticket;
 }
 $ticket_totals = [
-	'sold'      => 0,
-	'available' => 0,
+	'sold'             => 0,
+	'available'        => 0,
+	'global_available' => [],
 ];
 foreach ( $tickets_by_types as $type_name => $type_tickets ) {
 	foreach ( $type_tickets as $ticket ) {
@@ -43,12 +44,15 @@ foreach ( $tickets_by_types as $type_name => $type_tickets ) {
 		if ( $ticket_totals['available'] > -1 ) {
 			if ( -1 === $ticket->available() ) {
 				$ticket_totals['available'] = -1;
+			} elseif ( $ticket->global_stock_mode() == 'global' || $ticket->global_stock_mode() == 'capped' ) {
+				$ticket_totals['global_available'][] = $ticket->available();
 			} else {
 				$ticket_totals['available'] += $ticket->available();
 			}
 		}
 	}
 }
+$ticket_totals['available'] += max( $ticket_totals['global_available'] );
 
 ?>
 <div class="welcome-panel-column welcome-panel-middle">

--- a/src/admin-views/attendees/attendees-event/overview.php
+++ b/src/admin-views/attendees/attendees-event/overview.php
@@ -36,7 +36,7 @@ foreach ( $tickets as $ticket ) {
 $ticket_totals = [
 	'sold'             => 0,
 	'available'        => 0,
-	'global_available' => [],
+	'global_available' => [ 0 ],
 ];
 foreach ( $tickets_by_types as $type_name => $type_tickets ) {
 	foreach ( $type_tickets as $ticket ) {

--- a/tests/wpunit/Tribe/Tickets/Partials/__snapshots__/Attendees_Page_Header__should_match_snapshot__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/__snapshots__/Attendees_Page_Header__should_match_snapshot__1.php
@@ -48,7 +48,8 @@
 				(90 available)			</span>
 		</div>
 	</div>
-	</div>			<div class="welcome-panel-column welcome-panel-last alternate">
+	</div>
+			<div class="welcome-panel-column welcome-panel-last alternate">
 	<h3>Attendance Overview</h3>
 		<div class="tec-tickets__admin-attendees-attendance-type-list">
 		<div class="tec-tickets__admin-attendees-attendance-type">


### PR DESCRIPTION
### 🎫 Ticket

[GTRIA-1126] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The counting logic for the total number of available tickets on the attendees page did not account for shared capacity tickets correctly. All availability was added up instead of just adding the highest number of available tickets from the shared ones.
The new code checks if the ticket is a shared capacity ticket or one with a cap, and collects those numbers in an array.
After all other additions (single tickets) are done, the highest number from that array is added to the total available number.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot](https://www.dropbox.com/scl/fi/gah455m216ai6ko2g5n6w/shot_231123_235016.jpg?rlkey=knorzg2cwiv9h8gngplcnlsvv&dl=0)
[Screenshot with fix](https://www.dropbox.com/scl/fi/o6palgjc2hp5mawpjlmbb/shot_231124_000926.jpg?rlkey=9hqfgjvtvgguwh8drjo4skxes&dl=0)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] Not relevant - My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[GTRIA-1126]: https://stellarwp.atlassian.net/browse/GTRIA-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ