### PR TITLE
[ET-2020] Correct Text Domain

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -196,6 +196,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correct the text domain for a couple of text strings so they could be translated appropriately. [ET-2020]
+
 = [5.8.4] 2024-03-25 =
 
 * Fix - Events Calendar Pro promo shouldn't show when it's already installed or when not editing an event. [ET-2018]

--- a/src/views/emails/template-parts/body/ticket/number-from-total.php
+++ b/src/views/emails/template-parts/body/ticket/number-from-total.php
@@ -35,7 +35,7 @@ if ( empty( $tickets ) || count( $tickets ) === 1 ) {
 	<?php
 		echo sprintf(
 			// Translators: %1$s: Tickets label, in singular. %2$s: Current ticket number over total. %3$s: Number of total Tickets.
-			esc_html__( '%1$s %2$s of %3$s', 'event_tickets' ),
+			esc_html__( '%1$s %2$s of %3$s', 'event-tickets' ),
 			tribe_get_ticket_label_singular( 'tec_tickets_email_ticket_total' ),
 			$i,
 			count( $tickets )

--- a/src/views/emails/template-parts/body/tickets-total.php
+++ b/src/views/emails/template-parts/body/tickets-total.php
@@ -34,7 +34,7 @@ if ( empty( $tickets ) || count( $tickets ) === 1 ) {
 		<?php
 		echo sprintf(
 			// Translators: %1$s: Number of total Tickets. %2$s: Tickets label, in plural.
-			esc_html__( '%1$s %2$s Total', 'event_tickets' ),
+			esc_html__( '%1$s %2$s Total', 'event-tickets' ),
 			count( $tickets ),
 			tribe_get_ticket_label_plural( 'tec_tickets_email_ticket_total' )
 		);


### PR DESCRIPTION
### 🎫 Ticket
[ET-2020]

### 🗒️ Description
We found two strings that had `event_tickets` as the text domain rather than `event-tickets`, causing these strings to be unavailable for translating. This PR fixes those.

### 🎥 Artifacts <!-- if applicable-->
Berfore: https://github.com/the-events-calendar/event-tickets/blob/d1e364a09b97f243811e5272d463d65f4ea48dfb/src/views/emails/template-parts/body/tickets-total.php#L37
After: https://github.com/the-events-calendar/event-tickets/blob/f07c14c8b2b427a70b95131019f425442f7aa286/src/views/emails/template-parts/body/tickets-total.php#L37

Before: https://github.com/the-events-calendar/event-tickets/blob/d1e364a09b97f243811e5272d463d65f4ea48dfb/src/views/emails/template-parts/body/ticket/number-from-total.php#L38
After: https://github.com/the-events-calendar/event-tickets/blob/f07c14c8b2b427a70b95131019f425442f7aa286/src/views/emails/template-parts/body/ticket/number-from-total.php#L38

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2020]: https://stellarwp.atlassian.net/browse/ET-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ