### PR TITLE
Update phpcs workflow to use stellarwp/github-actions (reviewdog)

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,26 +1,9 @@
-name: 'PHP CodeSniffer'
-on:
-  pull_request:
-    paths:
-      - 'src/**.php'
-      - '*.php'
+name: 'PHPCS'
+on: [pull_request]
 jobs:
   phpcs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 100
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-      - uses: the-events-calendar/action-tribe-phpcs@master
-        with:
-          github-bot-token: ${{ secrets.GH_BOT_TOKEN }}
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@main
+    with:
+      ref: ${{ github.event.inputs.ref }}
+    secrets:
+      access-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
This re-enables PHPCS with comments on our PRs using https://github.com/reviewdog/reviewdog

If you want to see this in action with my test PR, you do so here: https://github.com/the-events-calendar/the-events-calendar/pull/4439

_Note: This is pull requested into `master` because this is merely a workflow addition._