### PR TITLE
fix(Metabox) use correct case for class name to count active providers

### DIFF
--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -467,7 +467,7 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 	 * @param int $post_id The ID of the post the form is being rendered for.
 	 */
 	public function render_ticket_form_toggle( int $post_id ): void {
-		$ticket_providing_modules = array_diff_key( tribe__tickets__tickets::modules(), [ 'tribe__tickets__rsvp' => true ] );
+		$ticket_providing_modules = array_diff_key( Tribe__Tickets__Tickets::modules(), [ 'Tribe__Tickets__RSVP' => true ] );
 		$add_new_ticket_label     = count( $ticket_providing_modules ) > 0
 			? esc_attr__( 'Add a new ticket', 'event-tickets' )
 			: esc_attr__( 'No commerce providers available', 'event-tickets' );

--- a/tests/ft_integration/Tribe/Tickets/MetaboxTest.php
+++ b/tests/ft_integration/Tribe/Tickets/MetaboxTest.php
@@ -404,7 +404,7 @@ class MetaboxTest extends WPTestCase {
 					]
 				)->create()->ID;
 				$occurrences_provisional_ids = occurrence::where( 'post_id', '=', $post_id )
-				                                         ->map( fn( occurrence $o ) => $o->provisional_id );
+					->map( fn( occurrence $o ) => $o->provisional_id );
 
 				return [ $post_id, $series_id, ...$occurrences_provisional_ids ];
 			},
@@ -445,7 +445,7 @@ class MetaboxTest extends WPTestCase {
 				)->create()->ID;
 
 				$occurrences_provisional_ids = Occurrence::where( 'post_id', '=', $post_id )
-				                                         ->map( fn( Occurrence $o ) => $o->provisional_id );
+					->map( fn( Occurrence $o ) => $o->provisional_id );
 
 				return [ $post_id, $pass_1, $pass_2, $series_id, ...$occurrences_provisional_ids ];
 			},
@@ -494,24 +494,34 @@ class MetaboxTest extends WPTestCase {
 
 		yield 'single event by Occurrence provisional ID' => [
 			function (): array {
-				$single_event = tribe_events()->set_args( [
-					'title'      => 'Single Event',
-					'status'     => 'publish',
-					'start_date' => '2021-01-01 10:00:00',
-					'end_date'   => '2021-01-01 12:00:00',
-				] )->create()->ID;
-				$ticket_1     = $this->create_tc_ticket( $single_event, 1, [
-					'tribe-ticket' => [
-						'mode'     => Global_Stock::OWN_STOCK_MODE,
-						'capacity' => 89,
-					],
-				] );
-				$ticket_2     = $this->create_tc_ticket( $single_event, 1, [
-					'tribe-ticket' => [
-						'mode'     => Global_Stock::OWN_STOCK_MODE,
-						'capacity' => 23,
-					],
-				] );
+				$single_event = tribe_events()->set_args(
+					[
+						'title'      => 'Single Event',
+						'status'     => 'publish',
+						'start_date' => '2021-01-01 10:00:00',
+						'end_date'   => '2021-01-01 12:00:00',
+					]
+				)->create()->ID;
+				$ticket_1     = $this->create_tc_ticket(
+					$single_event,
+					1,
+					[
+						'tribe-ticket' => [
+							'mode'     => Global_Stock::OWN_STOCK_MODE,
+							'capacity' => 89,
+						],
+					]
+				);
+				$ticket_2     = $this->create_tc_ticket(
+					$single_event,
+					1,
+					[
+						'tribe-ticket' => [
+							'mode'     => Global_Stock::OWN_STOCK_MODE,
+							'capacity' => 23,
+						],
+					]
+				);
 
 				$occurrence = Occurrence::where( 'post_id', $single_event )->first();
 
@@ -520,7 +530,7 @@ class MetaboxTest extends WPTestCase {
 				}
 
 				return [ $occurrence->provisional_id, $single_event, $ticket_1, $ticket_2 ];
-			}
+			},
 		];
 	}
 
@@ -564,18 +574,20 @@ class MetaboxTest extends WPTestCase {
 		yield 'post' => [
 			static function () {
 				return static::factory()->post->create( [ 'post_type' => 'post' ] );
-			}
+			},
 		];
 
 		yield 'event' => [
 			static function () {
-				return tribe_events()->set_args( [
-					'title'      => 'Test Event',
-					'status'     => 'publish',
-					'start_date' => '2022-10-01 10:00:00',
-					'duration'   => 2 * HOUR_IN_SECONDS,
-				] )->create()->ID;
-			}
+				return tribe_events()->set_args(
+					[
+						'title'      => 'Test Event',
+						'status'     => 'publish',
+						'start_date' => '2022-10-01 10:00:00',
+						'duration'   => 2 * HOUR_IN_SECONDS,
+					]
+				)->create()->ID;
+			},
 		];
 	}
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__event__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__event__0.snapshot.html
@@ -1,0 +1,403 @@
+<div
+	id="tribe_panel_base"
+	class="ticket_panel panel_base"
+	aria-hidden="false"
+	data-save-prompt="You have unsaved changes to your tickets. Discard those changes?"
+>
+	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
+		<div class="ticket_table_intro">
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="No commerce providers available"
+" disabled='disabled' disabled='disabled'"
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
+					</div>
+
+		<div class="ticket_table_intro__warnings">
+					<div  class="ticket-editor-notice info provider-warning" 								>
+			<span class="message">There is no payment gateway configured. To create tickets, you'll need to enable and configure an ecommerce solution. <a href="https://evnt.is/1ao5" target="_blank" rel="noopener noreferrer">Learn More</a></span>
+		</div>
+				<div  class="ticket-editor-notice info provider-warning" 								>
+			<span class="message">There is no payment gateway configured. To create tickets, you'll need to enable and configure an ecommerce solution. <a href="https://evnt.is/1ao5" target="_blank" rel="noopener noreferrer">Learn More</a></span>
+		</div>
+				</div>
+
+			</div>
+	<div class="tribe-ticket-control-wrap">
+		<div class="tribe-ticket-control-wrap__ctas">
+					</div>
+
+		<div class="tribe-ticket-control-wrap__settings">
+			
+					</div>
+	</div>
+		<div class="tec_ticket-panel__helper_text__wrap">
+		<p>
+		Create and manage single tickets and RSVPs for this event. <a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>.		</p>
+	</div>
+		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p><p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
+</div>
+<div id="tribe_panel_settings" class="ticket_panel panel_settings" aria-hidden="true" >
+	<h4>Ticket Settings	</h4>
+
+	<section class="settings_main">
+		
+	<fieldset class="screen-reader-text">
+								</fieldset>
+	</section>
+
+	<section id="tribe-tickets-image">
+	<div class="tribe-tickets-image-upload">
+		<div class="input_block">
+				<span class="ticket_form_label tribe-strong-label">Ticket header image:				</span>
+			<p class="description">
+				Select an image from your Media Library to display on emailed ticket. For best results, use a .jpg, .png, or .gif at least 1160px wide.			</p>
+		</div>
+		<input
+			type="button"
+			class="button"
+			name="tribe-tickets[settings][header_image]"
+			id="tribe_ticket_header_image"
+			value="Select an Image"
+		/>
+
+		<span id="tribe_tickets_image_preview_filename" class="">
+				<span class="dashicons dashicons-format-image"></span>
+				<span class="filename"></span>
+			</span>
+	</div>
+	<div class="tribe-tickets-image-preview">
+		<a class="tribe_preview" id="tribe_ticket_header_preview">
+					</a>
+		<p class="description">
+			<a href="#" id="tribe_ticket_header_remove">Remove</a>
+		</p>
+
+		<input
+			type="hidden"
+			id="tribe_ticket_header_image_id"
+			class="settings_field"
+			name="tribe-tickets[settings][header_image_id]"
+			value=""
+		/>
+	</div>
+</section>
+
+	<input type="button" id="tribe_settings_form_save" name="tribe_settings_form_save" value="Save settings" class="button-primary" />
+	<input type="button" id="tribe_settings_form_cancel" name="tribe_settings_form_cancel" value="Cancel" class="button-secondary" />
+</div>
+
+<div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
+	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
+     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+>
+	
+	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
+		<div id="ticket_form_table" class="eventtable ticket_form">
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-not-checked
+			>
+				<h4
+						id="ticket_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new ticket				</h4>
+				<h4
+						id="ticket_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit ticket				</h4>
+			</div>
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-checked
+			>
+				<h4
+						id="rsvp_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new RSVP				</h4>
+				<h4
+						id="rsvp_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit RSVP				</h4>
+			</div>
+			<section id="ticket_form_main" class="main"
+					 data-datepicker_format="1">
+
+				
+				<input
+					type='hidden'
+					id='ticket_type'
+					name='ticket_type'
+					value="default"
+				/>
+
+				<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_name">
+		Name:	</label>
+	<input
+		type='text'
+		id='ticket_name'
+		name='ticket_name'
+		class="ticket_field ticket_form_right"
+		size='25'
+		value=""
+		data-validation-is-required
+		data-validation-error="RSVP type is a required field"
+	/>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-not-checked
+	>
+	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-is-checked
+	>
+	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
+</div>
+
+				
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_description">
+		Description:	</label>
+	<textarea
+		rows="5"
+		cols="40"
+		name="ticket_description"
+		class="ticket_field ticket_form_right"
+		id="ticket_description"
+	></textarea>
+	<div class="input_block">
+		<label class="tribe_soft_note">
+			<input
+				type="checkbox"
+				id="tribe_tickets_show_description"
+				name="ticket_show_description"
+				value="1"
+				class="ticket_field ticket_form_left"
+				 checked='checked'			>
+			Show description on frontend ticket form.		</label>
+	</div>
+</div>
+
+				
+<div id="ticket_type_options" class="input_block">
+	<label class="ticket_form_label ticket_form_left" id="ticket_type_label" for="ticket_type">
+		Type:	</label>
+
+	<div class="ticket_form_right ticket_form_right--flex">
+		<img
+			class="tribe-tickets-svgicon tec-tickets-icon tec-tickets-icon__ticket-type"
+			src="http://wordpress.test/wp-content/plugins/event-tickets/src/resources/icons/ticket-default-icon.svg"
+			alt="Ticket"
+		/>
+		<span class="ticket-type__text ticket-type__text--default">
+		Single Ticket		</span>
+	</div>
+
+	<span class="tribe_soft_note ticket_form_right tribe-active">
+		A single ticket is specific to this event.	</span>
+</div>
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+		Start sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-start_date ticket_field"
+			name="ticket_start_date"
+			id="ticket_start_date"
+			value=""
+			data-validation-type="datepicker"
+			data-validation-is-less-or-equal-to="#ticket_end_date"
+			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-start_time ticket_field"
+			name="ticket_start_time"
+			id="ticket_start_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket start date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
+	</div>
+</div>
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+		End sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-end_date ticket_field"
+			name="ticket_end_date"
+			id="ticket_end_date"
+			value=""
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-end_time ticket_field"
+			name="ticket_end_time"
+			id="ticket_end_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket end date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
+	</div>
+</div>
+
+				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
+					<legend class="ticket_form_label">Sell using:</legend>
+									</fieldset>
+				<div
+	class="price tribe-dependent"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-not-checked
+	>
+	<div class="input_block">
+		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
+		<input
+			type="text"
+			id="ticket_price"
+			name="ticket_price"
+			class="ticket_field ticket_form_right"
+			size="7"
+			value=""
+						data-validation-error="Ticket price must be greater than zero."		/>
+					<p class="description ticket_form_right">
+				Leave blank for free Ticket			</p>
+				</div>
+
+	</div><div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="Tribe__Tickets__RSVP_capacity"
+		class="ticket_form_label ticket_form_left"
+	>
+		Capacity:	</label>
+	<input
+		type='text' id='Tribe__Tickets__RSVP_capacity'
+		name='tribe-ticket[capacity]'
+		class="ticket_field tribe-rsvp-field-capacity ticket_form_right"
+		size='7'
+		value=''
+	/>
+	<span class="tribe_soft_note ticket_form_right">Leave blank for unlimited</span>
+</div>
+
+<div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="tribe-tickets-rsvp-not-going"
+		class="ticket_form_label ticket_form_left"
+	>
+		Can&#039;t Go:	</label>
+	<input
+		type="checkbox"
+		id="tribe-tickets-rsvp-not-going"
+		name="tribe-ticket[not_going]"
+		class="ticket_field tribe-rsvp-field-not-going ticket_form_right"
+		value="yes"
+			/>
+	<span class="tribe_soft_note ticket_form_right">Enable &quot;Can&#039;t Go&quot; responses</span>
+</div>
+			</section>
+			<div class="accordion">
+				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+	<button class="accordion-header tribe_advanced_meta">
+		Advanced	</button>
+	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
+		<h4 class="accordion-label screen_reader_text">Advanced Settings</h4>
+		<div id="advanced_fields">
+			<div id="Tribe__Tickets__Commerce__PayPal__Main_advanced" class="tribe-dependent" data-depends="#Tribe__Tickets__Commerce__PayPal__Main_radio" data-condition-is-checked></div><div id="TECTicketsCommerceEditorMetabox_advanced" class="tribe-dependent" data-depends="#provider_TEC_Tickets_Commerce_Module_radio" data-condition-is-checked></div>		</div>
+	</section><!-- #ticket_form_advanced -->
+</div>
+			</div>
+
+						<div class="ticket_bottom">
+				<input
+						type="hidden"
+						name="ticket_id"
+						id="ticket_id"
+						class="ticket_field"
+						value=""
+				/>
+				<input
+						type="button"
+						id="ticket_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save ticket"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-not-checked
+				/>
+				<input
+						type="button"
+						id="rsvp_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save RSVP"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-checked
+				/>
+				<input
+						type="button"
+						id="ticket_form_cancel"
+						class="button-secondary"
+						name="ticket_form_cancel"
+						value="Cancel"
+				/>
+
+				
+				<div id="ticket_bottom_right">
+									</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__post__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__post__0.snapshot.html
@@ -1,0 +1,403 @@
+<div
+	id="tribe_panel_base"
+	class="ticket_panel panel_base"
+	aria-hidden="false"
+	data-save-prompt="You have unsaved changes to your tickets. Discard those changes?"
+>
+	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
+		<div class="ticket_table_intro">
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="No commerce providers available"
+" disabled='disabled' disabled='disabled'"
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
+					</div>
+
+		<div class="ticket_table_intro__warnings">
+					<div  class="ticket-editor-notice info provider-warning" 								>
+			<span class="message">There is no payment gateway configured. To create tickets, you'll need to enable and configure an ecommerce solution. <a href="https://evnt.is/1ao5" target="_blank" rel="noopener noreferrer">Learn More</a></span>
+		</div>
+				<div  class="ticket-editor-notice info provider-warning" 								>
+			<span class="message">There is no payment gateway configured. To create tickets, you'll need to enable and configure an ecommerce solution. <a href="https://evnt.is/1ao5" target="_blank" rel="noopener noreferrer">Learn More</a></span>
+		</div>
+				</div>
+
+			</div>
+	<div class="tribe-ticket-control-wrap">
+		<div class="tribe-ticket-control-wrap__ctas">
+					</div>
+
+		<div class="tribe-ticket-control-wrap__settings">
+			
+					</div>
+	</div>
+		<div class="tec_ticket-panel__helper_text__wrap">
+		<p>
+		Create and manage single tickets and RSVPs for this post. <a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>.		</p>
+	</div>
+		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p><p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
+</div>
+<div id="tribe_panel_settings" class="ticket_panel panel_settings" aria-hidden="true" >
+	<h4>Ticket Settings	</h4>
+
+	<section class="settings_main">
+		
+	<fieldset class="screen-reader-text">
+								</fieldset>
+	</section>
+
+	<section id="tribe-tickets-image">
+	<div class="tribe-tickets-image-upload">
+		<div class="input_block">
+				<span class="ticket_form_label tribe-strong-label">Ticket header image:				</span>
+			<p class="description">
+				Select an image from your Media Library to display on emailed ticket. For best results, use a .jpg, .png, or .gif at least 1160px wide.			</p>
+		</div>
+		<input
+			type="button"
+			class="button"
+			name="tribe-tickets[settings][header_image]"
+			id="tribe_ticket_header_image"
+			value="Select an Image"
+		/>
+
+		<span id="tribe_tickets_image_preview_filename" class="">
+				<span class="dashicons dashicons-format-image"></span>
+				<span class="filename"></span>
+			</span>
+	</div>
+	<div class="tribe-tickets-image-preview">
+		<a class="tribe_preview" id="tribe_ticket_header_preview">
+					</a>
+		<p class="description">
+			<a href="#" id="tribe_ticket_header_remove">Remove</a>
+		</p>
+
+		<input
+			type="hidden"
+			id="tribe_ticket_header_image_id"
+			class="settings_field"
+			name="tribe-tickets[settings][header_image_id]"
+			value=""
+		/>
+	</div>
+</section>
+
+	<input type="button" id="tribe_settings_form_save" name="tribe_settings_form_save" value="Save settings" class="button-primary" />
+	<input type="button" id="tribe_settings_form_cancel" name="tribe_settings_form_cancel" value="Cancel" class="button-secondary" />
+</div>
+
+<div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
+	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
+     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+>
+	
+	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
+		<div id="ticket_form_table" class="eventtable ticket_form">
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-not-checked
+			>
+				<h4
+						id="ticket_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new ticket				</h4>
+				<h4
+						id="ticket_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit ticket				</h4>
+			</div>
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-checked
+			>
+				<h4
+						id="rsvp_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new RSVP				</h4>
+				<h4
+						id="rsvp_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit RSVP				</h4>
+			</div>
+			<section id="ticket_form_main" class="main"
+					 data-datepicker_format="1">
+
+				
+				<input
+					type='hidden'
+					id='ticket_type'
+					name='ticket_type'
+					value="default"
+				/>
+
+				<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_name">
+		Name:	</label>
+	<input
+		type='text'
+		id='ticket_name'
+		name='ticket_name'
+		class="ticket_field ticket_form_right"
+		size='25'
+		value=""
+		data-validation-is-required
+		data-validation-error="RSVP type is a required field"
+	/>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-not-checked
+	>
+	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-is-checked
+	>
+	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
+</div>
+
+				
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_description">
+		Description:	</label>
+	<textarea
+		rows="5"
+		cols="40"
+		name="ticket_description"
+		class="ticket_field ticket_form_right"
+		id="ticket_description"
+	></textarea>
+	<div class="input_block">
+		<label class="tribe_soft_note">
+			<input
+				type="checkbox"
+				id="tribe_tickets_show_description"
+				name="ticket_show_description"
+				value="1"
+				class="ticket_field ticket_form_left"
+				 checked='checked'			>
+			Show description on frontend ticket form.		</label>
+	</div>
+</div>
+
+				
+<div id="ticket_type_options" class="input_block">
+	<label class="ticket_form_label ticket_form_left" id="ticket_type_label" for="ticket_type">
+		Type:	</label>
+
+	<div class="ticket_form_right ticket_form_right--flex">
+		<img
+			class="tribe-tickets-svgicon tec-tickets-icon tec-tickets-icon__ticket-type"
+			src="http://wordpress.test/wp-content/plugins/event-tickets/src/resources/icons/ticket-default-icon.svg"
+			alt="Ticket"
+		/>
+		<span class="ticket-type__text ticket-type__text--default">
+		Single Ticket		</span>
+	</div>
+
+	<span class="tribe_soft_note ticket_form_right tribe-active">
+		A single ticket is specific to this post.	</span>
+</div>
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+		Start sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-start_date ticket_field"
+			name="ticket_start_date"
+			id="ticket_start_date"
+			value=""
+			data-validation-type="datepicker"
+			data-validation-is-less-or-equal-to="#ticket_end_date"
+			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-start_time ticket_field"
+			name="ticket_start_time"
+			id="ticket_start_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket start date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
+	</div>
+</div>
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+		End sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-end_date ticket_field"
+			name="ticket_end_date"
+			id="ticket_end_date"
+			value=""
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-end_time ticket_field"
+			name="ticket_end_time"
+			id="ticket_end_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket end date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
+	</div>
+</div>
+
+				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
+					<legend class="ticket_form_label">Sell using:</legend>
+									</fieldset>
+				<div
+	class="price tribe-dependent"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-not-checked
+	>
+	<div class="input_block">
+		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
+		<input
+			type="text"
+			id="ticket_price"
+			name="ticket_price"
+			class="ticket_field ticket_form_right"
+			size="7"
+			value=""
+						data-validation-error="Ticket price must be greater than zero."		/>
+					<p class="description ticket_form_right">
+				Leave blank for free Ticket			</p>
+				</div>
+
+	</div><div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="Tribe__Tickets__RSVP_capacity"
+		class="ticket_form_label ticket_form_left"
+	>
+		Capacity:	</label>
+	<input
+		type='text' id='Tribe__Tickets__RSVP_capacity'
+		name='tribe-ticket[capacity]'
+		class="ticket_field tribe-rsvp-field-capacity ticket_form_right"
+		size='7'
+		value=''
+	/>
+	<span class="tribe_soft_note ticket_form_right">Leave blank for unlimited</span>
+</div>
+
+<div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="tribe-tickets-rsvp-not-going"
+		class="ticket_form_label ticket_form_left"
+	>
+		Can&#039;t Go:	</label>
+	<input
+		type="checkbox"
+		id="tribe-tickets-rsvp-not-going"
+		name="tribe-ticket[not_going]"
+		class="ticket_field tribe-rsvp-field-not-going ticket_form_right"
+		value="yes"
+			/>
+	<span class="tribe_soft_note ticket_form_right">Enable &quot;Can&#039;t Go&quot; responses</span>
+</div>
+			</section>
+			<div class="accordion">
+				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+	<button class="accordion-header tribe_advanced_meta">
+		Advanced	</button>
+	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
+		<h4 class="accordion-label screen_reader_text">Advanced Settings</h4>
+		<div id="advanced_fields">
+			<div id="Tribe__Tickets__Commerce__PayPal__Main_advanced" class="tribe-dependent" data-depends="#Tribe__Tickets__Commerce__PayPal__Main_radio" data-condition-is-checked></div><div id="TECTicketsCommerceEditorMetabox_advanced" class="tribe-dependent" data-depends="#provider_TEC_Tickets_Commerce_Module_radio" data-condition-is-checked></div>		</div>
+	</section><!-- #ticket_form_advanced -->
+</div>
+			</div>
+
+						<div class="ticket_bottom">
+				<input
+						type="hidden"
+						name="ticket_id"
+						id="ticket_id"
+						class="ticket_field"
+						value=""
+				/>
+				<input
+						type="button"
+						id="ticket_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save ticket"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-not-checked
+				/>
+				<input
+						type="button"
+						id="rsvp_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save RSVP"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-checked
+				/>
+				<input
+						type="button"
+						id="ticket_form_cancel"
+						class="button-secondary"
+						name="ticket_form_cancel"
+						value="Cancel"
+				/>
+
+				
+				<div id="ticket_bottom_right">
+									</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__event__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__event__0.snapshot.html
@@ -1,0 +1,404 @@
+<div
+	id="tribe_panel_base"
+	class="ticket_panel panel_base"
+	aria-hidden="false"
+	data-save-prompt="You have unsaved changes to your tickets. Discard those changes?"
+>
+	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
+		<div class="ticket_table_intro">
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="No commerce providers available"
+" disabled='disabled' disabled='disabled'"
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
+					</div>
+
+		<div class="ticket_table_intro__warnings">
+					<div  class="ticket-editor-notice info provider-warning" 								>
+			<span class="message">There is no payment gateway configured. To create tickets, you'll need to enable and configure an ecommerce solution. <a href="https://evnt.is/1ao5" target="_blank" rel="noopener noreferrer">Learn More</a></span>
+		</div>
+				</div>
+
+			</div>
+	<div class="tribe-ticket-control-wrap">
+		<div class="tribe-ticket-control-wrap__ctas">
+					</div>
+
+		<div class="tribe-ticket-control-wrap__settings">
+			
+					</div>
+	</div>
+		<div class="tec_ticket-panel__helper_text__wrap">
+		<p>
+		Create and manage single tickets and RSVPs for this event. <a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>.		</p>
+	</div>
+		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
+</div>
+<div id="tribe_panel_settings" class="ticket_panel panel_settings" aria-hidden="true" >
+	<h4>Ticket Settings	</h4>
+
+	<section class="settings_main">
+		
+	<fieldset class="screen-reader-text">
+								</fieldset>
+	</section>
+
+	<section id="tribe-tickets-image">
+	<div class="tribe-tickets-image-upload">
+		<div class="input_block">
+				<span class="ticket_form_label tribe-strong-label">Ticket header image:				</span>
+			<p class="description">
+				Select an image from your Media Library to display on emailed ticket. For best results, use a .jpg, .png, or .gif at least 1160px wide.			</p>
+		</div>
+		<input
+			type="button"
+			class="button"
+			name="tribe-tickets[settings][header_image]"
+			id="tribe_ticket_header_image"
+			value="Select an Image"
+		/>
+
+		<span id="tribe_tickets_image_preview_filename" class="">
+				<span class="dashicons dashicons-format-image"></span>
+				<span class="filename"></span>
+			</span>
+	</div>
+	<div class="tribe-tickets-image-preview">
+		<a class="tribe_preview" id="tribe_ticket_header_preview">
+					</a>
+		<p class="description">
+			<a href="#" id="tribe_ticket_header_remove">Remove</a>
+		</p>
+
+		<input
+			type="hidden"
+			id="tribe_ticket_header_image_id"
+			class="settings_field"
+			name="tribe-tickets[settings][header_image_id]"
+			value=""
+		/>
+	</div>
+</section>
+
+	<input type="button" id="tribe_settings_form_save" name="tribe_settings_form_save" value="Save settings" class="button-primary" />
+	<input type="button" id="tribe_settings_form_cancel" name="tribe_settings_form_cancel" value="Cancel" class="button-secondary" />
+</div>
+
+<div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
+	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
+     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+>
+	
+	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
+		<div id="ticket_form_table" class="eventtable ticket_form">
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-not-checked
+			>
+				<h4
+						id="ticket_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new ticket				</h4>
+				<h4
+						id="ticket_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit ticket				</h4>
+			</div>
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-checked
+			>
+				<h4
+						id="rsvp_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new RSVP				</h4>
+				<h4
+						id="rsvp_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit RSVP				</h4>
+			</div>
+			<section id="ticket_form_main" class="main"
+					 data-datepicker_format="1">
+
+				
+				<input
+					type='hidden'
+					id='ticket_type'
+					name='ticket_type'
+					value="default"
+				/>
+
+				<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_name">
+		Name:	</label>
+	<input
+		type='text'
+		id='ticket_name'
+		name='ticket_name'
+		class="ticket_field ticket_form_right"
+		size='25'
+		value=""
+		data-validation-is-required
+		data-validation-error="RSVP type is a required field"
+	/>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-not-checked
+	>
+	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-is-checked
+	>
+	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
+</div>
+
+				
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_description">
+		Description:	</label>
+	<textarea
+		rows="5"
+		cols="40"
+		name="ticket_description"
+		class="ticket_field ticket_form_right"
+		id="ticket_description"
+	></textarea>
+	<div class="input_block">
+		<label class="tribe_soft_note">
+			<input
+				type="checkbox"
+				id="tribe_tickets_show_description"
+				name="ticket_show_description"
+				value="1"
+				class="ticket_field ticket_form_left"
+				 checked='checked'			>
+			Show description on frontend ticket form.		</label>
+	</div>
+</div>
+
+				
+<div id="ticket_type_options" class="input_block">
+	<label class="ticket_form_label ticket_form_left" id="ticket_type_label" for="ticket_type">
+		Type:	</label>
+
+	<div class="ticket_form_right ticket_form_right--flex">
+		<img
+			class="tribe-tickets-svgicon tec-tickets-icon tec-tickets-icon__ticket-type"
+			src="http://wordpress.test/wp-content/plugins/event-tickets/src/resources/icons/ticket-default-icon.svg"
+			alt="Ticket"
+		/>
+		<span class="ticket-type__text ticket-type__text--default">
+		Single Ticket		</span>
+	</div>
+
+	<span class="tribe_soft_note ticket_form_right tribe-active">
+		A single ticket is specific to this event.	</span>
+</div>
+<div class="tec_tickets_editor__header__ticket-type-upsell-notice">
+	<img class="tec_tickets_editor__header__ticket-type-upsell-icon" src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/circle-bolt.svg" alt="upsell-icon">
+	<span>
+		For more ticket types, <a href="https://evnt.is/tt-ecp" target="_blank" rel="noopener noreferrer">upgrade</a> to Events Calendar Pro.	</span>
+</div><div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+		Start sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-start_date ticket_field"
+			name="ticket_start_date"
+			id="ticket_start_date"
+			value=""
+			data-validation-type="datepicker"
+			data-validation-is-less-or-equal-to="#ticket_end_date"
+			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-start_time ticket_field"
+			name="ticket_start_time"
+			id="ticket_start_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket start date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
+	</div>
+</div>
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+		End sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-end_date ticket_field"
+			name="ticket_end_date"
+			id="ticket_end_date"
+			value=""
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-end_time ticket_field"
+			name="ticket_end_time"
+			id="ticket_end_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket end date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
+	</div>
+</div>
+
+				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
+					<legend class="ticket_form_label">Sell using:</legend>
+									</fieldset>
+				<div
+	class="price tribe-dependent"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-not-checked
+	>
+	<div class="input_block">
+		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
+		<input
+			type="text"
+			id="ticket_price"
+			name="ticket_price"
+			class="ticket_field ticket_form_right"
+			size="7"
+			value=""
+						data-validation-error="Ticket price must be greater than zero."		/>
+					<p class="description ticket_form_right">
+				Leave blank for free Ticket			</p>
+				</div>
+
+	</div><div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="Tribe__Tickets__RSVP_capacity"
+		class="ticket_form_label ticket_form_left"
+	>
+		Capacity:	</label>
+	<input
+		type='text' id='Tribe__Tickets__RSVP_capacity'
+		name='tribe-ticket[capacity]'
+		class="ticket_field tribe-rsvp-field-capacity ticket_form_right"
+		size='7'
+		value=''
+	/>
+	<span class="tribe_soft_note ticket_form_right">Leave blank for unlimited</span>
+</div>
+
+<div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="tribe-tickets-rsvp-not-going"
+		class="ticket_form_label ticket_form_left"
+	>
+		Can&#039;t Go:	</label>
+	<input
+		type="checkbox"
+		id="tribe-tickets-rsvp-not-going"
+		name="tribe-ticket[not_going]"
+		class="ticket_field tribe-rsvp-field-not-going ticket_form_right"
+		value="yes"
+			/>
+	<span class="tribe_soft_note ticket_form_right">Enable &quot;Can&#039;t Go&quot; responses</span>
+</div>
+			</section>
+			<div class="accordion">
+				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+	<button class="accordion-header tribe_advanced_meta">
+		Advanced	</button>
+	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
+		<h4 class="accordion-label screen_reader_text">Advanced Settings</h4>
+		<div id="advanced_fields">
+			<div id="Tribe__Tickets__Commerce__PayPal__Main_advanced" class="tribe-dependent" data-depends="#Tribe__Tickets__Commerce__PayPal__Main_radio" data-condition-is-checked></div><div id="TECTicketsCommerceEditorMetabox_advanced" class="tribe-dependent" data-depends="#provider_TEC_Tickets_Commerce_Module_radio" data-condition-is-checked></div>		</div>
+	</section><!-- #ticket_form_advanced -->
+</div>
+			</div>
+
+						<div class="ticket_bottom">
+				<input
+						type="hidden"
+						name="ticket_id"
+						id="ticket_id"
+						class="ticket_field"
+						value=""
+				/>
+				<input
+						type="button"
+						id="ticket_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save ticket"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-not-checked
+				/>
+				<input
+						type="button"
+						id="rsvp_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save RSVP"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-checked
+				/>
+				<input
+						type="button"
+						id="ticket_form_cancel"
+						class="button-secondary"
+						name="ticket_form_cancel"
+						value="Cancel"
+				/>
+
+				
+				<div id="ticket_bottom_right">
+									</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__post__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__post__0.snapshot.html
@@ -1,0 +1,404 @@
+<div
+	id="tribe_panel_base"
+	class="ticket_panel panel_base"
+	aria-hidden="false"
+	data-save-prompt="You have unsaved changes to your tickets. Discard those changes?"
+>
+	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
+		<div class="ticket_table_intro">
+			<button
+	id="ticket_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="No commerce providers available"
+" disabled='disabled' disabled='disabled'"
+>
+New ticket</button><button
+	id="rsvp_form_toggle"
+	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
+	aria-label="Add a new RSVP"
+>
+	New RSVP</button>
+<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
+    Settings</button>
+
+					</div>
+
+		<div class="ticket_table_intro__warnings">
+					<div  class="ticket-editor-notice info provider-warning" 								>
+			<span class="message">There is no payment gateway configured. To create tickets, you'll need to enable and configure an ecommerce solution. <a href="https://evnt.is/1ao5" target="_blank" rel="noopener noreferrer">Learn More</a></span>
+		</div>
+				</div>
+
+			</div>
+	<div class="tribe-ticket-control-wrap">
+		<div class="tribe-ticket-control-wrap__ctas">
+					</div>
+
+		<div class="tribe-ticket-control-wrap__settings">
+			
+					</div>
+	</div>
+		<div class="tec_ticket-panel__helper_text__wrap">
+		<p>
+		Create and manage single tickets and RSVPs for this post. <a href="https://evnt.is/manage-tickets" target="_blank" rel="noopener noreferrer ">Learn more about ticket management</a>.		</p>
+	</div>
+		<p class="tec_ticket-panel__recurring-unsupported-warning" style="display: none">Single tickets and RSVPs are not yet supported on recurring events. <a href="https://evnt.is/1b7a" target="_blank" rel="noopener noreferrer"> Read about our plans for future features </a><p>
+</div>
+<div id="tribe_panel_settings" class="ticket_panel panel_settings" aria-hidden="true" >
+	<h4>Ticket Settings	</h4>
+
+	<section class="settings_main">
+		
+	<fieldset class="screen-reader-text">
+								</fieldset>
+	</section>
+
+	<section id="tribe-tickets-image">
+	<div class="tribe-tickets-image-upload">
+		<div class="input_block">
+				<span class="ticket_form_label tribe-strong-label">Ticket header image:				</span>
+			<p class="description">
+				Select an image from your Media Library to display on emailed ticket. For best results, use a .jpg, .png, or .gif at least 1160px wide.			</p>
+		</div>
+		<input
+			type="button"
+			class="button"
+			name="tribe-tickets[settings][header_image]"
+			id="tribe_ticket_header_image"
+			value="Select an Image"
+		/>
+
+		<span id="tribe_tickets_image_preview_filename" class="">
+				<span class="dashicons dashicons-format-image"></span>
+				<span class="filename"></span>
+			</span>
+	</div>
+	<div class="tribe-tickets-image-preview">
+		<a class="tribe_preview" id="tribe_ticket_header_preview">
+					</a>
+		<p class="description">
+			<a href="#" id="tribe_ticket_header_remove">Remove</a>
+		</p>
+
+		<input
+			type="hidden"
+			id="tribe_ticket_header_image_id"
+			class="settings_field"
+			name="tribe-tickets[settings][header_image_id]"
+			value=""
+		/>
+	</div>
+</section>
+
+	<input type="button" id="tribe_settings_form_save" name="tribe_settings_form_save" value="Save settings" class="button-primary" />
+	<input type="button" id="tribe_settings_form_cancel" name="tribe_settings_form_cancel" value="Cancel" class="button-secondary" />
+</div>
+
+<div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
+	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
+     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+>
+	
+	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
+		<div id="ticket_form_table" class="eventtable ticket_form">
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-not-checked
+			>
+				<h4
+						id="ticket_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new ticket				</h4>
+				<h4
+						id="ticket_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit ticket				</h4>
+			</div>
+			<div
+					class="tribe-dependent"
+					data-depends="#Tribe__Tickets__RSVP_radio"
+					data-condition-is-checked
+			>
+				<h4
+						id="rsvp_title_add"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-empty
+				>
+					Add new RSVP				</h4>
+				<h4
+						id="rsvp_title_edit"
+						class="ticket_form_title tribe-dependent"
+						data-depends="#ticket_id"
+						data-condition-is-not-empty
+				>
+					Edit RSVP				</h4>
+			</div>
+			<section id="ticket_form_main" class="main"
+					 data-datepicker_format="1">
+
+				
+				<input
+					type='hidden'
+					id='ticket_type'
+					name='ticket_type'
+					value="default"
+				/>
+
+				<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_name">
+		Name:	</label>
+	<input
+		type='text'
+		id='ticket_name'
+		name='ticket_name'
+		class="ticket_field ticket_form_right"
+		size='25'
+		value=""
+		data-validation-is-required
+		data-validation-error="RSVP type is a required field"
+	/>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-not-checked
+	>
+	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
+	<span
+		class="tribe_soft_note ticket_form_right"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+		data-condition-is-checked
+	>
+	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
+</div>
+
+				
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_description">
+		Description:	</label>
+	<textarea
+		rows="5"
+		cols="40"
+		name="ticket_description"
+		class="ticket_field ticket_form_right"
+		id="ticket_description"
+	></textarea>
+	<div class="input_block">
+		<label class="tribe_soft_note">
+			<input
+				type="checkbox"
+				id="tribe_tickets_show_description"
+				name="ticket_show_description"
+				value="1"
+				class="ticket_field ticket_form_left"
+				 checked='checked'			>
+			Show description on frontend ticket form.		</label>
+	</div>
+</div>
+
+				
+<div id="ticket_type_options" class="input_block">
+	<label class="ticket_form_label ticket_form_left" id="ticket_type_label" for="ticket_type">
+		Type:	</label>
+
+	<div class="ticket_form_right ticket_form_right--flex">
+		<img
+			class="tribe-tickets-svgicon tec-tickets-icon tec-tickets-icon__ticket-type"
+			src="http://wordpress.test/wp-content/plugins/event-tickets/src/resources/icons/ticket-default-icon.svg"
+			alt="Ticket"
+		/>
+		<span class="ticket-type__text ticket-type__text--default">
+		Single Ticket		</span>
+	</div>
+
+	<span class="tribe_soft_note ticket_form_right tribe-active">
+		A single ticket is specific to this post.	</span>
+</div>
+<div class="tec_tickets_editor__header__ticket-type-upsell-notice">
+	<img class="tec_tickets_editor__header__ticket-type-upsell-icon" src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/circle-bolt.svg" alt="upsell-icon">
+	<span>
+		For more ticket types, <a href="https://evnt.is/tt-ecp" target="_blank" rel="noopener noreferrer">upgrade</a> to Events Calendar Pro.	</span>
+</div><div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+		Start sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-start_date ticket_field"
+			name="ticket_start_date"
+			id="ticket_start_date"
+			value=""
+			data-validation-type="datepicker"
+			data-validation-is-less-or-equal-to="#ticket_end_date"
+			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-start_time ticket_field"
+			name="ticket_start_time"
+			id="ticket_start_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket start date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
+	</div>
+</div>
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+		End sale:	</label>
+	<div class="ticket_form_right">
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-datepicker tribe-field-end_date ticket_field"
+			name="ticket_end_date"
+			id="ticket_end_date"
+			value=""
+		/>
+		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+		<span class="datetime_seperator"> at </span>
+		<input
+			autocomplete="off"
+			type="text"
+			class="tribe-timepicker tribe-field-end_time ticket_field"
+			name="ticket_end_time"
+			id="ticket_end_time"
+						data-step="30"
+			data-round="00:00:00"
+			value=""
+			aria-label="Ticket end date"
+		/>
+		<span class="helper-text hide-if-js">HH:MM</span>
+		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
+	</div>
+</div>
+
+				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
+					<legend class="ticket_form_label">Sell using:</legend>
+									</fieldset>
+				<div
+	class="price tribe-dependent"
+		data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-not-checked
+	>
+	<div class="input_block">
+		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
+		<input
+			type="text"
+			id="ticket_price"
+			name="ticket_price"
+			class="ticket_field ticket_form_right"
+			size="7"
+			value=""
+						data-validation-error="Ticket price must be greater than zero."		/>
+					<p class="description ticket_form_right">
+				Leave blank for free Ticket			</p>
+				</div>
+
+	</div><div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="Tribe__Tickets__RSVP_capacity"
+		class="ticket_form_label ticket_form_left"
+	>
+		Capacity:	</label>
+	<input
+		type='text' id='Tribe__Tickets__RSVP_capacity'
+		name='tribe-ticket[capacity]'
+		class="ticket_field tribe-rsvp-field-capacity ticket_form_right"
+		size='7'
+		value=''
+	/>
+	<span class="tribe_soft_note ticket_form_right">Leave blank for unlimited</span>
+</div>
+
+<div
+	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
+	data-depends="#Tribe__Tickets__RSVP_radio"
+	data-condition-is-checked
+>
+	<label
+		for="tribe-tickets-rsvp-not-going"
+		class="ticket_form_label ticket_form_left"
+	>
+		Can&#039;t Go:	</label>
+	<input
+		type="checkbox"
+		id="tribe-tickets-rsvp-not-going"
+		name="tribe-ticket[not_going]"
+		class="ticket_field tribe-rsvp-field-not-going ticket_form_right"
+		value="yes"
+			/>
+	<span class="tribe_soft_note ticket_form_right">Enable &quot;Can&#039;t Go&quot; responses</span>
+</div>
+			</section>
+			<div class="accordion">
+				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+	<button class="accordion-header tribe_advanced_meta">
+		Advanced	</button>
+	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
+		<h4 class="accordion-label screen_reader_text">Advanced Settings</h4>
+		<div id="advanced_fields">
+			<div id="Tribe__Tickets__Commerce__PayPal__Main_advanced" class="tribe-dependent" data-depends="#Tribe__Tickets__Commerce__PayPal__Main_radio" data-condition-is-checked></div><div id="TECTicketsCommerceEditorMetabox_advanced" class="tribe-dependent" data-depends="#provider_TEC_Tickets_Commerce_Module_radio" data-condition-is-checked></div>		</div>
+	</section><!-- #ticket_form_advanced -->
+</div>
+			</div>
+
+						<div class="ticket_bottom">
+				<input
+						type="hidden"
+						name="ticket_id"
+						id="ticket_id"
+						class="ticket_field"
+						value=""
+				/>
+				<input
+						type="button"
+						id="ticket_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save ticket"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-not-checked
+				/>
+				<input
+						type="button"
+						id="rsvp_form_save"
+						class="button-primary tribe-dependent tribe-validation-submit"
+						name="ticket_form_save"
+						value="Save RSVP"
+						data-depends="#Tribe__Tickets__RSVP_radio"
+						data-condition-is-checked
+				/>
+				<input
+						type="button"
+						id="ticket_form_cancel"
+						class="button-secondary"
+						name="ticket_form_cancel"
+						value="Cancel"
+				/>
+
+				
+				<div id="ticket_bottom_right">
+									</div>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This PR fixes an issue related to an improper case class name, the `Tribe__Tickets__RSVP` one types all in lowercase (`tribe__tickets__rsvp`) and causing the `New Ticket` button to appear when no gateways are configured.

Artifacts:
* [Demo](https://share.cleanshot.com/yH7JJMNY)
* tests
