### PR TITLE
[ET-1883] ET > TC > Attendee List Export for Tickets Commerce does not populate order status

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -201,6 +201,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Ticket is removed now when using the delete option from the block editor. [ET-1879]
 * Tweak - Declared dynamic properties in Tribe__Tickets__Main, Tribe__Tickets__Tickets_Handler, Tribe__Tickets__REST__V1__Messages to prevent warnings in php 8.2 [ET-1950]
 * Fix - Resolve deprecation notices regarding `ArrayAccess::offsetGet()` [ET-1949]
+* Fix - Resolved an issue where Order Status was not populated when exporting the Attendee List using Tickets Commerce. [ET-1883]
 
 = [5.7.1] 2023-12-13 =
 

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -563,7 +563,7 @@ class Tribe__Tickets__Attendees {
 		);
 		$export_columns['attendee_id']  = esc_html(
 			sprintf(
-			/* translators: %s: The type of ID. */
+				/* Translators: %s: The type of ID. */
 				_x(
 					'%s ID',
 					'attendee export',

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -551,13 +551,47 @@ class Tribe__Tickets__Attendees {
 		$export_columns = array_diff_key( $columns, $hidden );
 
 		// Add additional expected columns.
-		$export_columns['order_id']           = esc_html_x( 'Order ID', 'attendee export', 'event-tickets' );
-		$export_columns['order_status'] = esc_html_x( 'Order Status', 'attendee export', 'event-tickets' );
-		$export_columns['attendee_id']        = esc_html( sprintf( _x( '%s ID', 'attendee export', 'event-tickets' ), tribe_get_ticket_label_singular( 'attendee_export_ticket_id' ) ) );
-		$export_columns['holder_name']        = esc_html_x( 'Ticket Holder Name', 'attendee export', 'event-tickets' );
-		$export_columns['holder_email']       = esc_html_x( 'Ticket Holder Email Address', 'attendee export', 'event-tickets' );
-		$export_columns['purchaser_name']     = esc_html_x( 'Purchaser Name', 'attendee export', 'event-tickets' );
-		$export_columns['purchaser_email']    = esc_html_x( 'Purchaser Email Address', 'attendee export', 'event-tickets' );
+		$export_columns['order_id']     = esc_html_x(
+			'Order ID',
+			'attendee export',
+			'event-tickets'
+		);
+		$export_columns['order_status'] = esc_html_x(
+			'Order Status',
+			'attendee export',
+			'event-tickets'
+		);
+		$export_columns['attendee_id']  = esc_html(
+			sprintf(
+			/* translators: %s: The type of ID. */
+				_x(
+					'%s ID',
+					'attendee export',
+					'event-tickets'
+				),
+				tribe_get_ticket_label_singular( 'attendee_export_ticket_id' )
+			)
+		);
+		$export_columns['holder_name']     = esc_html_x(
+			'Ticket Holder Name',
+			'attendee export',
+			'event-tickets'
+		);
+		$export_columns['holder_email']    = esc_html_x(
+			'Ticket Holder Email Address',
+			'attendee export',
+			'event-tickets'
+		);
+		$export_columns['purchaser_name']  = esc_html_x(
+			'Purchaser Name',
+			'attendee export',
+			'event-tickets'
+		);
+		$export_columns['purchaser_email'] = esc_html_x(
+			'Purchaser Email Address',
+			'attendee export',
+			'event-tickets'
+		);
 
 		/**
 		 * Used to modify what columns should be shown on the CSV export

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -552,7 +552,7 @@ class Tribe__Tickets__Attendees {
 
 		// Add additional expected columns.
 		$export_columns['order_id']           = esc_html_x( 'Order ID', 'attendee export', 'event-tickets' );
-		$export_columns['order_status_label'] = esc_html_x( 'Order Status', 'attendee export', 'event-tickets' );
+		$export_columns['order_status'] = esc_html_x( 'Order Status', 'attendee export', 'event-tickets' );
 		$export_columns['attendee_id']        = esc_html( sprintf( _x( '%s ID', 'attendee export', 'event-tickets' ), tribe_get_ticket_label_singular( 'attendee_export_ticket_id' ) ) );
 		$export_columns['holder_name']        = esc_html_x( 'Ticket Holder Name', 'attendee export', 'event-tickets' );
 		$export_columns['holder_email']       = esc_html_x( 'Ticket Holder Email Address', 'attendee export', 'event-tickets' );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1883] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->

<!-- What types of changes does your code introduce? -->
The `order_status` column was being referenced incorrectly as `order_status_label`.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[Event-with-ARF-attendees(2).csv](https://github.com/the-events-calendar/event-tickets/files/13834762/Event-with-ARF-attendees.2.csv)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1883]: https://stellarwp.atlassian.net/browse/ET-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ