### PR TITLE
[ET-1987] - Hide settings button from classic metabox if ETP is not enabled.

### DIFF
--- a/src/Tickets/Flexible_Tickets/Series_Passes/Base.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Base.php
@@ -171,6 +171,11 @@ class Base extends Controller {
 			$this,
 			'show_series_link_after_ticket_type_title'
 		], 10, 3 );
+        
+        add_filter( 'tribe_template_pre_html:tickets/admin-views/editor/panel/settings-button', [
+            $this,
+            'remove_settings_button_from_classic_metabox'
+        ], 10, 5 );
 	}
 
 	/**
@@ -287,6 +292,11 @@ class Base extends Controller {
 			$this,
 			'show_series_link_after_ticket_type_title'
 		], 10, 3 );
+        
+        remove_filter( 'tribe_template_pre_html:tickets/admin-views/editor/panel/settings-button', [
+            $this,
+            'remove_settings_button_from_classic_metabox'
+        ], 10, 5 );
 	}
 
 	/**
@@ -767,4 +777,25 @@ class Base extends Controller {
 
 		echo '<span class="tec-tickets__my-tickets-list__series-link">' . $series_link . '</span>';
 	}
+    
+    /**
+     * Hides the settings button from showing up for the classic editor metabox.
+     *
+     * @since TBD
+     *
+     * @param null|string         $html     The initial HTML.
+     * @param string              $file     Complete path to include the PHP File.
+     * @param string[]            $name     Template name.
+     * @param Template            $template Current instance of the Tribe__Template
+     * @param array<string,mixed> $context  The context data passed to the template.
+     *
+     * @return null|bool The filtered HTML, or `false` to hide the option.
+     */
+    public function remove_settings_button_from_classic_metabox( string $html = null, string $file, array $name, Template $template, array $context ): ?bool {
+        if ( ! isset( $context['post_id'] ) || get_post_type( $context['post_id'] ) !== Series_Post_Type::POSTTYPE ) {
+            return $html;
+        }
+        
+        return false;
+    }
 }

--- a/src/Tickets/Flexible_Tickets/Series_Passes/Base.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Base.php
@@ -14,7 +14,6 @@ use TEC\Common\Contracts\Provider\Controller;
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use TEC\Events_Pro\Custom_Tables\V1\Series\Post_Type as Series_Post_Type;
 use TEC\Events_Pro\Custom_Tables\V1\Templates\Provider as CT_Templates_Provider;
-use TEC\Tickets\Admin\Editor_Data;
 use TEC\Tickets\Admin\Upsell as Ticket_Upsell;
 use TEC\Tickets\Commerce\Reports\Data\Order_Summary;
 use TEC\Tickets\Flexible_Tickets\Repositories\Event_Repository;
@@ -172,10 +171,15 @@ class Base extends Controller {
 			'show_series_link_after_ticket_type_title'
 		], 10, 3 );
         
-        add_filter( 'tribe_template_pre_html:tickets/admin-views/editor/panel/settings-button', [
-            $this,
-            'remove_settings_button_from_classic_metabox'
-        ], 10, 5 );
+        add_filter(
+            'tribe_template_pre_html:tickets/admin-views/editor/panel/settings-button',
+            [
+                $this,
+                'remove_settings_button_from_classic_metabox',
+            ],
+            10,
+            5
+        );
 	}
 
 	/**
@@ -293,10 +297,15 @@ class Base extends Controller {
 			'show_series_link_after_ticket_type_title'
 		], 10, 3 );
         
-        remove_filter( 'tribe_template_pre_html:tickets/admin-views/editor/panel/settings-button', [
-            $this,
-            'remove_settings_button_from_classic_metabox'
-        ], 10, 5 );
+        remove_filter(
+            'tribe_template_pre_html:tickets/admin-views/editor/panel/settings-button',
+            [
+                $this,
+                'remove_settings_button_from_classic_metabox',
+            ],
+            10,
+            5
+        );
 	}
 
 	/**
@@ -777,25 +786,25 @@ class Base extends Controller {
 
 		echo '<span class="tec-tickets__my-tickets-list__series-link">' . $series_link . '</span>';
 	}
-    
-    /**
-     * Hides the settings button from showing up for the classic editor metabox.
-     *
-     * @since TBD
-     *
-     * @param null|string         $html     The initial HTML.
-     * @param string              $file     Complete path to include the PHP File.
-     * @param string[]            $name     Template name.
-     * @param Template            $template Current instance of the Tribe__Template
-     * @param array<string,mixed> $context  The context data passed to the template.
-     *
-     * @return null|bool The filtered HTML, or `false` to hide the option.
-     */
-    public function remove_settings_button_from_classic_metabox( string $html = null, string $file, array $name, Template $template, array $context ): ?bool {
-        if ( ! isset( $context['post_id'] ) || get_post_type( $context['post_id'] ) !== Series_Post_Type::POSTTYPE ) {
-            return $html;
-        }
-        
-        return false;
-    }
+	
+	/**
+	 * Hides the settings button from showing up for the classic editor metabox.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|string         $html     The initial HTML.
+	 * @param string              $file     Complete path to include the PHP File.
+	 * @param string[]            $name     Template name.
+	 * @param Template            $template Current instance of the Tribe__Template
+	 * @param array<string,mixed> $context  The context data passed to the template.
+	 *
+	 * @return null|bool The filtered HTML, or `false` to hide the option.
+	 */
+	public function remove_settings_button_from_classic_metabox( string $html = null, string $file, array $name, Template $template, array $context ): ?bool {
+		if ( ! isset( $context['post_id'] ) || get_post_type( $context['post_id'] ) !== Series_Post_Type::POSTTYPE ) {
+			return $html;
+		}
+		
+		return false;
+	}
 }

--- a/src/admin-views/editor/panel/list.php
+++ b/src/admin-views/editor/panel/list.php
@@ -17,6 +17,9 @@ $total_capacity = (int) tribe_get_event_capacity( $post_id );
 
 $container_class = 'tribe_sectionheader ticket_list_container';
 $container_class .= ( empty( $total_capacity ) ) ? ' tribe_no_capacity' : '';
+
+/** @var Tribe__Tickets__Admin__Views $admin_views */
+$admin_views = tribe( 'tickets.admin.views' );
 ?>
 <div
 	id="tribe_panel_base"
@@ -39,13 +42,11 @@ $container_class .= ( empty( $total_capacity ) ) ? ' tribe_no_capacity' : '';
 			 * @param array<Ticket_Object> $tickets The tickets for the event, any type.
 			 */
 			do_action( 'tribe_events_tickets_new_ticket_buttons', $post_id, $tickets );
+            
+            if ( empty( $tickets ) ) {
+                $admin_views->template( [ 'editor', 'panel', 'settings-button' ], [ 'post_id' => $post_id, 'tickets' => $tickets ] );
+            }
 			?>
-
-			<?php if ( empty( $tickets ) ) : ?>
-				<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					<?php esc_html_e( 'Settings', 'event-tickets' ); ?>
-				</button>
-			<?php endif; ?>
 
 			<?php if ( ! empty( $tickets ) ) : ?>
 				<div class="tec_ticket-panel__helper_link__wrap">
@@ -81,9 +82,6 @@ $container_class .= ( empty( $total_capacity ) ) ? ' tribe_no_capacity' : '';
 		</div>
 
 		<?php if ( ! empty( $tickets ) ) {
-			/** @var Tribe__Tickets__Admin__Views $admin_views */
-			$admin_views = tribe( 'tickets.admin.views' );
-
 			// Split tickets by type to render a list for each type of ticket, implicitly set the order of display.
 			$ticket_types = [ 'rsvp' => [], 'default' => [] ];
 
@@ -204,11 +202,11 @@ $container_class .= ( empty( $total_capacity ) ) ? ' tribe_no_capacity' : '';
 				?>
 			<?php endif; ?>
 
-			<?php if ( ! empty( $tickets ) ) : ?>
-				<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					<?php esc_html_e( 'Settings', 'event-tickets' ); ?>
-				</button>
-			<?php endif; ?>
+			<?php
+            if ( ! empty( $tickets ) ) {
+                $admin_views->template( [ 'editor', 'panel', 'settings-button' ], [ 'post_id' => $post_id, 'tickets' => $tickets ] );
+            }
+            ?>
 		</div>
 	</div>
 	<?php if ( empty( $tickets ) ): ?>

--- a/src/admin-views/editor/panel/settings-button.php
+++ b/src/admin-views/editor/panel/settings-button.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Render the settings button for the ticket editor.
+ *
+ * @since TBD
+ *
+ * @version TBD
+ */
+?>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    <?php esc_html_e( 'Settings', 'event-tickets' ); ?>
+</button>

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -94,9 +93,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -253,8 +252,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -101,9 +100,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -260,8 +259,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with tickets and RSVPs__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with tickets and RSVPs__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -236,9 +235,9 @@
 		<a href="#" id="capacity_form_toggle">400</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -395,8 +394,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -6,10 +6,9 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
 					</div>
 
 		<div class="ticket_table_intro__warnings">

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of a series with passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of a series with passes__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -150,9 +149,9 @@
 		<a href="#" id="capacity_form_toggle">200</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -309,8 +308,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of series with no passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of series with no passes__0.snapshot.html
@@ -6,10 +6,9 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
 					</div>
 
 		<div class="ticket_table_intro__warnings">

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with no passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with no passes__0.snapshot.html
@@ -15,9 +15,6 @@
 >
 	New Series Pass</button>
 
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
 					</div>
 
 		<div class="ticket_table_intro__warnings">

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with passes__0.snapshot.html
@@ -15,7 +15,6 @@
 >
 	New Series Pass</button>
 
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -147,8 +146,6 @@
 		<a href="#" id="capacity_form_toggle">200</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
 					</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
@@ -270,8 +267,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets and no series passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets and no series passes__0.snapshot.html
@@ -6,10 +6,9 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
 					</div>
 
 		<div class="ticket_table_intro__warnings">

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets, series has passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets, series has passes__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -150,9 +149,9 @@
 		<a href="#" id="capacity_form_toggle">200</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -309,8 +308,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with tickets, RSVPs and passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with tickets, RSVPs and passes__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -348,9 +347,9 @@
 		<a href="#" id="capacity_form_toggle">600</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -507,8 +506,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with RSVP__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with RSVP__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -94,9 +93,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -253,8 +252,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with ticket__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -101,9 +100,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -260,8 +259,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with tickets and RSVPs__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with tickets and RSVPs__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -236,9 +235,9 @@
 		<a href="#" id="capacity_form_toggle">400</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>
@@ -395,8 +394,7 @@
 		name="ticket_description"
 		class="ticket_field ticket_form_right"
 		id="ticket_description"
-	>
-			</textarea>
+	></textarea>
 	<div class="input_block">
 		<label class="tribe_soft_note">
 			<input

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event without tickets__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event without tickets__0.snapshot.html
@@ -6,10 +6,9 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
 					</div>
 
 		<div class="ticket_table_intro__warnings">

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -94,9 +93,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -101,9 +100,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
@@ -6,10 +6,9 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
 					</div>
 
 		<div class="ticket_table_intro__warnings">

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -94,9 +93,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -7,7 +7,6 @@
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
 			
-			
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -101,9 +100,9 @@
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-					</div>
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+		</div>
 	</div>
 		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
 </div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -6,10 +6,9 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			
-							<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
-					Settings				</button>
-			
+			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
 					</div>
 
 		<div class="ticket_table_intro__warnings">


### PR DESCRIPTION
### 🎫 Ticket

[ET-1987] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://www.loom.com/share/0598d0a658c44acdb09193e6f29f3796
### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1987]: https://stellarwp.atlassian.net/browse/ET-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ