### PR TITLE
[ET-2047] Site Health -  Fix fatal no providers enabled

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -202,6 +202,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Stock will be calculated correctly when an order fails and then succeeds while using Tickets Commerce.
 * Fix - Decode any HTML entities that appear int he subject line of outgoing emails. [ET-2007]
 * Fix - Fixed multiple issues related to series pass check-ins. [ET-1936]
+* Fix - Site Health will no longer fatal when providers are not setup. [ET-2047]
 * Tweak - Use dynamic ticket labels within the block editor's Tickets Block. [ET-690]
 
 = [5.8.2] 2024-02-19 =

--- a/src/Tickets/Site_Health/Abstract_Info_Subsection.php
+++ b/src/Tickets/Site_Health/Abstract_Info_Subsection.php
@@ -11,6 +11,8 @@
 
 namespace TEC\Tickets\Site_Health;
 
+use Tribe__Tickets__Tickets as Tickets;
+
 /**
  * Abstract class for creating subsections in the Site Health information section.
  *
@@ -79,5 +81,24 @@ abstract class Abstract_Info_Subsection {
 			'False',
 			'event-tickets'
 		);
+	}
+
+	/**
+	 * Checks if ticketing providers other than RSVP enabled.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Returns false if the only active ticketing provider is 'Tribe__Tickets__RSVP', indicating a minimal setup. Returns true if additional ticketing providers are active, suggesting a fully enabled ticketing environment.
+	 */
+	protected function are_ticketed_providers_enabled(): bool {
+		$rsvp_module    = 'Tribe__Tickets__RSVP';
+		$active_modules = Tickets::modules();
+
+		// Check if only one provider is returned and if that is Tribe__Tickets__RSVP.
+		if ( count( $active_modules ) === 1 && array_key_exists( $rsvp_module, $active_modules ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/Tickets/Site_Health/Subsections/Plugins/Plugin_Data_Subsection.php
+++ b/src/Tickets/Site_Health/Subsections/Plugins/Plugin_Data_Subsection.php
@@ -224,9 +224,14 @@ class Plugin_Data_Subsection extends Abstract_Info_Subsection {
 	/**
 	 * Counts the total number of posts with tickets.
 	 *
+	 * @since TBD Added additional check to confirm providers are enabled.
+	 *
 	 * @return int Count of ticketed posts.
 	 */
 	private function get_ticketed_post_count(): int {
+		if ( ! $this->are_ticketed_providers_enabled() ) {
+			return 0;
+		}
 		return tribe( 'tickets.post-repository' )->per_page( -1 )->where( 'has_tickets' )->count();
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
[ET-2047]

### 🗒️ Description

It was found that when ET/TEC were enabled on a fresh install the Site Health would error out. With the error `PHP Fatal error:  Uncaught TEC\Common\Exceptions\Not_Bound_Exception: Error while making cache: count(): Argument #1 ($value) must be of type Countable|array, null given. in /.../wp-content/plugins/the-events-calendar/common/src/Common/Contracts/Container.php:27`

After digging I found that when no providers are setup and the only provider is `Tribe__Tickets__RSVP` it would generate the error. Once a provider is enabled (TC,Woo,EDD) the error would resolve.

The error would occur within `Tribe( 'tickets.event-repository' )->per_page( -1 )->where( 'has_tickets' )->count();`. 

I added an additional check to confirm that ticketed providers are enabled prior to the check above.



<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2047]: https://stellarwp.atlassian.net/browse/ET-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ