### PR TITLE
[ET-1937] Fix `grid-area` names being renamed upon building

### DIFF
--- a/src/resources/postcss/tickets-admin/attendees/_table.pcss
+++ b/src/resources/postcss/tickets-admin/attendees/_table.pcss
@@ -6,9 +6,6 @@
 .tec-tickets__admin-attendees {
 	.tribe-report-panel .welcome-panel-last {
 		display: inline-block;
-		grid-column-start: c;
-		grid-row-start: c;
-		grid-row-end: c;
 		width: auto;
 	}
 
@@ -162,7 +159,7 @@
 
 	.tec-tickets__admin-attendees-overview-ticket-type-icon--ticket {
 		background-image: url( '../icons/icon-ticket-left.svg' );
-		
+
 	}
 
 	.tec-tickets__admin-attendees-overview-ticket-type-icon--rsvp {
@@ -174,7 +171,7 @@
 	}
 
 	.tec-tickets__admin-attendees-overview-ticket-type-border {
-		border-bottom: 1px solid #DCDCDE; 
+		border-bottom: 1px solid #DCDCDE;
 		flex: 1;
 		height: 1px;
 	}

--- a/src/resources/postcss/tickets-report.pcss
+++ b/src/resources/postcss/tickets-report.pcss
@@ -115,6 +115,7 @@
 
 	.welcome-panel-last {
 		display: inline-block;
+		grid-area: last;
 		width: auto;
 		@media screen and (max-width: 768px) {
 			width: 100%;


### PR DESCRIPTION
### 🎫 Ticket

[ET-1937] <!-- Ticket ID, if there's any put it between brackets -->
[ET-1938] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We were experiencing an issue when building the plugin (`npm run build`) where the grid area names were getting re-written in the minified css files. I eventually realized that the `grid-area` setting needed to be within the same pcss file where the `grid-template-areas` are being set.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
N/A

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1937]: https://stellarwp.atlassian.net/browse/ET-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-1938]: https://stellarwp.atlassian.net/browse/ET-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ