### PR TITLE
[ET-2061] Remove slashes from Tickets Emails subject line

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -200,6 +200,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 * Fix - The Attendee registration page will no longer generate warnings when viewing it. [ET-906]
 * Fix - When an event ticket is removed, it will no longer generate a 404 for the event. [TEC-5041]
+* Fix - Remove unwanted slashes from the Tickets Emails subject line. [ET-2061]
 * Fix - Correct the text domain for a couple of text strings so they could be translated appropriately. [ET-2020]
 * Fix - Changed incorrect file paths in DocBlocks for template overrides for all files in `src/views/tickets`. [ET-2004]
 

--- a/src/Tickets/Emails/Dispatcher.php
+++ b/src/Tickets/Emails/Dispatcher.php
@@ -545,6 +545,7 @@ class Dispatcher {
 	 *
 	 * @since 5.6.0
 	 * @since 5.8.3 Decodes the subject before sending the email.
+	 * @since TBD Removes slashes from the subject before sending the email.
 	 *
 	 * @return bool Whether the email was sent successfully.
 	 */
@@ -553,8 +554,8 @@ class Dispatcher {
 			return false;
 		}
 
-		// Handle any encoded characters in the subject.
-		$subject = wp_specialchars_decode( $this->get_subject() );
+		// Handle any encoded characters or slashes in the subject.
+		$subject = wp_unslash( wp_specialchars_decode( $this->get_subject() ) );
 
 		$sent = (bool) wp_mail(
 			$this->get_to(),


### PR DESCRIPTION
### 🎫 Ticket
[ET-2061]

### 🗒️ Description
There was a strange issue where, when using a placeholder within the subject line, and an apostrophe was put into the subject line AFTER the placeholder, a slash would be inserted into the subject line right before the apostrophe in the subject line.

### 🎥 Artifacts <!-- if applicable-->
Before:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/9f01fccd-a8b2-445e-bc41-265946cf8853)

After:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/7a4d3e20-ab1b-40af-9221-dd3be4b4ce8d)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2061]: https://stellarwp.atlassian.net/browse/ET-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ