### PR TITLE
Fix/ET-1879 delete ticket item block

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -197,7 +197,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = TBD
 
-* Fix - Ticket is removed now when using the delete option from the block editor [ET-1879]
+* Fix - Ticket is removed now when using the delete option from the block editor. [ET-1879]
 
 = [5.7.1] 2023-12-13 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= TBD
+
+* Fix - Ticket is removed now when using the delete option from the block editor [ET-1879]
+
 = [5.7.1] 2023-12-13 =
 
 * Tweak - Prevented Single Attendee endpoint from throwing a notice on PHP 8+. [ET-1935]

--- a/src/modules/blocks/ticket/__tests__/index.test.js
+++ b/src/modules/blocks/ticket/__tests__/index.test.js
@@ -8,27 +8,27 @@ jest.mock( '@moderntribe/common/utils/globals', () => ( {
 	iacVars: () => {
 		return {
 			iacDefault: 'none',
-		}
+		};
 	},
 	priceSettings: () => {
 		return {
 			defaultCurrencyPosition: true,
-		}
+		};
 	},
 	settings: () => {
 		return {
 			reverseCurrencyPosition: false,
-		}
+		};
 	},
 	tecDateSettings: () => {
 		return {
 			datepickerFormat: '',
-		}
+		};
 	},
 	tickets: () => {
 		return {
 			end_sale_buffer_duration: 2,
-		}
+		};
 	},
 	wpHooks: {
 		addFilter: () => {},
@@ -37,7 +37,6 @@ jest.mock( '@moderntribe/common/utils/globals', () => ( {
 		MediaUpload: () => ( <button>Media Upload</button> ),
 	},
 } ) );
-
 
 describe( 'Single ticket block declaration', () => {
 	test( 'Block declaration', () => {

--- a/src/modules/blocks/ticket/__tests__/index.test.js
+++ b/src/modules/blocks/ticket/__tests__/index.test.js
@@ -3,6 +3,42 @@
  */
 import TicketBlock from '@moderntribe/tickets/blocks/ticket';
 
+jest.mock( '@moderntribe/common/utils/globals', () => ( {
+	dateSettings: () => {},
+	iacVars: () => {
+		return {
+			iacDefault: 'none',
+		}
+	},
+	priceSettings: () => {
+		return {
+			defaultCurrencyPosition: true,
+		}
+	},
+	settings: () => {
+		return {
+			reverseCurrencyPosition: false,
+		}
+	},
+	tecDateSettings: () => {
+		return {
+			datepickerFormat: '',
+		}
+	},
+	tickets: () => {
+		return {
+			end_sale_buffer_duration: 2,
+		}
+	},
+	wpHooks: {
+		addFilter: () => {},
+	},
+	wpEditor: {
+		MediaUpload: () => ( <button>Media Upload</button> ),
+	},
+} ) );
+
+
 describe( 'Single ticket block declaration', () => {
 	test( 'Block declaration', () => {
 		expect( TicketBlock ).toMatchSnapshot();

--- a/src/modules/blocks/ticket/container.js
+++ b/src/modules/blocks/ticket/container.js
@@ -10,41 +10,15 @@ import { compose } from 'redux';
 import Template from './template';
 import { plugins } from '@moderntribe/common/data';
 import { withStore } from '@moderntribe/common/hoc';
-import { store } from '@moderntribe/common/store';
 import withSaveData from '@moderntribe/tickets/blocks/hoc/with-save-data';
 import { actions, selectors } from '@moderntribe/tickets/data/blocks/ticket';
 import {
 	isModalShowing,
 	getModalTicketId,
 } from '@moderntribe/tickets/data/shared/move/selectors';
+import { initHook } from './hooks';
 
-/**
- * Filter to determine if a block was deleted using the delete block option,
- * also validates if its a ticket block, then call deleteTicket on unmount
- */
-wp.hooks.addFilter(
-	'editor.BlockEdit',
-	'event-tickets',
-	( BlockEdit ) => ( props ) => {
-		const { dispatch } = store;
-
-		wp.element.useEffect( () => {
-			const { name, clientId } = props;
-
-			return () => {
-				if ( name === 'tribe/tickets-item' ) {
-					dispatch( actions.deleteTicket( clientId, false ) );
-				}
-			};
-		}, [] );
-
-		return wp.element.createElement(
-			wp.element.Fragment,
-			null,
-			wp.element.createElement( BlockEdit, props ),
-		);
-	}
-);
+initHook();
 
 const getShowTicket = ( state, ownProps ) => (
 	selectors.getTicketsIsSelected( state ) ||

--- a/src/modules/blocks/ticket/container.js
+++ b/src/modules/blocks/ticket/container.js
@@ -10,12 +10,41 @@ import { compose } from 'redux';
 import Template from './template';
 import { plugins } from '@moderntribe/common/data';
 import { withStore } from '@moderntribe/common/hoc';
+import { store } from '@moderntribe/common/store';
 import withSaveData from '@moderntribe/tickets/blocks/hoc/with-save-data';
 import { actions, selectors } from '@moderntribe/tickets/data/blocks/ticket';
 import {
 	isModalShowing,
 	getModalTicketId,
 } from '@moderntribe/tickets/data/shared/move/selectors';
+
+/**
+ * Filter to determine if a block was deleted using the delete block option,
+ * also validates if its a ticket block, then call deleteTicket on unmount
+ */
+wp.hooks.addFilter(
+	'editor.BlockEdit',
+	'event-tickets',
+	( BlockEdit ) => ( props ) => {
+		const { dispatch } = store;
+
+		wp.element.useEffect( () => {
+			const { name, clientId } = props;
+
+			return () => {
+				if ( name === 'tribe/tickets-item' ) {
+					dispatch( actions.deleteTicket( clientId, false ) );
+				}
+			};
+		}, [] );
+
+		return wp.element.createElement(
+			wp.element.Fragment,
+			null,
+			wp.element.createElement( BlockEdit, props ),
+		);
+	}
+);
 
 const getShowTicket = ( state, ownProps ) => (
 	selectors.getTicketsIsSelected( state ) ||

--- a/src/modules/blocks/ticket/hooks.js
+++ b/src/modules/blocks/ticket/hooks.js
@@ -1,0 +1,35 @@
+import { store } from '@moderntribe/common/store';
+import { actions } from '@moderntribe/tickets/data/blocks/ticket';
+import { wpHooks } from '@moderntribe/common/utils/globals';
+
+const filterBlockEdit = ( BlockEdit ) => ( props ) => {
+	const { dispatch } = store;
+
+	wp.element.useEffect( () => {
+		const { name, clientId } = props;
+
+		return () => {
+			if ( name === 'tribe/tickets-item' ) {
+				dispatch( actions.deleteTicket( clientId, false ) );
+			}
+		};
+	}, [] );
+
+	return wp.element.createElement(
+		wp.element.Fragment,
+		null,
+		wp.element.createElement( BlockEdit, props ),
+	);
+}
+
+/**
+ * Filter to determine if a block was deleted using the delete block option,
+ * also validates if its a ticket block, then call deleteTicket on unmount
+ */
+export const initHook = () => {
+	wpHooks.addFilter(
+		'editor.BlockEdit',
+		'event-tickets',
+		filterBlockEdit,
+	);
+}

--- a/src/modules/blocks/ticket/hooks.js
+++ b/src/modules/blocks/ticket/hooks.js
@@ -20,7 +20,7 @@ const filterBlockEdit = ( BlockEdit ) => ( props ) => {
 		null,
 		wp.element.createElement( BlockEdit, props ),
 	);
-}
+};
 
 /**
  * Filter to determine if a block was deleted using the delete block option,
@@ -32,4 +32,4 @@ export const initHook = () => {
 		'event-tickets',
 		filterBlockEdit,
 	);
-}
+};

--- a/src/modules/data/blocks/ticket/__tests__/__snapshots__/actions.test.js.snap
+++ b/src/modules/data/blocks/ticket/__tests__/__snapshots__/actions.test.js.snap
@@ -448,6 +448,7 @@ Object {
 exports[`Ticket actions Ticket saga actions delete ticket 1`] = `
 Object {
   "payload": Object {
+    "askForDeletion": undefined,
     "clientId": "modern-tribe",
   },
   "type": "@@MT/TICKETS/DELETE_TICKET",

--- a/src/modules/data/blocks/ticket/actions.js
+++ b/src/modules/data/blocks/ticket/actions.js
@@ -578,10 +578,11 @@ export const updateTicket = ( clientId ) => ( {
 	},
 } );
 
-export const deleteTicket = ( clientId ) => ( {
+export const deleteTicket = ( clientId, askForDeletion ) => ( {
 	type: types.DELETE_TICKET,
 	payload: {
 		clientId,
+		askForDeletion,
 	},
 } );
 

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -614,13 +614,19 @@ export function* updateTicket( action ) {
 }
 
 export function* deleteTicket( action ) {
-	const { clientId } = action.payload;
+	const { clientId, askForDeletion = true } = action.payload;
 	const props = { clientId };
 
-	const shouldDelete = yield call(
-		[ window, 'confirm' ],
-		__( 'Are you sure you want to delete this ticket? It cannot be undone.', 'event-tickets' ),
-	);
+	let shouldDelete = false;
+
+	if ( askForDeletion ) {
+		shouldDelete = yield call(
+			[ window, 'confirm' ],
+			__( 'Are you sure you want to delete this ticket? It cannot be undone.', 'event-tickets' ),
+		);
+	} else {
+		shouldDelete = true;
+	}
 
 	if ( shouldDelete ) {
 		const ticketId = yield select( selectors.getTicketId, props );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1879] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
- The issue is that when using the delete option from the “Three dots“ menu, the `deleteTicket` action is not being called.
- Now is fixed

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/221748b58e3547f2ab062e15b39dc342
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1879]: https://stellarwp.atlassian.net/browse/ET-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ