### PR TITLE
[ET-2062] QR Code creating deprecation notices

### DIFF
--- a/vendor/phpqrcode/qrencode.php
+++ b/vendor/phpqrcode/qrencode.php
@@ -139,7 +139,7 @@ namespace TEC\Tickets\phpqrcode;
                 if($col >= $this->rsblocks[0]->dataLength) {
                     $row += $this->b1;
                 }
-				$ret = $this->rsblocks[$row]->data[(int)$col];
+				$ret = $this->rsblocks[(int)$row]->data[(int)$col];
             } else if($this->count < $this->dataLength + $this->eccLength) {
                 $row = ($this->count - $this->dataLength) % $this->blocks;
                 $col = ($this->count - $this->dataLength) / $this->blocks;

--- a/vendor/phpqrcode/qrencode.php
+++ b/vendor/phpqrcode/qrencode.php
@@ -139,7 +139,7 @@ namespace TEC\Tickets\phpqrcode;
                 if($col >= $this->rsblocks[0]->dataLength) {
                     $row += $this->b1;
                 }
-                $ret = $this->rsblocks[$row]->data[$col];
+				$ret = $this->rsblocks[$row]->data[(int)$col];
             } else if($this->count < $this->dataLength + $this->eccLength) {
                 $row = ($this->count - $this->dataLength) % $this->blocks;
                 $col = ($this->count - $this->dataLength) / $this->blocks;


### PR DESCRIPTION
### 🎫 Ticket

[ET-2062]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->
When using PHP 8.1+ deprecation notices are generated when a QR code is generated. The exact issue has to do with the index of the `rsblocks` index being a float instead of an integer. By casting it as an int we fix the deprecation notice and the QR codes continue to work properly.

Before PHP 8.1 it was automatically converted to an int.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.