### PR TITLE
fix(Blocks/RSVP) do not show RSVP block on Recurring Events

### DIFF
--- a/src/Tickets/Commerce/Custom_Tables/V1/Provider.php
+++ b/src/Tickets/Commerce/Custom_Tables/V1/Provider.php
@@ -83,7 +83,7 @@ class Provider extends Controller {
 	 * @param string $admin_body_classes A space-separated list of classes.
 	 *
 	 * @return string A space-separated list of classes, updated to include the
-	 *                `tec-no-tickets-on-recurring` class.
+	 *                `tec-no-tickets-on-recurring` and `tec-no-rsvp-on-recurring` classes.
 	 */
 	public function prevent_tickets_on_recurring_events( ?string $admin_body_classes ): string {
 		$state = $this->container->make( State::class );
@@ -91,6 +91,8 @@ class Provider extends Controller {
 		if ( ! $state->is_migrated() ) {
 			return $admin_body_classes;
 		}
+
+		$classes = [];
 
 		/**
 		 * Filters whether tickets are allowed on recurring events or not.
@@ -102,15 +104,25 @@ class Provider extends Controller {
 		 */
 		$allow_tickets_on_recurring = apply_filters( 'tec_tickets_allow_tickets_on_recurring_events', false );
 
-		if ( $allow_tickets_on_recurring ) {
-			return $admin_body_classes;
+		if ( ! $allow_tickets_on_recurring ) {
+			$classes[] = 'tec-no-tickets-on-recurring';
 		}
 
-		$classes = array_unique(
-			array_merge(
-				Arr::list_to_array( $admin_body_classes ), [ 'tec-no-tickets-on-recurring' ]
-			)
-		);
+		/**
+		 * Filters whether RSVPs are allowed on recurring events or not.
+		 * By default, RSVPs are not allowed on Recurring Events.
+		 *
+		 * @since  5.8.0
+		 *
+		 * @params bool $allow_rsvps_on_recurring Whether RSVPs are allowed on recurring events or not.
+		 */
+		$allow_rsvp_on_recurring = apply_filters( 'tec_tickets_allow_rsvp_on_recurring_events', false );
+
+		if ( ! $allow_rsvp_on_recurring ) {
+			$classes[] = 'tec-no-rsvp-on-recurring';
+		}
+
+		$classes = array_unique( array_merge( Arr::list_to_array( $admin_body_classes ), $classes ) );
 
 		return implode( ' ', $classes );
 	}

--- a/src/modules/blocks/rsvp/container.js
+++ b/src/modules/blocks/rsvp/container.js
@@ -26,7 +26,7 @@ import {
 import { withStore } from '@moderntribe/common/hoc';
 import withSaveData from '@moderntribe/tickets/blocks/hoc/with-save-data';
 import { moment as momentUtil, time } from '@moderntribe/common/utils';
-import { hasRecurrenceRules, noTicketsOnRecurring } from '@moderntribe/common/utils/recurrence';
+import { hasRecurrenceRules, noRsvpsOnRecurring } from '@moderntribe/common/utils/recurrence';
 
 const getIsInactive = ( state ) => {
 	const startDateMoment = selectors.getRSVPStartDateMoment( state );
@@ -79,7 +79,7 @@ const mapStateToProps = ( state ) => {
 		isModalShowing: isModalShowing( state ) && getModalTicketId( state ) === rsvpId,
 		isSettingsOpen: selectors.getRSVPSettingsOpen( state ),
 		hasRecurrenceRules: hasRecurrenceRules( state ),
-		noTicketsOnRecurring: noTicketsOnRecurring(),
+		noRsvpsOnRecurring: noRsvpsOnRecurring(),
 		rsvpId,
 	};
 };

--- a/src/modules/blocks/rsvp/template.js
+++ b/src/modules/blocks/rsvp/template.js
@@ -33,7 +33,7 @@ const RSVP = ( {
 	isModalShowing,
 	isSelected,
 	isSettingsOpen,
-	noTicketsOnRecurring,
+	noRsvpsOnRecurring,
 	rsvpId,
 	setAddEditClosed,
 } ) => {
@@ -115,7 +115,7 @@ const RSVP = ( {
 		);
 	};
 
-	if ( hasRecurrenceRules && noTicketsOnRecurring ) {
+	if ( hasRecurrenceRules && noRsvpsOnRecurring ) {
 		return renderBlockNotSupported();
 	}
 
@@ -133,7 +133,7 @@ RSVP.propTypes = {
 	isModalShowing: PropTypes.bool.isRequired,
 	isSelected: PropTypes.bool.isRequired,
 	isSettingsOpen: PropTypes.bool.isRequired,
-	noTicketsOnRecurring: PropTypes.bool.isRequired,
+	noRsvpsOnRecurring: PropTypes.bool.isRequired,
 	rsvpId: PropTypes.number.isRequired,
 	setAddEditClosed: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Based on [Common PR](https://github.com/the-events-calendar/tribe-common/pull/2047)

[Demo](https://share.cleanshot.com/wbc04ntc)

This PR diversifies the block imposed on Recurring Events not to have tickets to more finely control Tickets and RSVPs.
By default, as was the case before, RSVPs and Tickets will **not** show on recurring events, but now the option for each type is filterable.
