### PR TITLE
[ET-2076] Paypal trailing slash

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -196,6 +196,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Corrected an issue where PayPal orders had an extra slash on the order table page. [ET-2076]
+
 = [5.9.1] 2024-04-17 =
 
 * Fix - Avoid error on order report page if no valid tickets are available for that event.

--- a/src/Tickets/Commerce/Gateways/PayPal/Order.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Order.php
@@ -21,7 +21,7 @@ class Order extends Abstract_Order {
 	 */
 	public function get_gateway_dashboard_url_by_order( \WP_Post $order ): string {
 		$status  = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
-		$payload = isset( $order->gateway_payload[ $status::SLUG ] ) ?? current( $order->gateway_payload );
+		$payload = $order->gateway_payload[$status::SLUG] ?? current($order->gateway_payload);
 
 		if ( ! is_array( $payload ) || empty( $payload ) ) {
 			return '';

--- a/src/Tickets/Commerce/Gateways/PayPal/Order.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Order.php
@@ -16,10 +16,12 @@ use Tribe__Utils__Array as Arr;
 class Order extends Abstract_Order {
 	/**
 	 * @inheritDoc
+	 *
+	 * @since TBD Fixed extra trailing slash.
 	 */
 	public function get_gateway_dashboard_url_by_order( \WP_Post $order ): string {
-		$status          = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
-		$payload         = isset( $order->gateway_payload[ $status::SLUG ] ) ? $order->gateway_payload[ $status::SLUG ] : current( $order->gateway_payload );
+		$status  = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
+		$payload = isset( $order->gateway_payload[ $status::SLUG ] ) ?? current( $order->gateway_payload );
 
 		if ( ! is_array( $payload ) || empty( $payload ) ) {
 			return '';
@@ -31,11 +33,11 @@ class Order extends Abstract_Order {
 		$paypal_base_url = 'https://www.paypal.com/';
 
 		$capture_link = Arr::get( $capture_payload, [ 'links', 0, 'href' ] );
-		// check if the link contains sandbox
+		// Check if the link contains sandbox.
 		if ( strpos( $capture_link, 'sandbox' ) !== false ) {
 			$paypal_base_url = 'https://sandbox.paypal.com/';
 		}
 
-		return sprintf( '%1$s/activity/payment/%2$s', $paypal_base_url, $capture_id );
+		return sprintf( '%1$s/activity/payment/%2$s', untrailingslashit( $paypal_base_url ), $capture_id );
 	}
 }

--- a/src/Tickets/Commerce/Gateways/PayPal/Order.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Order.php
@@ -21,7 +21,7 @@ class Order extends Abstract_Order {
 	 */
 	public function get_gateway_dashboard_url_by_order( \WP_Post $order ): string {
 		$status  = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
-		$payload = $order->gateway_payload[$status::SLUG] ?? current($order->gateway_payload);
+		$payload = $order->gateway_payload[ $status::SLUG ] ?? current( $order->gateway_payload );
 
 		if ( ! is_array( $payload ) || empty( $payload ) ) {
 			return '';


### PR DESCRIPTION
[ET-2076]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->
When displaying the PayPal payload link there was an extra slash when we concatenated the strings. This fixes the issue and cleans the code up a little bit.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/the-events-calendar/event-tickets/assets/12241059/a849dd9a-735a-434b-9f80-d4e1b4c801bc)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2076]: https://stellarwp.atlassian.net/browse/ET-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ