### PR TITLE
Add ETWP Upsells

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -199,6 +199,8 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Tweak - Prevented Single Attendee endpoint from throwing a notice on PHP 8+. [ET-1935]
 * Tweak - Attendees listed on the `Your Tickets` section will now match the order they were entered in. [ET-1924]
+* Tweak - Notify users of Wallet Plus availability on attendees page. [ET-1938]
+* Tweak - Notify users of Wallet Plus availability on Tickets Emails settings page. [ET-1937]
 
 = [5.7.0] 2023-11-16 =
 

--- a/src/Tickets/Admin/Upsell.php
+++ b/src/Tickets/Admin/Upsell.php
@@ -43,7 +43,7 @@ class Upsell {
 				'tec-admin__upsell-tec-tickets-capacity-arf'
 			],
 			'text'    => sprintf(
-				// Translators: %s: Link to "Wallet Plus" plugin.
+				// Translators: %s: Link to "Event Tickets Plus" plugin.
 				esc_html__( 'Get individual information collection from each attendee and advanced capacity options with %s' , 'event-tickets' ),
 				''
 			 ),
@@ -146,7 +146,7 @@ class Upsell {
 				'tec-admin__upsell-tec-tickets-wallet-plus'
 			],
 			'text'    => sprintf(
-				// Translators: %s: Link to "Event Tickets Plus" plugin.
+				// Translators: %s: Link to "Wallet Plus" plugin.
 				esc_html__( 'Get additional ticketing flexibility including Apple Wallet and PDF tickets with %s' , 'event-tickets' ),
 				''
 			),

--- a/src/Tickets/Admin/Upsell.php
+++ b/src/Tickets/Admin/Upsell.php
@@ -21,8 +21,9 @@ class Upsell {
 	 */
 	public function hooks() {
 		add_action( 'tribe_events_tickets_pre_edit', [ $this, 'maybe_show_capacity_arf' ] );
-		add_action( 'tec_tickets_attendees_event_summary_table_extra', [ $this, 'maybe_show_manual_attendees' ] );
+		add_action( 'tec_tickets_attendees_event_summary_table_extra', [ $this, 'show_on_attendees_page' ] );
 		add_filter( 'tribe_tickets_commerce_settings', [ $this, 'maybe_show_paystack_promo' ] );
+		add_filter( 'tec_tickets_emails_settings_template_list', [ $this, 'show_on_emails_settings_page' ] );
 	}
 
 	/**
@@ -42,7 +43,7 @@ class Upsell {
 				'tec-admin__upsell-tec-tickets-capacity-arf'
 			],
 			'text'    => sprintf(
-				// Translators: %s: Link to "Event Tickets Plus" plugin.
+				// Translators: %s: Link to "Wallet Plus" plugin.
 				esc_html__( 'Get individual information collection from each attendee and advanced capacity options with %s' , 'event-tickets' ),
 				''
 			 ),
@@ -57,21 +58,62 @@ class Upsell {
 	}
 
 	/**
-	 * Maybe show upsell for Manual Attendees.
-	 *
-	 * @since 5.5.7 - Added is_admin() to make sure upsells only display within the admin area.
-	 * @since 5.3.4
+	 * Show upsell on Attendees page.
+	 * 
+	 * @since TBD
+	 * 
+	 * @return void
 	 */
-	public function maybe_show_manual_attendees() {
-		// If they already have ET+ activated or are not within the admin area, then bail.
-		if ( class_exists( 'Tribe__Tickets_Plus__Main' ) || ! is_admin() ) {
+	public function show_on_attendees_page() {
+		// If not within the admin area, then bail.
+		if ( ! is_admin() ) {
 			return;
 		}
+
+		$has_tickets_plus = class_exists( '\Tribe__Tickets_Plus__Main', false );
+		$has_wallet_plus  = class_exists( '\TEC\Tickets_Wallet_Plus\Plugin', false );
+
+		// If both Tickets Plus and Wallet Plus are installed, then bail.
+		if ( $has_tickets_plus && $has_wallet_plus ) {
+			return;
+		}
+
+		// If Tickets Plus installed, but not Wallet Plus.
+		if ( $has_tickets_plus && ! $has_wallet_plus ) {
+			$this->show_wallet_plus();
+			return;
+		}
+
+		// If Wallet Plus installed, but not Tickets Plus.
+		if ( ! $has_tickets_plus && $has_wallet_plus ) {
+			$this->maybe_show_manual_attendees();
+			return;
+		}
+
+		// 50% chance of showing either upsell.
+		if ( wp_rand( 0, 1 ) ) {
+			$this->show_wallet_plus();
+			return;
+		}
+
+		$this->maybe_show_manual_attendees();
+	}
+
+	/**
+	 * Maybe show upsell for Manual Attendees.
+	 *
+	 * @since TBD   - Move logic into show_on_attendees_page().
+	 * @since 5.5.7 - Added is_admin() to make sure upsells only display within the admin area.
+	 * @since 5.3.4
+	 * 
+	 * @return void
+	 */
+	public function maybe_show_manual_attendees() {
 
 		echo '<div class="welcome-panel-column welcome-panel-extra">';
 		tribe( Upsell_Notice\Main::class )->render( [
 			'classes' => [
-				'tec-admin__upsell-tec-tickets-manual-attendees'
+				'tec-admin__upsell-tec-tickets-wallet-plus'
 			],
 			'text'    => sprintf(
 				// Translators: %s: Link to "Event Tickets Plus" plugin.
@@ -84,6 +126,36 @@ class Upsell {
 				],
 				'text'    => 'Event Tickets Plus',
 				'url'     => 'https://evnt.is/et-in-app-manual-attendees',
+			],
+		] );
+		echo '</div>';
+	}
+
+	/**
+	 * Maybe show upsell for Wallet Plus.
+	 *
+	 * @since TBD
+	 * 
+	 * @return void
+	 */
+	public function show_wallet_plus() {
+
+		echo '<div class="welcome-panel-column welcome-panel-extra">';
+		tribe( Upsell_Notice\Main::class )->render( [
+			'classes' => [
+				'tec-admin__upsell-tec-tickets-wallet-plus'
+			],
+			'text'    => sprintf(
+				// Translators: %s: Link to "Event Tickets Plus" plugin.
+				esc_html__( 'Get additional ticketing flexibility including Apple Wallet and PDF tickets with %s' , 'event-tickets' ),
+				''
+			),
+			'link'    => [
+				'classes' => [
+					'tec-admin__upsell-link--underlined'
+				],
+				'text'    => 'Wallet Plus',
+				'url'     => 'https://evnt.is/1bd9',
 			],
 		] );
 		echo '</div>';
@@ -135,5 +207,44 @@ class Upsell {
 		$settings_before = array_slice( $settings, 0, $general_setting_index );
 		$settings_after  = array_slice( $settings, $general_setting_index );
 		return array_merge( $settings_before, $new_setting, $settings_after);
-    }
+	}
+
+	/**
+	 * Show upsell on Emails Settings page.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $fields Template list settings fields.
+	 *
+	 * @return array Filtered template list settings fields.
+	 */
+	public function show_on_emails_settings_page( $fields ) {
+		// If they already have ET+ activated or are not within the admin area, then bail.
+		if ( class_exists( '\TEC\Tickets_Wallet_Plus\Plugin', false ) || ! is_admin() ) {
+			return $fields;
+		}
+
+		$fields[] = [
+			'type' => 'html',
+			'html'  => tribe( Upsell_Notice\Main::class )->render( [
+				'classes' => [
+					'tec-admin__upsell-tec-tickets-wallet-plus'
+				],
+				'text'    => sprintf(
+					// Translators: %s: Link to "Wallet Plus" plugin.
+					esc_html__( 'Get additional ticketing flexibility including Apple Wallet and PDF tickets with %s' , 'event-tickets' ),
+					''
+				),
+				'link'    => [
+					'classes' => [
+						'tec-admin__upsell-link--underlined'
+					],
+					'text'    => 'Wallet Plus',
+					'url'     => 'https://evnt.is/1bd9',
+				],
+			], false ),
+		];
+
+		return $fields;
+	}
 }

--- a/src/Tickets/Admin/Upsell.php
+++ b/src/Tickets/Admin/Upsell.php
@@ -113,7 +113,7 @@ class Upsell {
 		echo '<div class="welcome-panel-column welcome-panel-extra">';
 		tribe( Upsell_Notice\Main::class )->render( [
 			'classes' => [
-				'tec-admin__upsell-tec-tickets-wallet-plus'
+				'tec-admin__upsell-tec-tickets-manual-attendees'
 			],
 			'text'    => sprintf(
 				// Translators: %s: Link to "Event Tickets Plus" plugin.

--- a/src/resources/postcss/tickets-admin/attendees/_table.pcss
+++ b/src/resources/postcss/tickets-admin/attendees/_table.pcss
@@ -6,6 +6,9 @@
 .tec-tickets__admin-attendees {
 	.tribe-report-panel .welcome-panel-last {
 		display: inline-block;
+		grid-column-start: c;
+		grid-row-start: c;
+		grid-row-end: c;
 		width: auto;
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-1937] <!-- Ticket ID, if there's any put it between brackets -->
[ET-1938] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We want to show ETWP upsells to users that don't currently have ETWP installed/activated. They are added to the Tickets Emails settings page and to the attendees page. In the case where ETP is also not installed/activated, on the attendees page, the upsell will evenly alternate between the Manual Attendees upsell and the ETWP upsell randomly.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/64a01c72-d317-4365-b10f-04ce22054995)
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/4cddebcb-4d2b-424f-a534-679bff7ffad4)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1937]: https://stellarwp.atlassian.net/browse/ET-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-1938]: https://stellarwp.atlassian.net/browse/ET-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ