### PR TITLE
fix(Blocks) ensure ticket block will show correctly on front-end

### DIFF
--- a/src/Tickets/Blocks/Controller.php
+++ b/src/Tickets/Blocks/Controller.php
@@ -102,12 +102,14 @@ class Controller extends \TEC\Common\Contracts\Provider\Controller {
 	 * @since 5.3.0
 	 */
 	public function register_blocks() {
-		$post      = get_post() ?: get_post( tribe_get_request_var( 'post' ) );
-		$post_type = get_post_type( $post ) ?: tribe_get_request_var( 'post_type' );
-
-		if ( ! in_array( $post_type, (array) tribe_get_option( 'ticket-enabled-post-types', [] ), true ) ) {
-			// Register the Blocks only on ticket-enabled post types.
-			return;
+		if ( is_admin() ) {
+			// In admin context, do not register the blocks if the post type is not ticketable.
+			$post      = get_post() ?: get_post( tribe_get_request_var( 'post' ) );
+			$post_type = get_post_type( $post ) ?: tribe_get_request_var( 'post_type' );
+			if ( ! in_array( $post_type, (array) tribe_get_option( 'ticket-enabled-post-types', [] ), true ) ) {
+				// Register the Blocks only on ticket-enabled post types.
+				return;
+			}
 		}
 
 		// Register blocks.


### PR DESCRIPTION
This PR makes sure the checks to avoid Block Editor assets being registered on non ticketable post types, ad admin UI concern, will not leak to the front-end.

[Demo](https://share.cleanshot.com/zWk19pJf)
