### PR TITLE
fix(Ticket_Object) correct key used to filter out Attendees

### DIFF
--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -683,7 +683,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				foreach ( $event_attendees as $attendee ) {
 					$attendee_ticket_stock = new Tribe__Tickets__Global_Stock( $attendee['event_id'] );
 					// bypass any potential weirdness (RSVPs or such)
-					if ( empty( $attendee['product_id'] ) || (int)$attendee['product_id'] !== $event_id ) {
+					if ( empty( $attendee['product_id'] ) || (int) $attendee['event_id'] !== (int) $event_id ) {
 						continue;
 					}
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/SharedCapacityTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/SharedCapacityTest.php
@@ -40,7 +40,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 				'status'     => 'publish',
 				'start_date' => '2020-01-01 12:00:00',
 				'duration'   => 2 * HOUR_IN_SECONDS,
-			] 
+			]
 		)->create()->ID;
 		// Enable the global stock on the Event.
 		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
@@ -57,7 +57,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'mode'     => Global_Stock::CAPPED_STOCK_MODE,
 					'capacity' => 30,
 				],
-			] 
+			]
 		);
 		$ticket_b_id = $this->create_tc_ticket(
 			$event_id,
@@ -67,7 +67,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
 					'capacity' => 50,
 				],
-			] 
+			]
 		);
 
 		// Get the ticket objects.
@@ -99,7 +99,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 			[
 				$ticket_a_id => 5,
 				$ticket_b_id => 5,
-			] 
+			]
 		);
 
 		// Refresh the ticket objects.
@@ -114,7 +114,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 50, $ticket_b->capacity() );
 		$this->assertEquals( 50 - 10, $ticket_b->stock() );
 		$this->assertEquals( 50 - 10, $ticket_b->available() );
-		$this->assertEquals( 50 - 5, $ticket_b->inventory() );
+		$this->assertEquals( 50 - 10, $ticket_b->inventory() );
 
 		$this->assertEquals( 50 - 10, $global_stock->get_stock_level(), 'Global stock should be 50-10 = 40' );
 	}
@@ -126,7 +126,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 				'status'     => 'publish',
 				'start_date' => '2020-01-01 12:00:00',
 				'duration'   => 2 * HOUR_IN_SECONDS,
-			] 
+			]
 		)->create()->ID;
 		// Enable the global stock on the Event.
 		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
@@ -143,7 +143,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
 					'capacity' => 20,
 				],
-			] 
+			]
 		);
 
 		// Get the ticket object.
@@ -190,7 +190,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 				'status'     => 'publish',
 				'start_date' => '2020-01-01 12:00:00',
 				'duration'   => 2 * HOUR_IN_SECONDS,
-			] 
+			]
 		)->create()->ID;
 		// Enable the global stock on the Event.
 		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
@@ -208,7 +208,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'event_capacity' => 20,
 					'capacity'       => 20,
 				],
-			] 
+			]
 		);
 
 		// Get the ticket objects.
@@ -252,7 +252,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 				'status'     => 'publish',
 				'start_date' => '2020-01-01 12:00:00',
 				'duration'   => 2 * HOUR_IN_SECONDS,
-			] 
+			]
 		)->create()->ID;
 		// Enable the global stock on the Event.
 		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
@@ -270,7 +270,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'event_capacity' => 30,
 					'capacity'       => 20,
 				],
-			] 
+			]
 		);
 		$ticket_b_id = $this->create_tc_ticket(
 			$event_id,
@@ -281,7 +281,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'event_capacity' => 30,
 					'capacity'       => 30,
 				],
-			] 
+			]
 		);
 
 		// Get the ticket objects.
@@ -297,7 +297,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 			[
 				$ticket_a_id => 5,
 				$ticket_b_id => 5,
-			] 
+			]
 		);
 
 		// Refresh the ticket objects.
@@ -312,7 +312,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 30, $ticket_b->capacity() );
 		$this->assertEquals( 30 - 10, $ticket_b->stock() );
 		$this->assertEquals( 30 - 10, $ticket_b->available() );
-		$this->assertEquals( 30 - 5, $ticket_b->inventory() );
+		$this->assertEquals( 30 - 10, $ticket_b->inventory() );
 
 		$new_global_capacity = 40;
 		// Update the Event's capacity manually.
@@ -336,7 +336,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 40, tribe_tickets_get_capacity( $ticket_b_id ), 'Global Ticket Capacity should be increased to 40' );
 		$this->assertEquals( 40 - 10, $ticket_b->stock(), 'Global Ticket Stock should be 30' );
 		$this->assertEquals( 40 - 10, $ticket_b->available(), 'Global Ticket available should be 30' );
-		$this->assertEquals( 40 - 5, $ticket_b->inventory(), 'Global Ticket inventory should be 30' );
+		$this->assertEquals( 40 - 10, $ticket_b->inventory(), 'Global Ticket inventory should be 30' );
 
 		$event_ticket_counts    = \Tribe__Tickets__Tickets::get_ticket_counts( $event_id );
 		$expected_ticket_counts = [
@@ -357,7 +357,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 				'status'     => 'publish',
 				'start_date' => '2020-01-01 12:00:00',
 				'duration'   => 2 * HOUR_IN_SECONDS,
-			] 
+			]
 		)->create()->ID;
 		// Enable the global stock on the Event.
 		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
@@ -374,7 +374,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'mode'     => Global_Stock::CAPPED_STOCK_MODE,
 					'capacity' => 20,
 				],
-			] 
+			]
 		);
 		$ticket_b_id = $this->create_tc_ticket(
 			$event_id,
@@ -384,7 +384,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 					'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
 					'capacity' => 30,
 				],
-			] 
+			]
 		);
 
 		// Get the ticket objects.
@@ -400,7 +400,7 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 			[
 				$ticket_a_id => 5,
 				$ticket_b_id => 5,
-			] 
+			]
 		);
 
 		$new_global_capacity = 15;
@@ -422,13 +422,13 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 15, tribe_tickets_get_capacity( $ticket_a_id ), 'Capped Ticket Capacity should be decreased to 15' );
 		$this->assertEquals( 15 - 10, $ticket_a->stock(), 'Capped Ticket Stock should be decreased to 5' );
 		$this->assertEquals( 15 - 10, $ticket_a->available(), 'Capped Ticket available should be decreased to 5' );
-		$this->assertEquals( 15 - 5, $ticket_a->inventory(), 'Capped Ticket inventory should be decreased to 5' );
+		$this->assertEquals( 15 - 10, $ticket_a->inventory(), 'Capped Ticket inventory should be decreased to 5' );
 
 		$this->assertEquals( 15, $ticket_b->capacity(), 'Global Ticket Capacity should be decreased to 15' );
 		$this->assertEquals( 15, tribe_tickets_get_capacity( $ticket_b_id ), 'Global Ticket Capacity should be decreased to 15' );
 		$this->assertEquals( 15 - 10, $ticket_b->stock(), 'Global Ticket Stock should be 5' );
 		$this->assertEquals( 15 - 10, $ticket_b->available(), 'Global Ticket available should be 5' );
-		$this->assertEquals( 15 - 5, $ticket_b->inventory(), 'Global Ticket inventory should be 5' );
+		$this->assertEquals( 15 - 10, $ticket_b->inventory(), 'Global Ticket inventory should be 5' );
 
 		$event_ticket_counts    = \Tribe__Tickets__Tickets::get_ticket_counts( $event_id );
 		$expected_ticket_counts = [

--- a/tests/integration/Tribe/Tickets/Ticket_ObjectTest.php
+++ b/tests/integration/Tribe/Tickets/Ticket_ObjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Tickets;
 
+
 use TEC\Tickets\Commerce\Module;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
@@ -51,22 +52,32 @@ class Ticket_ObjectTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_not_include_attendees_injected_from_other_posts_into_global_inventory(): void {
-		$capacity_key = Tickets_Handler::instance()->key_capacity;
+		$capacity_key              = Tickets_Handler::instance()->key_capacity;
+		$global_stock_mode_enabled = Global_Stock::GLOBAL_STOCK_ENABLED;
 		// Create a first post and set its shared capacity to 100.
 		$post_1 = static::factory()->post->create();
 		update_post_meta( $post_1, $capacity_key, 100 );
-		// Create a second post and set its shared capacity to 100.
+		update_post_meta( $post_1, $global_stock_mode_enabled, 1 );
+		// Create a second post and set its shared capacity to 30.
 		$post_2 = static::factory()->post->create();
 		update_post_meta( $post_2, $capacity_key, 30 );
-		// Create two shared capacity tickets for the first post.
-		$global_ticket_for_post_1 = $this->create_tc_ticket( $post_1, 23, [
+		update_post_meta( $post_2, $global_stock_mode_enabled, 1 );
+		// Create one shared capacity ticket for the first post.
+		$post_1_ticket_1 = $this->create_tc_ticket( $post_1, 23, [
 			'tribe-ticket' => [
 				'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
 				'capacity' => 100,
 			],
 		] );
-		// Create 2 shared capcity tickets for the second post.
-		$global_ticket_for_post_2 = $this->create_tc_ticket( $post_2, 23, [
+		// Create one shared capacity ticket for the second post.
+		$post_2_ticket_1 = $this->create_tc_ticket( $post_2, 23, [
+			'tribe-ticket' => [
+				'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
+				'capacity' => 30,
+			],
+		] );
+		// Create a second shared capacity ticket for the second post.
+		$post_2_ticket_2 = $this->create_tc_ticket( $post_2, 23, [
 			'tribe-ticket' => [
 				'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
 				'capacity' => 30,
@@ -77,15 +88,29 @@ class Ticket_ObjectTest extends \Codeception\TestCase\WPTestCase {
 		$get_post_2_ticket = fn( int $id ) => Module::get_instance()->get_ticket( $post_2, $id );
 
 		// Baseline check before adding attendees.
-		$this->assertEquals( 100, $get_post_1_ticket( $global_ticket_for_post_1 )->inventory() );
-		$this->assertEquals( 30, $get_post_2_ticket( $global_ticket_for_post_2 )->inventory() );
+		$this->assertEquals( 100, $get_post_1_ticket( $post_1_ticket_1 )->inventory() );
+		$this->assertEquals( 30, $get_post_2_ticket( $post_2_ticket_1 )->inventory() );
+		$this->assertEquals( 30, $get_post_2_ticket( $post_2_ticket_2 )->inventory() );
 
-		// Add 2 Attendees to post 1, global ticket inventories should change accordingly.
-		$this->create_order( [ $global_ticket_for_post_1 => 2 ] );
-		$this->assertEquals( 98, $get_post_1_ticket( $global_ticket_for_post_1 )->inventory() );
-		$this->assertEquals( 30, $get_post_2_ticket( $global_ticket_for_post_2 )->inventory() );
+		// Add 3 Attendees to post 1 ticket 1, global ticket inventories should change accordingly.
+		$this->create_order( [ $post_1_ticket_1 => 3 ] );
+		$this->assertEquals( 97, $get_post_1_ticket( $post_1_ticket_1 )->inventory() );
+		$this->assertEquals( 30, $get_post_2_ticket( $post_2_ticket_1 )->inventory() );
+		$this->assertEquals( 30, $get_post_2_ticket( $post_2_ticket_2 )->inventory() );
 
-		// Filter the query to get post 2 Attendees to pull them from post 1 as well.
+		// Add 2 Attendees to post 2 ticket 2, global ticket inventories should change accordingly.
+		$this->create_order( [ $post_2_ticket_2 => 2 ] );
+		$this->assertEquals( 97, $get_post_1_ticket( $post_1_ticket_1 )->inventory() );
+		$this->assertEquals( 28, $get_post_2_ticket( $post_2_ticket_1 )->inventory() );
+		$this->assertEquals( 28, $get_post_2_ticket( $post_2_ticket_2 )->inventory() );
+
+		// Check the Attendees before injecting Post 1 Attendees among Post 2 Attendees.
+		$post_1_attendees = tribe_attendees()->where( 'event', $post_1 )->get_ids();
+		$post_2_attendees = tribe_attendees()->where( 'event', $post_2 )->get_ids();
+		$this->assertCount( 3, $post_1_attendees );
+		$this->assertCount( 2, $post_2_attendees );
+
+		// Filter the query to get Post 2 Attendees to pull them from Post 1 as well.
 		add_filter( 'tec_tickets_attendees_filter_by_event', function ( $post_ids ) use ( $post_1, $post_2 ) {
 			if ( (array) $post_ids === [ $post_2 ] ) {
 				return [ $post_1, $post_2 ];
@@ -94,14 +119,19 @@ class Ticket_ObjectTest extends \Codeception\TestCase\WPTestCase {
 			return $post_ids;
 		} );
 
+		// Refresh the cache on both tickets to make sure inventory is recalculated.
+		clean_post_cache( $post_1_ticket_1 );
+		clean_post_cache( $post_2_ticket_1 );
+
 		// Check attendees are the ones we expect: post 1 Attendees are injected into post 2 attendees.
-		$this->assertEqualSets(
-			tribe_attendees()->where( 'event', $post_1 )->get_ids(),
-			tribe_attendees()->where( 'event', $post_2 )->get_ids()
-		);
+		$this->assertEqualSets( [
+			...$post_1_attendees,
+			...$post_2_attendees
+		], tribe_attendees()->where( 'event', $post_2 )->get_ids() );
 
 		// No matter the injection of attendees, inventory should not be affected for post 2 global ticket.
-		$this->assertEquals( 98, $get_post_1_ticket( $global_ticket_for_post_1 )->inventory() );
-		$this->assertEquals( 30, $get_post_2_ticket( $global_ticket_for_post_2 )->inventory() );
+		$this->assertEquals( 97, $get_post_1_ticket( $post_1_ticket_1 )->inventory() );
+		$this->assertEquals( 28, $get_post_2_ticket( $post_2_ticket_1 )->inventory() );
+		$this->assertEquals( 28, $get_post_2_ticket( $post_2_ticket_2 )->inventory() );
 	}
 }

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
@@ -6,7 +6,19 @@
 >
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
-			
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new ticket"
+""
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -71,7 +83,30 @@
 				100	</td>
 
 	<td class="ticket_edit">
-			</td>
+		<button
+	data-provider='Tribe__Tickets__RSVP'
+	data-ticket-id='{{ ticket_id }}'
+	title='Edit Ticket ID: {{ ticket_id }}'
+	class='ticket_edit_button'>
+	<span class='ticket_edit_text'>Test RSVP ticket for {{ post_id }}</span>
+</button>
+
+	<button
+		data-provider='Tribe__Tickets__RSVP'
+		data-ticket-id='{{ ticket_id }}'
+		title='Duplicate Ticket ID: {{ ticket_id }}'
+		class='ticket_duplicate'>
+	<span class='ticket_duplicate_text'>Test RSVP ticket for {{ post_id }}</span>
+	</button>
+
+<button
+	attr-provider='Tribe__Tickets__RSVP'
+	attr-ticket-id='{{ ticket_id }}'
+	title='Delete Ticket ID: {{ ticket_id }}'
+	class='ticket_delete'>
+	<span class='ticket_delete_text'>Test RSVP ticket for {{ post_id }}</span>
+</button>
+	</td>
 </tr>
 		</tbody>
 	</table>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
@@ -6,7 +6,19 @@
 >
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
-			
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new ticket"
+""
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -73,7 +85,30 @@
 				100	</td>
 
 	<td class="ticket_edit">
-			</td>
+		<button
+	data-provider='TEC\Tickets\Commerce\Module'
+	data-ticket-id='{{ ticket_id }}'
+	title='Edit Ticket ID: {{ ticket_id }}'
+	class='ticket_edit_button'>
+	<span class='ticket_edit_text'>Test TC ticket for {{ post_id }}</span>
+</button>
+
+	<button
+		data-provider='TEC\Tickets\Commerce\Module'
+		data-ticket-id='{{ ticket_id }}'
+		title='Duplicate Ticket ID: {{ ticket_id }}'
+		class='ticket_duplicate'>
+	<span class='ticket_duplicate_text'>Test TC ticket for {{ post_id }}</span>
+	</button>
+
+<button
+	attr-provider='TEC\Tickets\Commerce\Module'
+	attr-ticket-id='{{ ticket_id }}'
+	title='Delete Ticket ID: {{ ticket_id }}'
+	class='ticket_delete'>
+	<span class='ticket_delete_text'>Test TC ticket for {{ post_id }}</span>
+</button>
+	</td>
 </tr>
 		</tbody>
 	</table>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
@@ -6,7 +6,19 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new ticket"
+""
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
     Settings</button>
 
 					</div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -6,7 +6,19 @@
 >
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
-			
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new ticket"
+""
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -71,7 +83,30 @@
 				100	</td>
 
 	<td class="ticket_edit">
-			</td>
+		<button
+	data-provider='Tribe__Tickets__RSVP'
+	data-ticket-id='{{ ticket_id }}'
+	title='Edit Ticket ID: {{ ticket_id }}'
+	class='ticket_edit_button'>
+	<span class='ticket_edit_text'>Test RSVP ticket for {{ post_id }}</span>
+</button>
+
+	<button
+		data-provider='Tribe__Tickets__RSVP'
+		data-ticket-id='{{ ticket_id }}'
+		title='Duplicate Ticket ID: {{ ticket_id }}'
+		class='ticket_duplicate'>
+	<span class='ticket_duplicate_text'>Test RSVP ticket for {{ post_id }}</span>
+	</button>
+
+<button
+	attr-provider='Tribe__Tickets__RSVP'
+	attr-ticket-id='{{ ticket_id }}'
+	title='Delete Ticket ID: {{ ticket_id }}'
+	class='ticket_delete'>
+	<span class='ticket_delete_text'>Test RSVP ticket for {{ post_id }}</span>
+</button>
+	</td>
 </tr>
 		</tbody>
 	</table>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -6,7 +6,19 @@
 >
 	<div class="tribe_sectionheader ticket_list_container">
 		<div class="ticket_table_intro">
-			
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new ticket"
+""
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+
 							<div class="tec_ticket-panel__helper_link__wrap">
 					<p>
 					<a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>					</p>
@@ -73,7 +85,30 @@
 				100	</td>
 
 	<td class="ticket_edit">
-			</td>
+		<button
+	data-provider='TEC\Tickets\Commerce\Module'
+	data-ticket-id='{{ ticket_id }}'
+	title='Edit Ticket ID: {{ ticket_id }}'
+	class='ticket_edit_button'>
+	<span class='ticket_edit_text'>Test TC ticket for {{ post_id }}</span>
+</button>
+
+	<button
+		data-provider='TEC\Tickets\Commerce\Module'
+		data-ticket-id='{{ ticket_id }}'
+		title='Duplicate Ticket ID: {{ ticket_id }}'
+		class='ticket_duplicate'>
+	<span class='ticket_duplicate_text'>Test TC ticket for {{ post_id }}</span>
+	</button>
+
+<button
+	attr-provider='TEC\Tickets\Commerce\Module'
+	attr-ticket-id='{{ ticket_id }}'
+	title='Delete Ticket ID: {{ ticket_id }}'
+	class='ticket_delete'>
+	<span class='ticket_delete_text'>Test TC ticket for {{ post_id }}</span>
+</button>
+	</td>
 </tr>
 		</tbody>
 	</table>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -6,7 +6,19 @@
 >
 	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
-			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new ticket"
+""
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
     Settings</button>
 
 					</div>


### PR DESCRIPTION
In the context of the work done to make sure Ticket inventory would be calculated correctly, I have set up the code to use the wrong key to exclude Attendees not for a specific post.
This PR fixes the issue where it was introduced, at the base level of the `Ticket__Object::inventory()` method.

Tests have been updated to better cover the fix and ensure they would fail when using the incorrect Attendee key (`product_id`) in place of the correct one (`event_id`).

[Demo](https://share.cleanshot.com/MgNxWLPv)
