### PR TITLE
Prevent problems related to Race condition for Payment Intent and Cha…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -204,6 +204,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Tweak - Add attendee name to attendees list after purchase or registration. [ET-1939]
 * Tweak - Added filter `tec_tickets_commerce_gateway_stripe_webhook_valid_key_polling_attempts` to allow the modification of how many attempts Tickets Commerce will poll for Stripe webhooks for validation.
 * Fix - Tickets Commerce Stripe webhooks properly handles internally validating the Secret Signing key. [ET-1511]
+* Fix - Tickets Commerce Stripe Charge and Payment Intent webhooks no longer create duplicated success emails for a single ticket purchase. [ET-1792]
 
 = [5.7.0] 2023-11-16 =
 

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -2,6 +2,7 @@
 
 namespace TEC\Tickets\Commerce\Gateways\Stripe\Webhooks;
 
+use TEC\Tickets\Commerce\Gateways\Stripe\Status;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\Gateways\Contracts\Webhook_Event_Interface;
@@ -25,6 +26,35 @@ class Charge_Webhook implements Webhook_Event_Interface {
 		$payment_intent_id = $charge_data['payment_intent'];
 
 		$order = tribe( Order::class )->get_from_gateway_order_id( $payment_intent_id );
+
+		$payment_intent = Payment_Intent::get( $payment_intent_id );
+
+		/**
+		 * We were having problems for Payment Intent and Charge happening at the exact same time, so a race condition was happening
+		 * this particular piece of code prevents that problem, by making the Change Webhook look at the Payment Intent status on
+		 * Stripe it forces the Payment Intent to be the source of truth.
+		 *
+		 * See the link below for more information on the problems caused by this bug.
+		 *
+		 * @link https://stellarwp.atlassian.net/browse/ET-1792
+		 *
+		 * @since TBD
+		 */
+		if (
+			$payment_intent
+			&& isset( $payment_intent['status'] )
+			&& $payment_intent['status'] === Status::SUCCEEDED
+		) {
+				$response->set_status( 200 );
+				$response->set_data( sprintf(
+				// Translators: %1$s is the event id and %2$s is the event type name.
+					__( 'Event %1$s was received and will not be handled because the Payment Intent %2$s was already moved to the Success status.', 'event-tickets' ),
+					esc_html( Arr::get( $event, 'id' ) ),
+					esc_html( $payment_intent_id )
+				) );
+
+				return $response;
+		}
 
 		if ( empty( $order ) ) {
 

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -43,15 +43,17 @@ class Charge_Webhook implements Webhook_Event_Interface {
 		if (
 			$payment_intent
 			&& isset( $payment_intent['status'] )
-			&& $payment_intent['status'] === Status::SUCCEEDED
+			&& Status::SUCCEEDED === $payment_intent['status']
 		) {
 				$response->set_status( 200 );
-				$response->set_data( sprintf(
-				// Translators: %1$s is the event id and %2$s is the event type name.
-					__( 'Event %1$s was received and will not be handled because the Payment Intent %2$s was already moved to the Success status.', 'event-tickets' ),
-					esc_html( Arr::get( $event, 'id' ) ),
-					esc_html( $payment_intent_id )
-				) );
+				$response->set_data(
+					sprintf(
+						// Translators: %1$s is the event id and %2$s is the event type name.
+						__( 'Event %1$s was received and will not be handled because the Payment Intent %2$s was already moved to the Success status.', 'event-tickets' ),
+						esc_html( Arr::get( $event, 'id' ) ),
+						esc_html( $payment_intent_id )
+					)
+				);
 
 				return $response;
 		}

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -129,7 +129,11 @@ abstract class Status_Abstract implements Status_Interface {
 	 * {@inheritdoc}
 	 */
 	public function can_apply_to( $order, $new_status ) {
-		$order = tec_tc_get_order( $order );
+		$order = tec_tc_get_order( $order, OBJECT, 'raw', true );
+		if ( ! $order instanceof \WP_Post ) {
+			return false;
+		}
+
 		$current_status = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
 
 		if ( $current_status->get_wp_slug() === $new_status->get_wp_slug() ) {


### PR DESCRIPTION
### 🎫 Ticket

[ET-1792]

### 🗒️ Description

We were having problems for Payment Intent and Charge happening at the exact same time, so a race condition was happening this particular piece of code prevents that problem, by making the Change Webhook look at the Payment Intent status on Stripe it forces the Payment Intent to be the source of truth.

### 🎥 Artifacts <!-- if applicable-->
https://i.bordoni.me/glL0Tgng


[ET-1792]: https://stellarwp.atlassian.net/browse/ET-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ