### PR TITLE
[ET-2035] Tickets Block > Button glitch

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Front-end tickets block button padding is now consistent on hover and when disabled. [ET-2035]
+
+= [TBD] TBD =
+
 * Fix - Fixed updating stock data when Tickets Commerce attendees are moved. [ET-2009]
 * Fix - Fixed showing duplicate order overview data from TribeCommerce when ETP is disabled. [ET-2011]
 * Fix - Stock will be calculated correctly when an order fails and then succeeds while using Tickets Commerce.

--- a/src/resources/postcss/components/buttons/_small.pcss
+++ b/src/resources/postcss/components/buttons/_small.pcss
@@ -17,6 +17,14 @@
 			background-color: var(--tec-color-accent-primary);
 			padding: 11px 14px;
 			width: auto;
+
+			&:hover {
+				padding: 11px 14px;
+			}
+
+			&:disabled {
+				padding: 11px 14px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket
[ET-2035]

### 🗒️ Description
The button padding for the tickets block on the front-end was inconsistent when disabled or hovering. We are using the `.tribe-common-c-btn--small` class for that button, which has a padding set that differs from common's `.tribe-common-c-btn` class. However we do not set the padding for `:disabled` or `:hover`, so the padding for the regular button overrides.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/b5da4914db54423daf56e25f8882891c?sid=ef845986-af6a-4a7f-8d6c-2f718fd8740f

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.