### PR TITLE
[ET-2017] ORM error with no providers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -206,6 +206,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - Allow blank sender name and email to be stored within Tickets Emails settings. [ET-2008]
 * Fix - Corrected an issue where `attendees_table->prepare_items()` was being called multiple times. [ET-2005]
 * Fix - Tickets block will be properly registered when creating a new post or page. [ET-2045]
+* Fix - Corrected an issue where the Post Tickets ORM method `filter_by_has_tickets` would prepare an empty statement. [ET-2017]
 * Tweak - Added additional fields to the Event Tickets Site Health section. [ET-2017]
 
 = [5.8.3] 2024-03-12 =

--- a/src/Tribe/Repositories/Traits/Post_Tickets.php
+++ b/src/Tribe/Repositories/Traits/Post_Tickets.php
@@ -341,6 +341,7 @@ trait Post_Tickets {
 	 *
 	 * @since 5.8.0
 	 * @since 5.8.3 Set $meta_keys to an empty array.
+	 * @since TBD Implemented a check for when $meta_keys is empty to not prepare anything for the query.
 	 *
 	 * @param string   $alias     The alias to use for the post meta table.
 	 * @param string[] $allow     A list of providers to include in the comparison. If this argument is `null`,
@@ -362,6 +363,10 @@ trait Post_Tickets {
 			}
 
 			$meta_keys[] = tribe( $provider )->get_event_key();
+		}
+
+		if ( empty( $meta_keys ) ) {
+			return '';
 		}
 
 		$unprepared = implode( " OR ", array_fill( 0, count( $meta_keys ), "$alias.meta_key = %s" ) );


### PR DESCRIPTION
While testing ET-2017] with no providers it was found that the query wasn't being built correctly.  When this scenario occurs I put an early return which fixes the issue.