### PR TITLE
[ET-1993] Fixed incorrect redirect on updating tickets data from My tickets page.

### DIFF
--- a/src/Tickets/Flexible_Tickets/Series_Passes/Series_Passes.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Series_Passes.php
@@ -1160,9 +1160,9 @@ class Series_Passes extends Controller {
 	 *
 	 * @since TBD Filter my tickets rewrite rules to include the series page.
 	 *
-	 * @param array $rules Rewrite rules array.
+	 * @param array<string> $rules Rewrite rules array.
 	 *
-	 * @return array The updated rewrite rules array.
+	 * @return array<string> The updated rewrite rules array.
 	 */
 	public function include_rewrite_rules_for_series_my_tickets_page( array $rules ): array {
 		$post_type = get_post_type_object( Series_Post_Type::POSTTYPE );

--- a/src/Tickets/Flexible_Tickets/Series_Passes/Series_Passes.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Series_Passes.php
@@ -277,7 +277,7 @@ class Series_Passes extends Controller {
 		);
 		add_filter( 'tec_tickets_is_ticket_editable_from_post', [ $this, 'is_ticket_editable_from_post' ], 10, 3 );
 		add_filter( 'tec_tickets_my_tickets_link_ticket_count_by_type', [ $this, 'filter_my_tickets_link_data' ], 10, 3 );
-		add_action( 'generate_rewrite_rules', [ $this, 'include_rewrite_rules_for_series_my_tickets_page' ] );
+		add_filter( 'tec_tickets_my_tickets_page_rewrite_rules', [ $this, 'include_rewrite_rules_for_series_my_tickets_page' ] );
 
 		/**
 		 * The FT feature will only be available if the CT1 feature is active: this implies Recurring Events
@@ -394,7 +394,7 @@ class Series_Passes extends Controller {
 		remove_filter( 'tec_tickets_is_ticket_editable_from_post', [ $this, 'is_ticket_editable_from_post' ] );
 		remove_filter( 'tec_tickets_my_tickets_link_ticket_count_by_type', [ $this, 'filter_my_tickets_link_data' ], 10, 3 );
 		remove_filter( 'tec_tickets_allow_tickets_on_recurring_events', [ $this, 'allow_tickets_on_recurring_events' ] );
-		remove_action( 'generate_rewrite_rules', [ $this, 'include_rewrite_rules_for_series_my_tickets_page' ] );
+		remove_filter( 'tec_tickets_my_tickets_page_rewrite_rules', [ $this, 'include_rewrite_rules_for_series_my_tickets_page' ] );
 		
 		remove_filter( 'tribe_template_context:tickets/admin-views/editor/recurring-warning', [ $this, 'filter_recurring_warning_message' ], 10, 4 );
 		remove_filter( 'tec_tickets_commerce_provider_missing_warning_message', [ $this, 'filter_no_commerce_provider_warning_message' ] );
@@ -1158,19 +1158,21 @@ class Series_Passes extends Controller {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param WP_Rewrite $wp_rewrite Current WP_Rewrite instance (passed by reference).
+	 * @since TBD Filter my tickets rewrite rules to include the series page.
 	 *
-	 * @return void
+	 * @param array $rules Rewrite rules array.
+	 *
+	 * @return array The updated rewrite rules array.
 	 */
-	public function include_rewrite_rules_for_series_my_tickets_page( WP_Rewrite $wp_rewrite ): void {
+	public function include_rewrite_rules_for_series_my_tickets_page( array $rules ): array {
 		$post_type = get_post_type_object( Series_Post_Type::POSTTYPE );
 		$slug      = $post_type->rewrite['slug'];
 
-		$rules = [
+		$series_rules = [
 			'(?:' . $slug . ')/([^/]+)/(?:tickets)/?$' => 'index.php?' . $post_type->name . '=$matches[1]&post_type=' . $post_type->name . '&eventDisplay=tickets',
 		];
 
-		$wp_rewrite->rules = $rules + $wp_rewrite->rules;
+		return array_merge( $rules, $series_rules );
 	}
 	
 	/**

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -63,7 +63,7 @@ class Tribe__Tickets__Tickets_View {
 	public function prevent_page_redirect( $query ) {
 		$is_correct_page = isset( $query->query_vars['tribe-edit-orders'] ) && $query->query_vars['tribe-edit-orders'];
 
-		if ( ! $is_correct_page ) {
+		if ( ! $is_correct_page || ! $this->is_edit_page() ) {
 			return;
 		}
 
@@ -113,6 +113,8 @@ class Tribe__Tickets__Tickets_View {
 	/**
 	 * Gets the List of Rewrite rules we are using here.
 	 *
+	 * @since TBD Added filter to allow users to add additional rewrite rules for the My Tickets page.
+	 *
 	 * @return array
 	 */
 	public function rewrite_rules_array() {
@@ -121,8 +123,13 @@ class Tribe__Tickets__Tickets_View {
 		$rules = [
 			sanitize_title_with_dashes( $bases['tickets'][0] ) . '/([0-9]{1,})/?' => 'index.php?p=$matches[1]&tribe-edit-orders=1',
 		];
-
-		return $rules;
+		
+		/**
+		 * Filter the rewrite rules for the My Tickets page.
+		 *
+		 * @param array $rules The rewrite rules for the My Tickets page.
+		 */
+		return apply_filters( 'tec_tickets_my_tickets_page_rewrite_rules', $rules );
 	}
 
 	/**

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -224,9 +224,8 @@ class Tribe__Tickets__Tickets_View {
 
 		// After editing the values, we update the transient.
 		Tribe__Post_Transient::instance()->delete( $post_id, Tribe__Tickets__Tickets::ATTENDEES_CACHE );
-
-		// If it's not events CPT
-		$url = $this->get_tickets_page_url( $post_id, ! $is_correct_page );
+  
+		$url = $this->get_tickets_page_url( $post_id );
 		$url = add_query_arg( 'tribe_updated', 1, $url );
 		wp_safe_redirect( esc_url_raw( $url ) );
 		exit;
@@ -1365,7 +1364,6 @@ class Tribe__Tickets__Tickets_View {
 	public function get_my_tickets_link_data( int $event_id, int $user_id ): array {
 		$event              = get_post( $event_id );
 		$post_type          = get_post_type_object( $event->post_type );
-		$is_event_page      = class_exists( 'Tribe__Events__Main' ) && ( Tribe__Events__Main::POSTTYPE === $event->post_type || 'tribe_event_series' === $event->post_type );
 		$post_type_singular = $post_type ? $post_type->labels->singular_name : _x( 'Post', 'fallback post type singular name', 'event-tickets' );
 		$counters           = [];
 		$rsvp_count         = $this->count_rsvp_attendees( $event_id, $user_id );
@@ -1429,7 +1427,7 @@ class Tribe__Tickets__Tickets_View {
 			'total_count' => $total_count,
 			'message'     => $message,
 			'link_label'  => $link_label,
-			'link'        => $this->get_tickets_page_url( $event_id, $is_event_page ),
+			'link'        => $this->get_tickets_page_url( $event_id ),
 		];
 	}
 }

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -248,7 +248,7 @@ class Tribe__Tickets__Tickets_View {
 		
 		if ( is_null( $is_event_page ) ) {
 			$post_type     = get_post_type( $event_id );
-			$is_event_page = 'tribe_events' === $post_type || 'tribe_events_series' === $post_type;
+			$is_event_page = 'tribe_events' === $post_type || 'tribe_event_series' === $post_type;
 		}
 		
 		// Is on the Event post type.

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -254,6 +254,10 @@ class Tribe__Tickets__Tickets_View {
 		$has_plain_permalink = '' === get_option( 'permalink_structure' );
 		$event_url           = get_permalink( $event_id );
 		
+		if ( empty( $event_url ) ) {
+			return '';
+		}
+		
 		$post_type     = get_post_type( $event_id );
 		$is_event_page = 'tribe_events' === $post_type || 'tribe_event_series' === $post_type;
 		

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -165,6 +165,8 @@ class Tribe__Tickets__Tickets_View {
 
 	/**
 	 * Update the RSVP and Tickets values for each Attendee.
+	 *
+	 * @since TBD Removed optional param from get_tickets_page_url call.
 	 */
 	public function update_tickets() {
 		$is_correct_page = $this->is_edit_page();
@@ -1355,6 +1357,7 @@ class Tribe__Tickets__Tickets_View {
 	 * Generate the required data for the "My Tickets" link.
 	 *
 	 * @since 5.8.0
+	 * @since TBD Removed the optional parameter from `get_tickets_page_url` call.
 	 *
 	 * @param int $event_id The event ID.
 	 * @param int $user_id The user ID.

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -236,17 +236,23 @@ class Tribe__Tickets__Tickets_View {
 	 * Helper function to generate the Link to the tickets page of an event.
 	 *
 	 * @since 4.7.1
+	 * @since TBD Updated method signature to make $is_event_page parameter optional.
 	 *
-	 * @param $event_id
-	 * @param $is_event_page
+	 * @param int  $event_id      The Event ID we're checking.
+	 * @param bool $is_event_page Optional. Whether the link is for an event post type or not.
 	 *
-	 * @return string|void
+	 * @return string      The URL to the tickets page.
 	 */
-	public function get_tickets_page_url( $event_id, $is_event_page ) {
+	public function get_tickets_page_url( int $event_id, bool $is_event_page = null ): string {
 		$has_plain_permalink = '' === get_option( 'permalink_structure' );
-		$event_url = get_permalink( $event_id );
-
-		// Is on the Event post type
+		$event_url           = get_permalink( $event_id );
+		
+		if ( is_null( $is_event_page ) ) {
+			$post_type     = get_post_type( $event_id );
+			$is_event_page = 'tribe_events' === $post_type || 'tribe_events_series' === $post_type;
+		}
+		
+		// Is on the Event post type.
 		if ( $is_event_page ) {
 			$link = $has_plain_permalink
 				? add_query_arg( 'eventDisplay', 'tickets', untrailingslashit( $event_url ) )

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -244,21 +244,18 @@ class Tribe__Tickets__Tickets_View {
 	 * Helper function to generate the Link to the tickets page of an event.
 	 *
 	 * @since 4.7.1
-	 * @since TBD Updated method signature to make $is_event_page parameter optional.
+	 * @since TBD Removed the $is_event_page param.
 	 *
-	 * @param int  $event_id      The Event ID we're checking.
-	 * @param bool $is_event_page Optional. Whether the link is for an event post type or not.
+	 * @param int $event_id event_id The Event ID we're checking.
 	 *
 	 * @return string      The URL to the tickets page.
 	 */
-	public function get_tickets_page_url( int $event_id, bool $is_event_page = null ): string {
+	public function get_tickets_page_url( int $event_id ): string {
 		$has_plain_permalink = '' === get_option( 'permalink_structure' );
 		$event_url           = get_permalink( $event_id );
 		
-		if ( is_null( $is_event_page ) ) {
-			$post_type     = get_post_type( $event_id );
-			$is_event_page = 'tribe_events' === $post_type || 'tribe_event_series' === $post_type;
-		}
+		$post_type     = get_post_type( $event_id );
+		$is_event_page = 'tribe_events' === $post_type || 'tribe_event_series' === $post_type;
 		
 		// Is on the Event post type.
 		if ( $is_event_page ) {

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -93,14 +93,14 @@ class Tribe__Tickets__Tickets_View {
 	 */
 	public function maybe_regenerate_rewrite_rules() {
 		// if they don't have any rewrite rules, do nothing
-		// Don't try to run stuff for non-logged users (too time consuming)
+		// Don't try to run stuff for non-logged users (too time consuming).
 		if ( ! is_array( $GLOBALS['wp_rewrite']->rules ) || ! is_user_logged_in() ) {
 			return;
 		}
 
 		$rules = $this->rewrite_rules_array();
 
-		$diff = array_diff( $rules, $GLOBALS['wp_rewrite']->rules );
+		$diff     = array_diff( $rules, $GLOBALS['wp_rewrite']->rules );
 		$key_diff = array_diff_assoc( $rules, $GLOBALS['wp_rewrite']->rules );
 
 		if ( empty( $diff ) && empty( $key_diff ) ) {
@@ -115,7 +115,7 @@ class Tribe__Tickets__Tickets_View {
 	 *
 	 * @since TBD Added filter to allow users to add additional rewrite rules for the My Tickets page.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function rewrite_rules_array() {
 		$bases = $this->add_rewrite_base_slug();
@@ -127,7 +127,7 @@ class Tribe__Tickets__Tickets_View {
 		/**
 		 * Filter the rewrite rules for the My Tickets page.
 		 *
-		 * @param array $rules The rewrite rules for the My Tickets page.
+		 * @param array<string> $rules The rewrite rules for the My Tickets page.
 		 */
 		return apply_filters( 'tec_tickets_my_tickets_page_rewrite_rules', $rules );
 	}

--- a/src/views/shortcodes/my-attendance-list.php
+++ b/src/views/shortcodes/my-attendance-list.php
@@ -9,6 +9,7 @@
  * @since   4.8.2
  * @since   4.12.3 Removed target="_blank" from links, added direct link to each post's "My Tickets" view,
  *          rename $event_id variable.
+ * @since TBD Removed optional param $is_event_page from the `get_tickets_page_url` call.
  *
  * @version 4.12.3
  *
@@ -21,8 +22,7 @@ $view = Tribe__Tickets__Tickets_View::instance();
 <ul class="tribe-tickets my-attendance-list">
 	<?php
 	foreach ( $event_ids as $event_id ) :
-		$is_event               = function_exists( 'tribe_is_event' ) ? tribe_is_event( $event_id ) : false;
-		$direct_link_my_tickets = $view->get_tickets_page_url( $event_id, $is_event );
+		$direct_link_my_tickets = $view->get_tickets_page_url( $event_id );
 		?>
 		<?php $start_date = tribe_get_start_date( $event_id ); ?>
 		<li class="event-<?php echo esc_attr( $event_id ); ?>">

--- a/tests/wpunit/Tribe/Tickets/Tickets_ViewTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets_ViewTest.php
@@ -40,6 +40,17 @@ class Tickets_ViewTest extends WPTestCase {
 	private function make_instance() {
 		return new Tickets_View();
 	}
+	
+	/**
+	 * Placeholder for post ids.
+	 */
+	public function placehold_post_ids( string $snapshot, array $ids ): string {
+		return str_replace(
+			array_values( $ids ),
+			array_map( static fn( string $name ) => "{{ $name }}", array_keys( $ids ) ),
+			$snapshot
+		);
+	}
 
 	/**
 	 * @test
@@ -291,6 +302,7 @@ class Tickets_ViewTest extends WPTestCase {
 		
 		$sut = $this->make_instance();
 		$url = $sut->get_tickets_page_url( $post_id );
+		$url = $this->placehold_post_ids( $url, [ 'post_id' => $post_id ] );
 		
 		if ( $has_output ) {
 			$this->assertMatchesHtmlSnapshot( $url );
@@ -312,6 +324,7 @@ class Tickets_ViewTest extends WPTestCase {
 		update_option( 'permalink_structure', '' );
 		$sut = $this->make_instance();
 		$url = $sut->get_tickets_page_url( $post_id );
+		$url = $this->placehold_post_ids( $url, [ 'post_id' => $post_id ] );
 		
 		if ( $has_output ) {
 			$this->assertMatchesHtmlSnapshot( $url );

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url__with valid event id__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url__with valid event id__0.snapshot.html
@@ -1,0 +1,1 @@
+http://wordpress.test/?tribe_events=test-event/tickets

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url__with valid post id__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url__with valid post id__0.snapshot.html
@@ -1,1 +1,1 @@
-http://wordpress.test/tickets/5096
+http://wordpress.test/tickets/{{ post_id }}

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url__with valid post id__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url__with valid post id__0.snapshot.html
@@ -1,0 +1,1 @@
+http://wordpress.test/tickets/5096

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url_for_plain_permalink__with valid event id__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url_for_plain_permalink__with valid event id__0.snapshot.html
@@ -1,0 +1,1 @@
+http://wordpress.test/?tribe_events=test-event&eventDisplay=tickets

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url_for_plain_permalink__with valid post id__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url_for_plain_permalink__with valid post id__0.snapshot.html
@@ -1,0 +1,1 @@
+http://wordpress.test/?p=5098&tribe-edit-orders=1

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url_for_plain_permalink__with valid post id__0.snapshot.html
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/Tickets_ViewTest__should_get_tickets_page_url_for_plain_permalink__with valid post id__0.snapshot.html
@@ -1,1 +1,1 @@
-http://wordpress.test/?p=5098&tribe-edit-orders=1
+http://wordpress.test/?p={{ post_id }}&tribe-edit-orders=1


### PR DESCRIPTION
### 🎫 Ticket

[ET-1993] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

* Fixed an issue where the My tickets page for Series post types was redirecting to the wrong URL on update.
* Now the fix is tested against regular `post`, `event` and `series` types and are working as expected.
* Changes are covered by these tests: [With Series Pass](https://github.com/the-events-calendar/event-tickets/blob/cc4650810fede21a82a592ed28c3529960c662f5/tests/ft_integration/Tribe/Tickets/MyTickets/MyTicketsTest.php#L17-L16) & [Without series Pass](https://github.com/the-events-calendar/event-tickets/blob/b11c409cd61a69371bc5838e544a3a960b05f997/tests/integration/Tribe/Tickets/MyTickets/MyTicketsTest.php#L14-L13)
<!-- Please describe what you have changed or added -->
<!-- What types of changes does your code introduce? -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Include any important information for reviewers -->
<!-- Etc, etc, etc -->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://www.loom.com/share/84ce624e3b254f48894761d88ae04768

[Test with and without series pass activated](https://www.loom.com/share/d16b59dd560f43b599f9d69f07132cac)

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [x] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).


[ET-1993]: https://stellarwp.atlassian.net/browse/ET-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ