### PR TITLE
[ET-2046] Block Editor > Tickets Block > Tickets getting deleted when opening settings

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'EVENT_TICKETS_DIR', dirname( __FILE__ ) );
 define( 'EVENT_TICKETS_MAIN_PLUGIN_FILE', __FILE__ );
 
-// Load the required php min version functions
+// Load the required php min version functions.
 require_once dirname( EVENT_TICKETS_MAIN_PLUGIN_FILE ) . '/src/functions/php-min-version.php';
 
 // Load the Composer autoload file.

--- a/event-tickets.php
+++ b/event-tickets.php
@@ -11,6 +11,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: event-tickets
 Domain Path: /lang/
 */
+
 /*
  Copyright 2010-2022 by The Events Calendar and the contributors
 

--- a/event-tickets.php
+++ b/event-tickets.php
@@ -11,7 +11,6 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: event-tickets
 Domain Path: /lang/
 */
-
 /*
  Copyright 2010-2022 by The Events Calendar and the contributors
 

--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - In the block editor, ticket will no longer be deleted when you open the ticket settings. [ET-2018]
+
+= [TBD] TBD =
+
 * Fix - Fixed updating stock data when Tickets Commerce attendees are moved. [ET-2009]
 * Fix - Fixed showing duplicate order overview data from TribeCommerce when ETP is disabled. [ET-2011]
 * Fix - Stock will be calculated correctly when an order fails and then succeeds while using Tickets Commerce.

--- a/readme.txt
+++ b/readme.txt
@@ -197,7 +197,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Fix - In the block editor, ticket will no longer be deleted when you open the ticket settings. [ET-2018]
+* Fix - In the block editor, ticket will no longer be deleted when you open the ticket block settings. [ET-2018]
 
 = [TBD] TBD =
 

--- a/src/Tickets/Blocks/Tickets/app/editor/container/style.pcss
+++ b/src/Tickets/Blocks/Tickets/app/editor/container/style.pcss
@@ -17,6 +17,12 @@
 	}
 }
 
+.tribe-editor__tickets--settings-open {
+	.tribe-editor__tickets__container {
+		display: none;
+	}
+}
+
 .tribe-editor__tickets__overlay {
 	position: absolute;
 	left: 0;

--- a/src/Tickets/Blocks/Tickets/app/editor/container/template.js
+++ b/src/Tickets/Blocks/Tickets/app/editor/container/template.js
@@ -35,10 +35,6 @@ const TicketsContainer = ({
 	uneditableTickets,
 	uneditableTicketsAreLoading,
 }) => {
-	if (isSettingsOpen) {
-		return null;
-	}
-
 	const innerBlocksClassName = classNames({
 		'tribe-editor__tickets__inner-blocks': true,
 		'tribe-editor__tickets__inner-blocks--show': !showInactiveBlock,


### PR DESCRIPTION
### 🎫 Ticket
[ET-2046]

### 🗒️ Description
Within the block editor, tickets were getting deleted when opening the "Settings" view within the block. I found that we had made a change where the individual Ticket Blocks get removed instead of just hiding them, which was triggering the call to delete the ticket. Instead of removing the components, I used CSS to hide them instead, which avoids the tickets from being deleted.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/ffaa6354090b4ecaa68fdd5e5c7f8ab2?sid=cf25f923-e2ba-4d89-a455-d4de3483ba63

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2046]: https://stellarwp.atlassian.net/browse/ET-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ