### PR TITLE
[ET-2007] Decode html entites in email subject string

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Stock will be calculated correctly when an order fails and then succeeds while using Tickets Commerce.
+* Fix - Decode any HTML entities that appear int he subject line of outgoing emails. [ET-2007]
 
 = [5.8.2] 2024-02-19 =
 

--- a/src/Tickets/Emails/Dispatcher.php
+++ b/src/Tickets/Emails/Dispatcher.php
@@ -552,9 +552,12 @@ class Dispatcher {
 			return false;
 		}
 
+		// Handle any encoded characters in the subject.
+		$subject = html_entity_decode( $this->get_subject() );
+
 		$sent = (bool) wp_mail(
 			$this->get_to(),
-			$this->get_subject(),
+			$subject,
 			$this->get_content(),
 			$this->get_headers_formatted(),
 			$this->get_attachments()

--- a/src/Tickets/Emails/Dispatcher.php
+++ b/src/Tickets/Emails/Dispatcher.php
@@ -544,6 +544,7 @@ class Dispatcher {
 	 * Send an email.
 	 *
 	 * @since 5.6.0
+	 * @since TBD Decodes the subject before sending the email.
 	 *
 	 * @return bool Whether the email was sent successfully.
 	 */

--- a/src/Tickets/Emails/Dispatcher.php
+++ b/src/Tickets/Emails/Dispatcher.php
@@ -554,7 +554,7 @@ class Dispatcher {
 		}
 
 		// Handle any encoded characters in the subject.
-		$subject = html_entity_decode( $this->get_subject() );
+		$subject = wp_specialchars_decode( $this->get_subject() );
 
 		$sent = (bool) wp_mail(
 			$this->get_to(),


### PR DESCRIPTION
### 🎫 Ticket

[ET-2007]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
It was reported the Ampersands were being encoded when an event (or post) title included one in its title and when using the `{event_name}` placeholder within the subject line of an email. We found that `wp_kses()` was causing this to occur. We are using `wp_specialchars_decode()` just before sending the email to prevent these characters from being sent out.
### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/e0918416a8a242fd893200d26713d04e

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2007]: https://stellarwp.atlassian.net/browse/ET-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ