### PR TITLE
[ET-2015] Adjusted the logic for calculating fees when using Stripe.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -207,6 +207,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Corrected an issue where `attendees_table->prepare_items()` was being called multiple times. [ET-2005]
 * Fix - Tickets block will be properly registered when creating a new post or page. [ET-2045]
 * Tweak - Added additional fields to the Event Tickets Site Health section. [ET-2017]
+* Tweak - Adjusted the logic for calculating fees when using Stripe. [ET-2015]
 
 = [5.8.3] 2024-03-12 =
 

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -594,12 +594,18 @@ class Settings {
 		$cache_key = __METHOD__;
 		$cached    = get_transient( $cache_key );
 
-		if ( ! empty( $cached ) ) {
-			return $cached;
+		// Decode the JSON string. If $cached is false (transient not set), json_decode returns null.
+		$cached_value = false !== $cached ? json_decode( $cached, true ) : null;
+
+		// Check explicitly for null to determine if the transient was not set.
+		if ( null !== $cached_value ) {
+			return $cached_value;
 		}
-		// Forcing a revalidate of is_current_license_valid can be expensive. Cache it for 1 hour.
+
 		$is_license_valid = $pue->is_current_license_valid( $revalidate );
-		set_transient( $cache_key, $is_license_valid, HOUR_IN_SECONDS );
+
+		// Forcing a revalidate of is_current_license_valid can be expensive. Cache it for 1 hour.
+		set_transient( $cache_key, wp_json_encode( $is_license_valid ), HOUR_IN_SECONDS );
 
 		return $is_license_valid;
 	}

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -567,8 +567,8 @@ class Settings {
 	/**
 	 * Is a valid license of Event Tickets Plus available?
 	 *
-	 * @since TBD Added caching.
 	 * @since 5.3.0
+	 * @since TBD Added caching.
 	 *
 	 * @param bool $revalidate whether to submit a new validation API request.
 	 *


### PR DESCRIPTION
### 🎫 Ticket

[ET-2015]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

In a previous PR (https://github.com/the-events-calendar/event-tickets/pull/2403) we removed certain parts of the `is_licensed_plugin` logic due to its resource-intensive nature, especially noticeable on the checkout page when Stripe is enabled.  This PR reintroduces the logic with the idea of caching the revalidation of `id_current_license_valid`. 

Scenario - 
When $revalidate is true we need to check the most recent license. This happens [here](https://github.com/the-events-calendar/event-tickets/blob/master/src/Tickets/Commerce/Gateways/Stripe/Application_Fee.php#L34). This method is always called when you checkout for Stripe to see if the fee must be added.

I added in additional caching when `$revalidate` is true. The cache will only last an hour and will help alleviate multiple calls to `is_current_license_valid` which is resource intensive.

I originally tackled this using Tribe Cache. However, I found that the value wasn't being kept in the cache and it was blank every page load. Therefore I moved forward using transients instead.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2015]: https://stellarwp.atlassian.net/browse/ET-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ