### PR TITLE
[ET-2006] Tickets Emails > Allow excerpts to display line breaks within emails

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Show post excerpt line breaks within ticket emails. [ET-2006]
+
+= [TBD] TBD =
+
 * Fix - Fixed updating stock data when Tickets Commerce attendees are moved. [ET-2009]
 * Fix - Fixed showing duplicate order overview data from TribeCommerce when ETP is disabled. [ET-2011]
 * Fix - Stock will be calculated correctly when an order fails and then succeeds while using Tickets Commerce.

--- a/src/views/emails/template-parts/body/post-description.php
+++ b/src/views/emails/template-parts/body/post-description.php
@@ -28,6 +28,6 @@ if ( empty( $post->post_excerpt ) ) {
 ?>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		<?php echo esc_html( $post->post_excerpt ); ?>
+		<?php echo wp_kses( wpautop( $post->post_excerpt ), 'post' ); ?>
 	</td>
 </tr>

--- a/tests/ft_integration/TEC/Tickets/Emails/__snapshots__/TicketsTest__test_tickets_email_for_series_pass__series with single series pass and 3 attached events__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Emails/__snapshots__/TicketsTest__test_tickets_email_for_series_pass__series with single series pass and 3 attached events__0.snapshot.html
@@ -638,7 +638,8 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		Test Series for Series pass email	</td>
+		<p>Test Series for Series pass email</p>
+	</td>
 </tr>
 					</table>
 				</td>

--- a/tests/ft_integration/TEC/Tickets/Emails/__snapshots__/TicketsTest__test_tickets_email_for_series_pass__series with single series pass but no events__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Emails/__snapshots__/TicketsTest__test_tickets_email_for_series_pass__series with single series pass but no events__0.snapshot.html
@@ -634,7 +634,8 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		Test Series for Series pass email	</td>
+		<p>Test Series for Series pass email</p>
+	</td>
 </tr>
 					</table>
 				</td>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-		
+
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -624,7 +624,8 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... 	</td>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+	</td>
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-event-venue-title-container">

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-		
+
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -695,6 +695,31 @@
 		</td>
 	</tr>
 </table>
+				</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+<tr>
+	<td class="tec-tickets__email-table-content-event-links-container">
+		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
+			<tr>
+				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
+					<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-ical-link"
+>
+	Add event to iCal</a>
+
+<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-gcal-link"
+>
+	Add event to Google Calendar</a>
 				</td>
 			</tr>
 		</table>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -624,7 +624,7 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at "Arts in the Park"!  Join us for an enchanting day of vibrant musics and captivating... </p>
 	</td>
 </tr>
 <tr>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-
+		
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set rsvp__1.php
@@ -700,31 +700,6 @@
 		</table>
 	</td>
 </tr>
-<tr>
-	<td class="tec-tickets__email-table-content-event-links-container">
-		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
-			<tr>
-				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
-					<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-ical-link"
->
-	Add event to iCal</a>
-
-<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-gcal-link"
->
-	Add event to Google Calendar</a>
-				</td>
-			</tr>
-		</table>
-	</td>
-</tr>
 					</table>
 				</td>
 			</tr>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-		
+
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -624,7 +624,8 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... 	</td>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+	</td>
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-event-venue-title-container">

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-		
+
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -695,6 +695,31 @@
 		</td>
 	</tr>
 </table>
+				</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+<tr>
+	<td class="tec-tickets__email-table-content-event-links-container">
+		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
+			<tr>
+				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
+					<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-ical-link"
+>
+	Add event to iCal</a>
+
+<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-gcal-link"
+>
+	Add event to Google Calendar</a>
 				</td>
 			</tr>
 		</table>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -624,7 +624,7 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at "Arts in the Park"!  Join us for an enchanting day of vibrant musics and captivating... </p>
 	</td>
 </tr>
 <tr>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-
+		
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>

--- a/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/Admin/__snapshots__/Preview_ModalTest__it_should_match_snapshot_for_individual_email_preview with data set ticket__1.php
@@ -700,31 +700,6 @@
 		</table>
 	</td>
 </tr>
-<tr>
-	<td class="tec-tickets__email-table-content-event-links-container">
-		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
-			<tr>
-				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
-					<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-ical-link"
->
-	Add event to iCal</a>
-
-<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-gcal-link"
->
-	Add event to Google Calendar</a>
-				</td>
-			</tr>
-		</table>
-	</td>
-</tr>
 					</table>
 				</td>
 			</tr>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-		
+
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -624,7 +624,8 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... 	</td>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+	</td>
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-event-venue-title-container">

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -624,7 +624,7 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at "Arts in the Park"!  Join us for an enchanting day of vibrant musics and captivating... </p>
 	</td>
 </tr>
 <tr>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -700,34 +700,6 @@
 		</table>
 	</td>
 </tr>
-<tr>
-	<td class="tec-tickets__email-table-content-event-links-container">
-		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
-			<tr>
-				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
-
-					<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-ical-link"
->
-	Add event to iCal</a>
-
-					
-<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-gcal-link"
->
-	Add event to Google Calendar</a>
-
-				</td>
-			</tr>
-		</table>
-	</td>
-</tr>
 					</table>
 				</td>
 			</tr>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set rsvp__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-
+		
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -695,6 +695,34 @@
 		</td>
 	</tr>
 </table>
+				</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+<tr>
+	<td class="tec-tickets__email-table-content-event-links-container">
+		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
+			<tr>
+				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
+
+					<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-ical-link"
+>
+	Add event to iCal</a>
+
+					
+<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-gcal-link"
+>
+	Add event to Google Calendar</a>
+
 				</td>
 			</tr>
 		</table>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-		
+
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -624,7 +624,8 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... 	</td>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+	</td>
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-event-venue-title-container">

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -624,7 +624,7 @@
 </tr>
 <tr>
 	<td class="tec-tickets__email-table-content-post-description-container">
-		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at &quot;Arts in the Park&quot;!  Join us for an enchanting day of vibrant musics and captivating... </p>
+		<p>Experience the magic of creativity in nature. Save the date and indulge your senses at "Arts in the Park"!  Join us for an enchanting day of vibrant musics and captivating... </p>
 	</td>
 </tr>
 <tr>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -700,34 +700,6 @@
 		</table>
 	</td>
 </tr>
-<tr>
-	<td class="tec-tickets__email-table-content-event-links-container">
-		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
-			<tr>
-				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
-
-					<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-ical-link"
->
-	Add event to iCal</a>
-
-					
-<a
-	target="_blank"
-	rel="noopener noreferrer"
-	href="#"
-	class="tec-tickets__email-table-content-event-links-gcal-link"
->
-	Add event to Google Calendar</a>
-
-				</td>
-			</tr>
-		</table>
-	</td>
-</tr>
 					</table>
 				</td>
 			</tr>

--- a/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
+++ b/tests/integration/TEC/Tickets/Emails/__snapshots__/TemplateTest__it_should_match_snapshot with data set ticket__1.php
@@ -554,7 +554,7 @@
 </style>
 <div class="tec-tickets__email-body">
 
-
+		
 		<table role="presentation" class="tec-tickets__email-table-main">
 
 			<tr>
@@ -695,6 +695,34 @@
 		</td>
 	</tr>
 </table>
+				</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+<tr>
+	<td class="tec-tickets__email-table-content-event-links-container">
+		<table role="presentation" class="tec-tickets__email-table-content-event-links-table">
+			<tr>
+				<td class="tec-tickets__email-table-content-event-links-table-data" align="center">
+
+					<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-ical-link"
+>
+	Add event to iCal</a>
+
+					
+<a
+	target="_blank"
+	rel="noopener noreferrer"
+	href="#"
+	class="tec-tickets__email-table-content-event-links-gcal-link"
+>
+	Add event to Google Calendar</a>
+
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
### 🎫 Ticket
[ET-2006]

### 🗒️ Description
Prior to this, post excerpts have been displaying as the "post description" within emails, but if they had any line breaks, they were being stripped. This fix converts line breaks to `<br>` tags so that the line breaks will be preserved within the email content.

### 🎥 Artifacts <!-- if applicable-->
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/7142d75b-701e-4934-b144-c776bcba0ef4)
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/5ef7439f-cd11-44af-b6a8-5ea356d10589)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2006]: https://stellarwp.atlassian.net/browse/ET-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ