### PR TITLE
Fixed deprecation errors.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fix PHP 8.2 deprecation errors `PHP Deprecated:  Creation of dynamic property Tribe__Tickets__Main::$registered is deprecated in /.../wp-content/plugins/event-tickets/src/Tribe/Main.php on line 452`. [ECP-1603]
+
 = [5.7.1] 2023-12-13 =
 
 * Tweak - Prevented Single Attendee endpoint from throwing a notice on PHP 8+. [ET-1935]

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -239,6 +239,7 @@ class Tickets implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		$this->data = $this->fetch_data();
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -77,11 +77,11 @@ class Tribe__Tickets__Main {
 	public $plugin_slug;
 
 	/**
-     * The Plugin Register instance.
-     *
+	 * The Plugin Register instance.
+	 *
 	 * @var Tribe__Tickets__Plugin_Register
 	 */
-    public $registered;
+	public $registered;
 
 	/**
 	 * @var Tribe__Tickets__Legacy_Provider_Support

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -70,6 +70,20 @@ class Tribe__Tickets__Main {
 	public $plugin_url;
 
 	/**
+	 * Slug of the plugin
+	 *
+	 * @var string
+	 */
+	public $plugin_slug;
+
+	/**
+     * The Plugin Register instance.
+     *
+	 * @var Tribe__Tickets__Plugin_Register
+	 */
+    public $registered;
+
+	/**
 	 * @var Tribe__Tickets__Legacy_Provider_Support
 	 */
 	public $legacy_provider_support;

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -9,6 +9,13 @@ class Tribe__Tickets__REST__V1__Messages implements Tribe__REST__Messages_Interf
 	protected $message_prefix = 'rest-v1:';
 
 	/**
+	 * The list of messages.
+	 *
+	 * @var array<string,string>
+	 */
+	public array $messages = [];
+
+	/**
 	 * Tribe__Tickets__REST__V1__Messages constructor.
 	 *
 	 * @since 4.7.5

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -98,6 +98,13 @@ class Tribe__Tickets__Tickets_Handler {
 	public $unlimited_term = 'Unlimited';
 
 	/**
+	 * The directory path.
+	 *
+	 * @var string
+	 */
+	public $path;
+
+	/**
 	 *    Class constructor.
 	 */
 	public function __construct() {


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1603](https://stellarwp.atlassian.net/browse/ECP-1603)

### 🗒️ Description

This resolves several php 8.2 deprecation errors.

### 🎥 Artifacts <!-- if applicable-->
```
PHP Deprecated:  Creation of dynamic property Tribe__Tickets__Main::$registered is deprecated in /.../wp-content/plugins/event-tickets/src/Tribe/Main.php on line 452

```

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ECP-1603]: https://stellarwp.atlassian.net/browse/ECP-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ