### PR TITLE
[ET-1988] Wrong Attendee Name Being Used with Multiple Attendees

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -207,6 +207,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Update usage of `method_exists()` to comply with PHP 8.1 standards. [ET-1759]
 * Fix - Update button will now show when the opt-out checkbox shows on the My Tickets page. [ET-1980]
 * Tweak - Customer name appears now as description of a Stripe payment. Added `tec_tickets_commerce_stripe_update_payment_description` filter. [ET-1607]
+* Fix - Ensure correct attendee information is included in the attendee emails. [ET-1988]
 
 = [5.7.1] 2023-12-13 =
 

--- a/src/Tickets/Emails/Email_Abstract.php
+++ b/src/Tickets/Emails/Email_Abstract.php
@@ -289,8 +289,8 @@ abstract class Email_Abstract {
 	 */
 	public function set_placeholders( array $placeholders = [] ): array {
 		$this->placeholders = array_merge(
-			$placeholders,
-			$this->get_placeholders()
+			$this->get_placeholders(),
+			$placeholders
 		);
 
 		return $this->placeholders;

--- a/src/Tickets/Emails/Provider.php
+++ b/src/Tickets/Emails/Provider.php
@@ -33,6 +33,14 @@ class Provider extends Service_Provider {
 		// Dispatcher is not a singleton!
 		$this->container->bind( Dispatcher::class, Dispatcher::class );
 
+		// Emails are not singletons!
+		$this->container->bind( Email\Completed_Order::class, Email\Completed_Order::class );
+		$this->container->bind( Email\Purchase_Receipt::class, Email\Purchase_Receipt::class );
+		$this->container->bind( Email\RSVP_Not_Going::class, Email\RSVP_Not_Going::class );
+		$this->container->bind( Email\RSVP::class, Email\RSVP::class );
+		$this->container->bind( Email\Completed_Order::class, Email\Completed_Order::class );
+		$this->container->bind( Email\Ticket::class, Email\Ticket::class );
+
 		$this->container->singleton( Legacy_Hijack::class );
 
 		$this->container->singleton( Admin\Emails_Tab::class );


### PR DESCRIPTION
### 🎫 Ticket

[ET-1988] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->
It was found that when purchasing more than one ticket in an order and IAC is enabled, the wrong attendee name is being sent out to subsequent attendees (after the first one).

This PR ensures that each email class will not be used as a singleton and that newly assigned placeholders are merged into existing placeholder (not the other way around).

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Order:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/fd897590-87ad-4fdc-a92b-c81488a69290)

Before (email to 2nd attendee):
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/6c1aedc6-3933-4658-ad48-5bd1a7ac8f00)

After (email to 2nd attendee):
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/1257d71c-ee04-4a4b-a9a4-93668415b32e)


### ✔️ Checklist
- [x] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [x] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1988]: https://stellarwp.atlassian.net/browse/ET-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ