### PR TITLE
 [GTRIA-1260] - Adds attendee meta data to Tickets Commerce Completed Order emails

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -196,6 +196,11 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Adds attendee meta data to Tickets Commerce Completed Order emails. [GTRIA-1260]
+* Fix - Corrects override template URL for custom-fields.php template file. [GTRIA-1260]
+
 = [5.9.0] 2024-04-04 =
 
 * Feature - Sale Price for Tickets Commerce: Set a sale price for individual tickets for a certain duration of time within Tickets Commerce.

--- a/src/views/emails/template-parts/body/order/attendees-table/custom-fields.php
+++ b/src/views/emails/template-parts/body/order/attendees-table/custom-fields.php
@@ -19,11 +19,11 @@
  */
 
 // @todo @codingmusician: This needs to come from ET+
-if ( empty( $attendee['custom_fields'] ) ) {
+if ( empty( $attendee['attendee_meta'] ) ) {
 	return;
 }
 
 ?>
-<?php foreach ( $attendee['custom_fields'] as $custom_field ) : ?>
-	<div><?php echo esc_html( $custom_field['label'] ); ?> - <?php echo esc_html( $custom_field['value'] ); ?></div>
+<?php foreach ( $attendee['attendee_meta'] as $label => $value ) : ?>
+    <div><?php echo esc_html( $label ); ?> - <?php echo esc_html( $value ); ?></div>
 <?php endforeach; ?>

--- a/src/views/emails/template-parts/body/order/attendees-table/custom-fields.php
+++ b/src/views/emails/template-parts/body/order/attendees-table/custom-fields.php
@@ -3,7 +3,7 @@
  * Event Tickets Emails: Order Attendee Info
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/emails/template-parts/body/order/attendee-info.php
+ * [your-theme]/tribe/tickets/emails/template-parts/body/order/attendees-table/custom-fields.php
  *
  * See more documentation about our views templating system.
  *


### PR DESCRIPTION
### 🎫 Ticket

 [GTRIA-1260]

### 🗒️ Description

<!--
The template file is supposed to add attendee meta data to Tickets Commerce Completed Order emails but wasn't doing so. This PR fixes that.
This PR also corrects the override URL for the template file.
-->

### 🎥 Artifacts <!-- if applicable-->
Before: https://imgur.com/CjpVyqd
After: https://imgur.com/ea6PhRv

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.