### PR TITLE
[ET-2074] Add font family to Sale Label so it's uniform

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -198,7 +198,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [TBD] TBD =
 
-* Fix - Updated sale label font to be uniform with other EVent Tickets elements. [ET-2074]
+* Fix - Updated sale label font to be uniform with other Event Tickets elements. [ET-2074]
 
 = [5.9.1] 2024-04-18 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -196,6 +196,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Updated sale label font to be uniform with other EVent Tickets elements. [ET-2074]
+
 = [5.9.1] 2024-04-18 =
 
 * Fix - Avoid error on order report page if no valid tickets are available for that event.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -54,7 +54,7 @@ class Tribe__Tickets__Main {
 	protected $min_tec_version = '6.3.0-dev';
 
 	/**
-	 * Name of the provider
+	 * Name of the provider.
 	 * @var string
 	 */
 	public $plugin_name;

--- a/src/resources/postcss/tickets/_block.pcss
+++ b/src/resources/postcss/tickets/_block.pcss
@@ -125,6 +125,7 @@
 		border-radius: var(--tec-spacer-2);
 		color: var(--tec-color-icon-focus);
 		display: inline-block;
+		font-family: var(--tec-font-family-sans-serif);
 		font-size: var(--tec-font-size-0);
 		font-weight: var(--tec-font-weight-bold);
 		margin-bottom: 5px;


### PR DESCRIPTION
### 🎫 Ticket
[ET-2074]

### 🗒️ Description
There were reports that the font of the sale label was inheriting the font from different themes, but we want the font to be uniform with the rest of the elements in ET

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/dc8895b1e5a7431eba5cbaf614072dd5?sid=c1e0ddcf-390b-46f3-89f4-9e10e066d8b0

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2074]: https://stellarwp.atlassian.net/browse/ET-2074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ