### PR TITLE
 [ET-2047] Repository fatals when no providers enabled

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -202,6 +202,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Stock will be calculated correctly when an order fails and then succeeds while using Tickets Commerce.
 * Fix - Decode any HTML entities that appear int he subject line of outgoing emails. [ET-2007]
 * Fix - Fixed multiple issues related to series pass check-ins. [ET-1936]
+* Fix - Site Health will no longer fatal when providers are not setup. [ET-2047]
 * Tweak - Use dynamic ticket labels within the block editor's Tickets Block. [ET-690]
 
 = [5.8.2] 2024-02-19 =

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -226,37 +226,35 @@ trait Post_Tickets {
 	 *
 	 * @param bool $has_tickets Indicates if the event should have ticket types attached to it or not.
 	 */
-	public function filter_by_has_tickets( $has_tickets = true ) {
-		$repo = $this;
-
-		// If the repo is decorated, use that.
-		if ( ! empty( $repo ) ) {
-			$repo = $this->decorated;
-		}
-
+	public function filter_by_has_tickets($has_tickets = true) {
 		global $wpdb;
+		$prefix = $has_tickets ? 'has_tickets' : 'has_no_tickets';
 
-		if ( (bool) $has_tickets ) {
-			$prefix = 'has_tickets';
+		$meta_key_compare_clause = $this->ticket_to_post_meta_key_compare("{$prefix}_ticket_event", null, $has_tickets ? [RSVP::class] : null);
+		$meta_value_compare_clause = $this->ticket_to_post_meta_value_compare("{$prefix}_ticket_event");
 
-			$meta_key_compare_clause   = $this->ticket_to_post_meta_key_compare( "{$prefix}_ticket_event", null, [ RSVP::class ] );
-			$meta_value_compare_clause = $this->ticket_to_post_meta_value_compare( "{$prefix}_ticket_event" );
+		// Start with the JOIN type based on the ticket presence.
+		$join_clause = ($has_tickets ? "JOIN" : "LEFT JOIN") . " {$wpdb->postmeta} {$prefix}_ticket_event ON ";
 
-			// Join to the meta that relates tickets to events but exclude RSVP tickets.
-			$repo->join_clause( "JOIN {$wpdb->postmeta} {$prefix}_ticket_event
-				 ON ({$meta_key_compare_clause}) AND ({$meta_value_compare_clause})" );
-
-			return;
+		// Add conditions if they are not empty, with an AND if both are present.
+		if (!empty($meta_key_compare_clause)) {
+			$join_clause .= "($meta_key_compare_clause)";
+		}
+		if (!empty($meta_key_compare_clause) && !empty($meta_value_compare_clause)) {
+			$join_clause .= ' AND ';
+		}
+		if (!empty($meta_value_compare_clause)) {
+			$join_clause .= "($meta_value_compare_clause)";
 		}
 
-		$prefix                    = 'has_no_tickets';
-		$meta_key_compare_clause = $this->ticket_to_post_meta_key_compare( "{$prefix}_ticket_event" );
-		$meta_value_compare_clause = $this->ticket_to_post_meta_value_compare( "{$prefix}_ticket_event" );
-		// Keep events that have no tickets assigned or are assigned RSVP tickets.
-		$repo->join_clause( "LEFT JOIN {$wpdb->postmeta} {$prefix}_ticket_event
-					ON ({$meta_key_compare_clause}) AND ({$meta_value_compare_clause})" );
-		$repo->where_clause( "{$prefix}_ticket_event.meta_key = '_tribe_rsvp_for_event' OR {$prefix}_ticket_event.meta_id IS NULL" );
+		$this->join_clause($join_clause);
+
+		// Additional logic for when tickets are not expected.
+		if (!$has_tickets) {
+			$this->where_clause("{$prefix}_ticket_event.meta_key = '_tribe_rsvp_for_event' OR {$prefix}_ticket_event.meta_id IS NULL");
+		}
 	}
+
 
 	/**
 	 * Filters events to include only those that match the provided RSVP state.
@@ -341,6 +339,7 @@ trait Post_Tickets {
 	 * meta key index to kick in.
 	 *
 	 * @since 5.8.0
+	 * @since TBD Set $meta_keys to an empty array.
 	 *
 	 * @param string   $alias     The alias to use for the post meta table.
 	 * @param string[] $allow     A list of providers to include in the comparison. If this argument is `null`,
@@ -351,6 +350,7 @@ trait Post_Tickets {
 	 * @return string The SQL clause to compare meta keys to the ones relating tickets to posts.
 	 */
 	protected function ticket_to_post_meta_key_compare( string $alias, array $allow = null, array $exclude = null ): string {
+		$meta_keys = [];
 		foreach ( Tickets::modules() as $provider => $name ) {
 			if ( $allow !== null && ! in_array( $provider, $allow, true ) ) {
 				continue;

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -223,35 +223,36 @@ trait Post_Tickets {
 	 * cost custom field.
 	 *
 	 * @since 4.12.1
+	 * @since TBD Refactored to catch instances when `$meta_key_compare_clause` is empty.
 	 *
 	 * @param bool $has_tickets Indicates if the event should have ticket types attached to it or not.
 	 */
-	public function filter_by_has_tickets($has_tickets = true) {
+	public function filter_by_has_tickets( $has_tickets = true ) {
 		global $wpdb;
 		$prefix = $has_tickets ? 'has_tickets' : 'has_no_tickets';
 
-		$meta_key_compare_clause = $this->ticket_to_post_meta_key_compare("{$prefix}_ticket_event", null, $has_tickets ? [RSVP::class] : null);
-		$meta_value_compare_clause = $this->ticket_to_post_meta_value_compare("{$prefix}_ticket_event");
+		$meta_key_compare_clause   = $this->ticket_to_post_meta_key_compare( "{$prefix}_ticket_event", null, $has_tickets ? [ RSVP::class ] : null );
+		$meta_value_compare_clause = $this->ticket_to_post_meta_value_compare( "{$prefix}_ticket_event" );
 
 		// Start with the JOIN type based on the ticket presence.
-		$join_clause = ($has_tickets ? "JOIN" : "LEFT JOIN") . " {$wpdb->postmeta} {$prefix}_ticket_event ON ";
+		$join_clause = ( $has_tickets ? "JOIN" : "LEFT JOIN" ) . " {$wpdb->postmeta} {$prefix}_ticket_event ON ";
 
 		// Add conditions if they are not empty, with an AND if both are present.
-		if (!empty($meta_key_compare_clause)) {
+		if ( ! empty( $meta_key_compare_clause ) ) {
 			$join_clause .= "($meta_key_compare_clause)";
 		}
-		if (!empty($meta_key_compare_clause) && !empty($meta_value_compare_clause)) {
+		if ( ! empty( $meta_key_compare_clause ) && ! empty( $meta_value_compare_clause ) ) {
 			$join_clause .= ' AND ';
 		}
-		if (!empty($meta_value_compare_clause)) {
+		if ( ! empty( $meta_value_compare_clause ) ) {
 			$join_clause .= "($meta_value_compare_clause)";
 		}
 
-		$this->join_clause($join_clause);
+		$this->join_clause( $join_clause );
 
 		// Additional logic for when tickets are not expected.
-		if (!$has_tickets) {
-			$this->where_clause("{$prefix}_ticket_event.meta_key = '_tribe_rsvp_for_event' OR {$prefix}_ticket_event.meta_id IS NULL");
+		if ( ! $has_tickets ) {
+			$this->where_clause( "{$prefix}_ticket_event.meta_key = '_tribe_rsvp_for_event' OR {$prefix}_ticket_event.meta_id IS NULL" );
 		}
 	}
 

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -235,7 +235,7 @@ trait Post_Tickets {
 		$meta_value_compare_clause = $this->ticket_to_post_meta_value_compare( "{$prefix}_ticket_event" );
 
 		// Start with the JOIN type based on the ticket presence.
-		$join_clause = ( $has_tickets ? "JOIN" : "LEFT JOIN" ) . " {$wpdb->postmeta} {$prefix}_ticket_event ON ";
+		$join_clause = ( $has_tickets ? 'JOIN' : 'LEFT JOIN' ) . " {$wpdb->postmeta} {$prefix}_ticket_event ON ";
 
 		// Add conditions if they are not empty, with an AND if both are present.
 		if ( ! empty( $meta_key_compare_clause ) ) {


### PR DESCRIPTION
### 🎫 Ticket

[ET-2047]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
```
PHP Fatal error:  Uncaught TEC\Common\Exceptions\Not_Bound_Exception: Error while making cache: count(): Argument #1 ($value) must be of type Countable|array, null given. in /.../wp-content/plugins/the-events-calendar/common/src/Common/Contracts/Container.php:27
```
It was found that on a fresh install of TEC/ET the Site Health page was throwing a fatal. Upon looking into the issue I found that the repository method `filter_by_has_tickets` was throwing an error due to `$meta_key_compare_clause` being empty. I refactored the code to build the join for times when `$meta_key_compare_clause` is empty.

This change is covered by the tests found within `tests/wpunit/Tribe/Tickets `.


<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[et_2047_artifact.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/c9b40ff3-6f5b-4169-aef5-773b6682cc63)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2047]: https://stellarwp.atlassian.net/browse/ET-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ