### PR TITLE
WooCommerce HPOS Issue - Added filter to extend WooCommerce URL.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Tweak - Customer name appears now as description of a Stripe payment. Added `tec_tickets_commerce_stripe_update_payment_description` filter. [ET-1607]
 * Tweak - Declared dynamic properties in Tribe__Tickets__Main, Tribe__Tickets__Tickets_Handler, Tribe__Tickets__REST__V1__Messages to prevent warnings in php 8.2 [ET-1950]
 * Tweak - Update default footer text of Tickets Emails to include link to website. [ET-1971]
+* Tweak - Added new filter `tec__tickets_attendees_table_order_id_url` to allow for overwriting the Attendees Order URL. [ET-1914]
 
 = [5.8.0] 2024-01-22 =
 

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -307,7 +307,6 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 	public function get_order_id_url( array $item ) {
 		// Backwards compatibility.
 		if ( empty( $item['order_id_url'] ) ) {
-			// @todo fix this piece
 			$item['order_id_url'] = get_edit_post_link( $item['order_id'], true );
 		}
 
@@ -320,7 +319,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		 * @param array  $item The item array.
 		 */
 		return apply_filters(
-			'tec_attendees_table_order_id_url',
+			'tec__tickets_attendees_table_order_id_url',
 			$item['order_id_url'],
 			$item
 		);

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -319,7 +319,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		 * @param array  $item The item array.
 		 */
 		return apply_filters(
-			'tec__tickets_attendees_table_order_id_url',
+			'tec_tickets_attendees_table_order_id_url',
 			$item['order_id_url'],
 			$item
 		);

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -307,10 +307,23 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 	public function get_order_id_url( array $item ) {
 		// Backwards compatibility.
 		if ( empty( $item['order_id_url'] ) ) {
+			// @todo fix this piece
 			$item['order_id_url'] = get_edit_post_link( $item['order_id'], true );
 		}
 
-		return $item['order_id_url'];
+		/**
+		 * Filter the order ID URL.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $order_id_url The URL of the order ID.
+		 * @param array  $item The item array.
+		 */
+		return apply_filters(
+			'tec_attendees_table_order_id_url',
+			$item['order_id_url'],
+			$item
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ticket: [ETP-901]

Added a new filter so that WooCommerce can hook into and add the proper URL.

https://github.com/the-events-calendar/event-tickets-plus/pull/1519

[ETP-901]: https://stellarwp.atlassian.net/browse/ETP-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ