### PR TITLE
[ET-1925] Fix calculation issue on site health page

### DIFF
--- a/src/Tickets/Site_Health/Subsections/Features/Tickets_Commerce_Subsection.php
+++ b/src/Tickets/Site_Health/Subsections/Features/Tickets_Commerce_Subsection.php
@@ -14,6 +14,7 @@ use TEC\Tickets\Commerce\Gateways\Stripe\Gateway as Stripe_Gateway;
 use TEC\Tickets\Commerce\Repositories\Tickets_Repository;
 use TEC\Tickets\Commerce\Settings;
 use TEC\Tickets\Commerce\Utils\Currency;
+use TEC\Tickets\Commerce\Utils\Value;
 use TEC\Tickets\Site_Health\Abstract_Info_Subsection;
 
 /**
@@ -134,41 +135,20 @@ class Tickets_Commerce_Subsection extends Abstract_Info_Subsection {
 			if ( 'Free' === $price || '' === $price || null === $price ) {
 				// Skip free or empty prices for average calculation.
 				continue;
-			} else {
-				// Match the number with international currency format.
-				preg_match(
-					'/\d+([,.]\d+)?/',
-					$price,
-					$matches
-				);
-				if ( isset( $matches[0] ) ) {
-					// Convert to a standard number format (replace comma with period).
-					$number = floatval(
-						str_replace(
-							',',
-							'.',
-							$matches[0]
-						)
-					);
-					$total += $number;
-
-					++$count;
-				}
 			}
+
+			$number = Value::create( $price )->get_float();
+			$total += $number;
+			++$count;
+
+
 		}
 
 		// Calculate the average price, avoid division by zero.
 		$tickets_commerce_average_price = $count > 0 ? $total / $count : 0;
 
-		// Format the average price with two decimal points.
-		$tickets_commerce_formatted_average_price = number_format(
-			$tickets_commerce_average_price,
-			2,
-			'.',
-			','
-		);
 
-		return $tickets_commerce_formatted_average_price;
+		return Value::create( $tickets_commerce_average_price )->get_currency();
 	}
 
 	/**

--- a/src/Tickets/Site_Health/Subsections/Plugins/Plugin_Data_Subsection.php
+++ b/src/Tickets/Site_Health/Subsections/Plugins/Plugin_Data_Subsection.php
@@ -412,7 +412,7 @@ class Plugin_Data_Subsection extends Abstract_Info_Subsection {
 	 * @return array Associative array with formatted average, max, and min ticket prices.
 	 */
 	private function get_formatted_prices(): array {
-		$ticket_ids = tribe( 'tickets.event-repository' )->per_page( -1 )->where( 'has_tickets' )->pluck('ID');
+		$ticket_ids = tribe( 'tickets.event-repository' )->per_page( -1 )->where( 'has_tickets' )->pluck( 'ID' );
 
 		$ticket_prices = [];
 

--- a/src/Tickets/Site_Health/Subsections/Plugins/Plugin_Data_Subsection.php
+++ b/src/Tickets/Site_Health/Subsections/Plugins/Plugin_Data_Subsection.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Site_Health\Subsections\Plugins;
 
 use TEC\Tickets\Site_Health\Abstract_Info_Subsection;
 use Tribe__Tickets__Query;
+use Tribe__Tickets__Tickets;
 use Tribe__Utils__Array as Arr;
 use TEC\Tickets\Commerce\Utils\Value;
 
@@ -411,7 +412,19 @@ class Plugin_Data_Subsection extends Abstract_Info_Subsection {
 	 * @return array Associative array with formatted average, max, and min ticket prices.
 	 */
 	private function get_formatted_prices(): array {
-		$ticket_prices = tribe( 'tickets.event-repository' )->per_page( -1 )->where( 'has_tickets' )->pluck( 'cost' );
+		$ticket_ids = tribe( 'tickets.event-repository' )->per_page( -1 )->where( 'has_tickets' )->pluck('ID');
+
+		$ticket_prices = [];
+
+		foreach ( $ticket_ids as $id ) {
+			$tickets = Tribe__Tickets__Tickets::get_all_event_tickets( $id );
+
+			foreach ( $tickets as $ticket ) {
+				if ( isset( $ticket->price ) ) {
+					$ticket_prices[] = $ticket->price;
+				}
+			}
+		}
 
 		$total_and_count = $this->calculate_total_and_count( $ticket_prices );
 		$max_price       = $this->calculate_max_price( $ticket_prices );


### PR DESCRIPTION
### 🎫 Ticket
[ET-1925] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!-- Please describe what you have changed or added -->
While testing Romine found that under certain scenarios the calculation for ticket averages was incorrect. This fixes the logic

![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/d5c72928-f99e-45a8-9eda-6669ccdd340f)


[ET-1925]: https://stellarwp.atlassian.net/browse/ET-1925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ