### PR TITLE
[ET-1980] - Fix My Tickets Update Button When Only Opt-Out Form Shows

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -205,7 +205,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Resolved an issue where Order Status was not populated when exporting the Attendee List using Tickets Commerce. [ET-1883]
 * Tweak - Update default footer text of Tickets Emails to include link to website. [ET-1971]
 * Fix - Update usage of `method_exists()` to comply with PHP 8.1 standards. [ET-1759]
-* Fix - Update button will now show when the opt-out checkbox shows ont heMy Tickets page. [ET-1980]
+* Fix - Update button will now show when the opt-out checkbox shows on the My Tickets page. [ET-1980]
 
 = [5.7.1] 2023-12-13 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -204,6 +204,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Resolved an issue where Order Status was not populated when exporting the Attendee List using Tickets Commerce. [ET-1883]
 * Tweak - Update default footer text of Tickets Emails to include link to website. [ET-1971]
 * Fix - Update usage of `method_exists()` to comply with PHP 8.1 standards. [ET-1759]
+* Fix - Update button will now show when the opt-out checkbox shows ont heMy Tickets page. [ET-1980]
 
 = [5.7.1] 2023-12-13 =
 

--- a/src/views/tickets/orders.php
+++ b/src/views/tickets/orders.php
@@ -50,6 +50,9 @@ $user_has_tickets           = $view->has_ticket_attendees( $event_id, $user_id )
 $user_has_rsvp              = $rsvp->get_attendees_count_going_for_user( $event_id, $user_id );
 $tribe_my_tickets_have_meta = false;
 
+// Check to see if we are hiding the opt-out form.
+$hide_attendee_list_optout = apply_filters( 'tribe_tickets_plus_hide_attendees_list_optout', false, $event_id );
+
 /**
  * This filter allows the admin to control the re-send email option when an attendee's email is updated.
  *
@@ -158,6 +161,7 @@ $is_event_page = class_exists( 'Tribe__Events__Main' ) && Tribe__Events__Main::P
 					$view->has_ticket_attendees( $event_id, get_current_user_id() )
 					&& $tribe_my_tickets_have_meta
 				)
+				|| ! $hide_attendee_list_optout
 			) : ?>
 				<div class="tribe-submit-tickets-form">
 					<button

--- a/src/views/tickets/orders.php
+++ b/src/views/tickets/orders.php
@@ -50,7 +50,13 @@ $user_has_tickets           = $view->has_ticket_attendees( $event_id, $user_id )
 $user_has_rsvp              = $rsvp->get_attendees_count_going_for_user( $event_id, $user_id );
 $tribe_my_tickets_have_meta = false;
 
-// Check to see if we are hiding the opt-out form.
+/**
+ * Use this filter to hide the Attendees List Optout
+ *
+ * @since 4.9
+ *
+ * @param bool
+ */
 $hide_attendee_list_optout = apply_filters( 'tribe_tickets_plus_hide_attendees_list_optout', false, $event_id );
 
 /**


### PR DESCRIPTION
### 🎫 Ticket

[ET-1980] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
We found that when only Tickets appear on the My Tickets page, the update button only shows when IAC or ARF are in place. The update button does NOT show in the case where the user can opt attendees out of the public attendees list.

This PR adds that logic in the correct place.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/2822301a-9c37-451c-ad1f-bf670d8486a6)

### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1980]: https://stellarwp.atlassian.net/browse/ET-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ