### PR TITLE
Fix - Avoid fatal on order report screen if no tickets are added to event.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
+* Fix - Avoid fatal on order report page if no valid tickets are available for that event.
 * Fix - Fixed an issue with Ticket repository that was causing all tickets to be fetched for 0 as event ID. [ET-2023]
 * Fix - Display recurring events are not supported warning while adding tickets on Community Events. [ECP-1671]
 * Fix - The Attendee registration page will no longer generate warnings when viewing it. [ET-906]

--- a/readme.txt
+++ b/readme.txt
@@ -198,7 +198,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Fix - Avoid fatal on order report page if no valid tickets are available for that event.
+* Fix - Avoid error on order report page if no valid tickets are available for that event.
 * Fix - Fixed an issue with Ticket repository that was causing all tickets to be fetched for 0 as event ID. [ET-2023]
 * Fix - Display recurring events are not supported warning while adding tickets on Community Events. [ECP-1671]
 * Fix - The Attendee registration page will no longer generate warnings when viewing it. [ET-906]

--- a/src/Tickets/Commerce/Reports/Data/Order_Summary.php
+++ b/src/Tickets/Commerce/Reports/Data/Order_Summary.php
@@ -202,7 +202,7 @@ class Order_Summary {
 	protected function process_order_sales_data( string $status_slug, int $ticket_id, $item ): void {
 		$tickets = $this->get_tickets();
 
-		if ( ! $this->should_include_event_sales_data( $tickets[ $ticket_id ], $item ) ) {
+		if ( ! isset( $tickets[ $ticket_id ] ) || ! $this->should_include_event_sales_data( $tickets[ $ticket_id ], $item ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* This adds a fail-safe to avoid fatal when tickets are not available for order report page.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

🎥 screencast(s): https://www.loom.com/share/1fa81605c6af462ba4c3df8deebf4c02

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.