### PR TITLE
[ET-2005] Attendees Table being prepared twice

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 = [TBD] TBD =
 
 * Fix - Allow blank sender name and email to be stored within Tickets Emails settings. [ET-2008]
+* Fix - Corrected an issue where `attendees_table->prepare_items()` was being called multiple times. [ET-2005]
 
 = [TBD] TBD =
 

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -943,6 +943,10 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 	 * Prepares the list of items for displaying.
 	 */
 	public function prepare_items() {
+		if ( ! empty( $this->items ) ) {
+			return;
+		}
+
 		$this->process_actions();
 
 		$current_page = $this->get_pagenum();

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -941,12 +941,10 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 	/**
 	 * Prepares the list of items for displaying.
+	 *
+	 * @since TBD Adding caching to eliminate method running multiple times.
 	 */
 	public function prepare_items() {
-		if ( ! empty( $this->items ) ) {
-			return;
-		}
-
 		$this->process_actions();
 
 		$current_page = $this->get_pagenum();
@@ -965,6 +963,16 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		$event_id = Event::filter_event_id( filter_var( tribe_get_request_var( 'event_id' ), FILTER_VALIDATE_INT ), 'attendees-table' );
 		$search   = sanitize_text_field( tribe_get_request_var( $this->search_box_input_name ) );
+
+		/** @var Tribe__Cache $cache */
+		$cache     = tribe( 'cache' );
+		$cache_key = __METHOD__ . '-' . md5( wp_json_encode( $args ) . $event_id );
+		$cached    = $cache->get( $cache_key );
+
+		if ( $cached ) {
+			$this->items = $cached;
+			return $cached;
+		}
 
 		if ( ! empty( $search ) ) {
 			$search_keys = array_keys( $this->get_search_options() );
@@ -1045,6 +1053,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		}
 
 		$this->items = $items;
+		$cache->set( $cache_key, $items, 60 );
 
 		$this->set_pagination_args( $pagination_args );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2005]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->
In a previous MR we implemented an export button for the attendees table next to the title of the event. However, at that point on the page the attendees data wasn't isn't prepared yet. We run `prepare_items` at this point, and again later during page load. However, this causes an issue because `prepare_items` expects to only be ran once per a page. 

To mitigate this issue I added caching into the method so that if it runs multiple times on a page it uses the original data and returns early.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[artifact_etp_2005.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/f544d166-3e4f-481f-94c0-8a37fa9cfcf2)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2005]: https://stellarwp.atlassian.net/browse/ET-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ