### PR TITLE
[ET-1971] Add site name and link to Tickets Emails footer

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -201,6 +201,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Ticket is removed now when using the delete option from the block editor. [ET-1879]
 * Tweak - Declared dynamic properties in Tribe__Tickets__Main, Tribe__Tickets__Tickets_Handler, Tribe__Tickets__REST__V1__Messages to prevent warnings in php 8.2 [ET-1950]
 * Fix - Resolve deprecation notices regarding `ArrayAccess::offsetGet()` [ET-1949]
+* Tweak - Update default footer text of Tickets Emails to include link to website. [ET-1971]
 
 = [5.7.1] 2023-12-13 =
 

--- a/src/views/emails/template-parts/body/footer/credit.php
+++ b/src/views/emails/template-parts/body/footer/credit.php
@@ -41,7 +41,7 @@ $et_link     = sprintf(
 	esc_html__( 'Event Tickets', 'event-tickets' )
 );
 $credit_html = sprintf(
-	// Translators: %1$s - HTML link to orgin website; %2$s - HTML link to `Event Tickets` website.
+	// Translators: %1$s - HTML link to origin website; %2$s - HTML link to `Event Tickets` website.
 	__( '%1$s tickets are powered by %2$s', 'event-tickets' ),
 	$site_link,
 	$et_link

--- a/src/views/emails/template-parts/body/footer/credit.php
+++ b/src/views/emails/template-parts/body/footer/credit.php
@@ -30,14 +30,20 @@ if ( ! tribe_is_truthy( $footer_credit ) ) {
 	return;
 }
 
+$site_link   = sprintf(
+	'<a href="%1$s" class="tec-tickets__email-table-main-footer-credit-link">%2$s</a>',
+	esc_url( home_url() ),
+	get_bloginfo( 'name' )
+);
 $et_link     = sprintf(
 	'<a href="%1$s" class="tec-tickets__email-table-main-footer-credit-link">%2$s</a>',
 	'https://evnt.is/et-in-app-email-credit',
 	esc_html__( 'Event Tickets', 'event-tickets' )
 );
 $credit_html = sprintf(
-	// Translators: %s - HTML link to `Event Tickets` website.
-	__( 'Powered by %1$s', 'event-tickets' ),
+	// Translators: %1$s - HTML link to orgin website; %2$s - HTML link to `Event Tickets` website.
+	__( '%1$s tickets are powered by %2$s', 'event-tickets' ),
+	$site_link,
 	$et_link
 );
 

--- a/src/views/emails/template-parts/body/footer/credit.php
+++ b/src/views/emails/template-parts/body/footer/credit.php
@@ -32,7 +32,7 @@ if ( ! tribe_is_truthy( $footer_credit ) ) {
 
 $site_link   = sprintf(
 	'<a href="%1$s" class="tec-tickets__email-table-main-footer-credit-link">%2$s</a>',
-	esc_url( home_url() ),
+	esc_url( site_url() ),
 	get_bloginfo( 'name' )
 );
 $et_link     = sprintf(

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set completed-order__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set completed-order__1.php
@@ -499,7 +499,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set purchase-receipt__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set purchase-receipt__1.php
@@ -505,7 +505,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp-not-going__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp-not-going__1.php
@@ -409,7 +409,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -707,7 +707,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -707,7 +707,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set completed-order__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set completed-order__1.php
@@ -499,7 +499,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set purchase-receipt__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set purchase-receipt__1.php
@@ -505,7 +505,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp-not-going__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp-not-going__1.php
@@ -409,7 +409,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -707,7 +707,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -707,7 +707,7 @@
 		<table role="presentation" class="tec-tickets__email-table-main-footer-table">
 						<tr>
 	<td class="tec-tickets__email-table-main-footer-credit-container" align="right">
-		Powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
+		<a href="http://wordpress.test" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets Tests</a> tickets are powered by <a href="https://evnt.is/et-in-app-email-credit" class="tec-tickets__email-table-main-footer-credit-link">Event Tickets</a>	</td>
 </tr>
 		</table>
 	</td>


### PR DESCRIPTION
### 🎫 Ticket

[ET-1971] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We're adding a link to the site in the footer of the Tickets Emails template to reduce the amount of confusion as to where the tickets are being purchased from.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/b2714c6f-a90f-4a1b-abfe-068373954e41)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1971]: https://stellarwp.atlassian.net/browse/ET-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ