### PR TITLE
Fix - Total capacity not showing properly when Series Pass with Shared capacity is added.

### DIFF
--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1148,7 +1148,16 @@ if ( ! function_exists( 'tribe_get_event_capacity' ) ) {
 
 		$value = (int) $rsvp_cap + (int) $tickets_cap;
 
-		return (int) $value;
+		/**
+		 * Filters the event capacity.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $value The event capacity.
+		 * @param int $post_id The event ID.
+		 * @param bool|Tribe__Tickets__Tickets $provider The ticket provider.
+		 */
+		return apply_filters( 'tec_tickets_get_event_capacity', (int) $value, $post_id, $provider );
 	}
 }
 

--- a/tests/ft_integration/Tribe/Tickets/MetaboxTest.php
+++ b/tests/ft_integration/Tribe/Tickets/MetaboxTest.php
@@ -49,7 +49,9 @@ class MetaboxTest extends WPTestCase {
 		yield 'post with ticket' => [
 			function (): array {
 				$post_id   = $this->factory()->post->create( [ 'post_title' => 'Test post' ] );
-				$ticket_id = $this->create_tc_ticket( $post_id, 23
+				$ticket_id = $this->create_tc_ticket(
+					$post_id,
+					23
 				);
 
 				return [ $post_id, $ticket_id ];
@@ -59,12 +61,15 @@ class MetaboxTest extends WPTestCase {
 		yield 'post with RSVP' => [
 			function (): array {
 				$post_id   = $this->factory()->post->create( [ 'post_title' => 'Test post' ] );
-				$ticket_id = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
+				$ticket_id = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
 
 				return [ $post_id, $ticket_id ];
 			},
@@ -73,38 +78,66 @@ class MetaboxTest extends WPTestCase {
 		yield 'post with tickets and RSVPs' => [
 			function (): array {
 				$post_id  = $this->factory()->post->create( [ 'post_title' => 'Test post' ] );
-				$rsvp_1   = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
-				$rsvp_2   = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
+				$rsvp_1   = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
+				$rsvp_2   = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
 				$ticket_1 = $this->create_tc_ticket( $post_id, 25 );
 				$ticket_2 = $this->create_tc_ticket( $post_id, 26 );
 				// Sort the tickets "manually".
-				wp_update_post( [ 'ID' => $rsvp_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $rsvp_2, 'menu_order' => 0 ] );
-				wp_update_post( [ 'ID' => $ticket_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $ticket_2, 'menu_order' => 0 ] );
+				wp_update_post(
+					[
+						'ID'         => $rsvp_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $rsvp_2,
+						'menu_order' => 0,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $ticket_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $ticket_2,
+						'menu_order' => 0,
+					] 
+				);
 
 				return [ $post_id, $rsvp_1, $rsvp_2, $ticket_1, $ticket_2 ];
-			}
+			},
 		];
 
 		yield 'single event without tickets' => [
 			function (): array {
-				$post_id = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-				] )->create()->ID;
+				$post_id = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+					] 
+				)->create()->ID;
 
 				return [ $post_id ];
 			},
@@ -112,12 +145,14 @@ class MetaboxTest extends WPTestCase {
 
 		yield 'single event with ticket' => [
 			function (): array {
-				$post_id   = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-				] )->create()->ID;
+				$post_id   = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+					] 
+				)->create()->ID;
 				$ticket_id = $this->create_tc_ticket( $post_id, 23 );
 
 				return [ $post_id, $ticket_id ];
@@ -126,18 +161,23 @@ class MetaboxTest extends WPTestCase {
 
 		yield 'single event with RSVP' => [
 			function (): array {
-				$post_id = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-				] )->create()->ID;
-				$rsvp_id = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
+				$post_id = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+					] 
+				)->create()->ID;
+				$rsvp_id = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
 
 				return [ $post_id, $rsvp_id ];
 			},
@@ -145,50 +185,82 @@ class MetaboxTest extends WPTestCase {
 
 		yield 'single event with tickets and RSVPs' => [
 			function (): array {
-				$post_id  = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-				] )->create()->ID;
-				$rsvp_1   = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
-				$rsvp_2   = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
+				$post_id  = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+					] 
+				)->create()->ID;
+				$rsvp_1   = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
+				$rsvp_2   = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
 				$ticket_1 = $this->create_tc_ticket( $post_id, 25 );
 				$ticket_2 = $this->create_tc_ticket( $post_id, 26 );
 
 				// Sort the tickets "manually".
-				wp_update_post( [ 'ID' => $rsvp_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $rsvp_2, 'menu_order' => 2 ] );
-				wp_update_post( [ 'ID' => $ticket_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $ticket_2, 'menu_order' => 2 ] );
+				wp_update_post(
+					[
+						'ID'         => $rsvp_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $rsvp_2,
+						'menu_order' => 2,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $ticket_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $ticket_2,
+						'menu_order' => 2,
+					] 
+				);
 
 				return [ $post_id, $rsvp_1, $rsvp_2, $ticket_1, $ticket_2 ];
-			}
+			},
 		];
 
 		yield 'single event part of a series with no tickets and no series passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
-				$post_id   = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-					'series'     => $series_id,
-				] )->create()->ID;
+				$series_id = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
+				$post_id   = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+						'series'     => $series_id,
+					] 
+				)->create()->ID;
 
 				return [ $post_id, $series_id ];
 			},
@@ -196,22 +268,36 @@ class MetaboxTest extends WPTestCase {
 
 		yield 'single event part of a series with no tickets, series has passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
+				$series_id = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
 				$pass_1    = $this->create_tc_series_pass( $series_id, 23 )->ID;
 				$pass_2    = $this->create_tc_series_pass( $series_id, 89 )->ID;
 				// Sort the tickets "manually".
-				wp_update_post( [ 'ID' => $pass_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $pass_2, 'menu_order' => 2 ] );
-				$post_id   = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-					'series'     => $series_id,
-				] )->create()->ID;
+				wp_update_post(
+					[
+						'ID'         => $pass_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $pass_2,
+						'menu_order' => 2,
+					] 
+				);
+				$post_id = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+						'series'     => $series_id,
+					] 
+				)->create()->ID;
 
 				return [ $post_id, $pass_1, $pass_2, $series_id ];
 			},
@@ -219,123 +305,196 @@ class MetaboxTest extends WPTestCase {
 
 		yield 'single event part of a series with tickets, RSVPs and passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
+				$series_id = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
 				$pass_1    = $this->create_tc_series_pass( $series_id, 23 )->ID;
 				$pass_2    = $this->create_tc_series_pass( $series_id, 89 )->ID;
-				$post_id   = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-					'series'     => $series_id,
-				] )->create()->ID;
+				$post_id   = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+						'series'     => $series_id,
+					] 
+				)->create()->ID;
 				$ticket_1  = $this->create_tc_ticket( $post_id, 25 );
 				$ticket_2  = $this->create_tc_ticket( $post_id, 26 );
-				$rsvp_1    = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
-				$rsvp_2    = $this->create_rsvp_ticket( $post_id, [
-					'meta_input' => [
-						'_ticket_start_date' => '2020-01-02',
-						'_ticket_end_date'   => '2050-03-01',
-					]
-				] );
+				$rsvp_1    = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
+				$rsvp_2    = $this->create_rsvp_ticket(
+					$post_id,
+					[
+						'meta_input' => [
+							'_ticket_start_date' => '2020-01-02',
+							'_ticket_end_date'   => '2050-03-01',
+						],
+					] 
+				);
 				// Sort the tickets "manually".
-				wp_update_post( [ 'ID' => $pass_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $pass_2, 'menu_order' => 2 ] );
-				wp_update_post( [ 'ID' => $ticket_1, 'menu_order' => 0 ] );
-				wp_update_post( [ 'ID' => $ticket_2, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $rsvp_1, 'menu_order' => 0 ] );
-				wp_update_post( [ 'ID' => $rsvp_2, 'menu_order' => 1 ] );
+				wp_update_post(
+					[
+						'ID'         => $pass_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $pass_2,
+						'menu_order' => 2,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $ticket_1,
+						'menu_order' => 0,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $ticket_2,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $rsvp_1,
+						'menu_order' => 0,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $rsvp_2,
+						'menu_order' => 1,
+					] 
+				);
 
 				return [ $post_id, $ticket_1, $ticket_2, $pass_1, $pass_2, $rsvp_1, $rsvp_2, $series_id ];
-			}
+			},
 		];
 
 		yield 'recurring event part of series with no passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
-				$post_id   = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-					'recurrence' => 'RRULE:FREQ=DAILY;COUNT=2',
-					'series'     => $series_id,
-				] )->create()->ID;
-                $occurrences_provisional_ids = occurrence::where('post_id', '=', $post_id)
-                    ->map(fn(occurrence $o) => $o->provisional_id);
+				$series_id                   = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
+				$post_id                     = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+						'recurrence' => 'RRULE:FREQ=DAILY;COUNT=2',
+						'series'     => $series_id,
+					] 
+				)->create()->ID;
+				$occurrences_provisional_ids = occurrence::where( 'post_id', '=', $post_id )
+					->map( fn( occurrence $o ) => $o->provisional_id );
 
 				return [ $post_id, $series_id, ...$occurrences_provisional_ids ];
-			}
+			},
 		];
 
 		yield 'recurring event part of a series with passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
+				$series_id = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
 				$pass_1    = $this->create_tc_series_pass( $series_id, 23 )->ID;
 				$pass_2    = $this->create_tc_series_pass( $series_id, 89 )->ID;
 				// Sort the tickets "manually".
-				wp_update_post( [ 'ID' => $pass_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $pass_2, 'menu_order' => 0 ] );
-				$post_id = tribe_events()->set_args( [
-					'title'      => 'Test event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-					'recurrence' => 'RRULE:FREQ=DAILY;COUNT=2',
-					'series'     => $series_id,
-				] )->create()->ID;
+				wp_update_post(
+					[
+						'ID'         => $pass_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $pass_2,
+						'menu_order' => 0,
+					] 
+				);
+				$post_id = tribe_events()->set_args(
+					[
+						'title'      => 'Test event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+						'recurrence' => 'RRULE:FREQ=DAILY;COUNT=2',
+						'series'     => $series_id,
+					] 
+				)->create()->ID;
 
-                $occurrences_provisional_ids = Occurrence::where('post_id', '=', $post_id)
-                    ->map(fn(Occurrence $o) => $o->provisional_id);
+				$occurrences_provisional_ids = Occurrence::where( 'post_id', '=', $post_id )
+					->map( fn( Occurrence $o ) => $o->provisional_id );
 
 				return [ $post_id, $pass_1, $pass_2, $series_id, ...$occurrences_provisional_ids ];
-			}
+			},
 		];
 
 		yield 'series with no passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
+				$series_id = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
 
 				return [ $series_id ];
-			}
+			},
 		];
 
 		yield 'series with passes' => [
 			function (): array {
-				$series_id = static::factory()->post->create( [
-					'post_type'  => Series_Post_Type::POSTTYPE,
-					'post_title' => 'Test series',
-				] );
+				$series_id = static::factory()->post->create(
+					[
+						'post_type'  => Series_Post_Type::POSTTYPE,
+						'post_title' => 'Test series',
+					] 
+				);
 				$pass_1    = $this->create_tc_series_pass( $series_id, 23 )->ID;
 				$pass_2    = $this->create_tc_series_pass( $series_id, 89 )->ID;
 				// Sort the tickets "manually".
-				wp_update_post( [ 'ID' => $pass_1, 'menu_order' => 1 ] );
-				wp_update_post( [ 'ID' => $pass_2, 'menu_order' => 0 ] );
+				wp_update_post(
+					[
+						'ID'         => $pass_1,
+						'menu_order' => 1,
+					] 
+				);
+				wp_update_post(
+					[
+						'ID'         => $pass_2,
+						'menu_order' => 0,
+					] 
+				);
 
 				return [ $series_id, $pass_1, $pass_2 ];
-			}
+			},
 		];
 	}
 
 	public function placehold_post_ids(
-		string $snapshot, array $ids
+		string $snapshot,
+		array $ids
 	): string {
 		return str_replace(
 			$ids,
@@ -347,8 +506,7 @@ class MetaboxTest extends WPTestCase {
 	/**
 	 * @dataProvider get_panels_provider
 	 */
-	public
-	function test_get_panels(
+	public function test_get_panels(
 		Closure $fixture
 	): void {
 		// Mock the current date to consolidate the snapshots.


### PR DESCRIPTION
### 🎫 Ticket

[114](https://docs.google.com/spreadsheets/d/1PmKGre7-yrf8zbQVM97Zr6DKXIKCn5OQO5_closegwg/edit#gid=0&range=H19) <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Show total event capacity count properly on Ticket Metabox when shared capacity series passes are added.

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
