### PR TITLE
Fix - FT check-in SP Attendees once

### DIFF
--- a/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
@@ -517,7 +517,7 @@ class Attendees extends Controller {
 			return $response;
 		}
 
-		if ( $this->checkin_failures[ $attendee_id ] === self::ALREADY_CHECKED_IN ) {
+		if ( self::ALREADY_CHECKED_IN === $this->checkin_failures[ $attendee_id ] ) {
 			/*
 			 * Build a response similar to the one the QR endpoint would produce to indicate the Attendee is already
 			 * checked in.
@@ -534,7 +534,7 @@ class Attendees extends Controller {
 			);
 		}
 
-		$post_repository = tribe( 'tec.rest-v1.repository' );
+		$post_repository     = tribe( 'tec.rest-v1.repository' );
 		$prepared_candidates = array_map(
 			static fn( int $candidate ) => $post_repository->get_event_data( $candidate, 'single' ),
 			$this->checkin_failures[ $attendee_id ]['candidates']
@@ -792,8 +792,8 @@ class Attendees extends Controller {
 		if ( $qr && $checked_in ) {
 			// The Attendee has already been checked in, let's not check-in again.
 			$this->checkin_failures[ $attendee_id ] = self::ALREADY_CHECKED_IN;
-			$original_attendee_id = get_post_meta( $attendee_id, self::CLONE_META_KEY, true );
-			$this->checkin_failures[ $original_attendee_id ] = self::ALREADY_CHECKED_IN;
+			$original_id                            = get_post_meta( $attendee_id, self::CLONE_META_KEY, true );
+			$this->checkin_failures[ $original_id ] = self::ALREADY_CHECKED_IN;
 
 			// The correct REST response will be built by the `build_attendee_failure_response` method.
 			return false;


### PR DESCRIPTION
### 🎫 Ticket

[ET-1936]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Previously, cloned Attendees would, from the context of a check-in made with QR code, be incorrectly checked for already checked-in status.
If the Series Pass Attendee has an ID of 23, and the clone has an ID of 89, then the check for already checked-in status would be done,
incorrectly, on the Series Pass Attendee (never checked-in) and not on the cloned Attendee.

### 🎥 Artifacts
[Issue in action](https://share.cleanshot.com/Vr1fLTGX) -- I can check-in multiple times
[Issue fixed](https://share.cleanshot.com/TwpVSr7h) -- I cannot check-in after the first time

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-1936]: https://stellarwp.atlassian.net/browse/ET-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ