### PR TITLE
[ET-2068] Fix `Get Tickets` button padding on focus and active

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -53,7 +53,7 @@ if ( tribe_is_not_min_php_version() ) {
 	 *
 	 * @since  4.10
 	 *
-	 * @param  array $names current list of names.
+	 * @param  array $names Current list of names.
 	 *
 	 * @return array
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -201,6 +201,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 * Fix - The Attendee registration page will no longer generate warnings when viewing it. [ET-906]
 * Fix - When an event ticket is removed, it will no longer generate a 404 for the event. [TEC-5041]
 * Fix - Remove unwanted slashes from the Tickets Emails subject line. [ET-2061]
+* Fix - `Get Tickets` button padding will be consistent in `active` and `focus` states. [ET-2068]
 * Fix - Correct the text domain for a couple of text strings so they could be translated appropriately. [ET-2020]
 * Fix - Changed incorrect file paths in DocBlocks for template overrides for all files in `src/views/tickets`. [ET-2004]
 

--- a/src/resources/postcss/components/buttons/_small.pcss
+++ b/src/resources/postcss/components/buttons/_small.pcss
@@ -18,11 +18,10 @@
 			padding: 11px 14px;
 			width: auto;
 
+			&:active,
+			&:disabled,
+			&:focus,
 			&:hover {
-				padding: 11px 14px;
-			}
-
-			&:disabled {
 				padding: 11px 14px;
 			}
 		}


### PR DESCRIPTION
### 🎫 Ticket
[ET-2068]

### 🗒️ Description
On `:active` and `:focus` states, the padding for the `Get Tickets` button was not consistent, causing the button to change in size sporadically.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/319a06b9b1a647d4beafda27d2b32ff6?sid=e13033fb-611a-4c6b-bd7b-1bf7d718f721

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2068]: https://stellarwp.atlassian.net/browse/ET-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ