### PR TITLE
[GTRIA-1268] Corrected the Attendees page when languages other than English are used.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -196,6 +196,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [5.9.1.1] TBD =
+
+* Fix - Corrected the Attendees page when languages other than English are used. [GTRIA-1268]
+
 = [5.9.1] 2024-04-18 =
 
 * Fix - Avoid error on order report page if no valid tickets are available for that event.

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -186,6 +186,7 @@ class Settings {
 	 * Adds the Event Tickets menu and pages.
 	 *
 	 * @since 5.4.0
+	 * @since 5.9.1.1 Removed translation from the Title.
 	 */
 	public function add_admin_pages() {
 		$admin_pages = tribe( 'admin.pages' );
@@ -194,7 +195,7 @@ class Settings {
 			[
 				'id'       => static::$parent_slug,
 				'path'     => static::$parent_slug,
-				'title'    => esc_html__( 'Tickets', 'event-tickets' ),
+				'title'    => 'Tickets',
 				'icon'     => $this->get_menu_icon(),
 				'position' => 7,
 				'callback' => [

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -338,8 +338,8 @@ class Tribe__Tickets__Attendees {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'load_pointers' ] );
-		add_action( "load-{$this->page_id}", [ $this, 'screen_setup' ] );
-		add_action( "load-{$attendees_page_hook_suffix}", [ $this, 'screen_setup' ] );
+
+		$this->screen_setup();
 	}
 
 	/**

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -301,6 +301,7 @@ class Tribe__Tickets__Attendees {
 	 * Registers the Attendees admin page
 	 *
 	 * @since 4.6.2
+	 * @since 5.9.1.1 Moved from `load-` action to calling the `screen_setup` method directly.
 	 */
 	public function register_page() {
 		$cap      = 'edit_posts';

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -301,7 +301,6 @@ class Tribe__Tickets__Attendees {
 	 * Registers the Attendees admin page
 	 *
 	 * @since 4.6.2
-	 * @since 5.9.1.1 Moved from `load-` action to calling the `screen_setup` method directly.
 	 */
 	public function register_page() {
 		$cap      = 'edit_posts';
@@ -339,8 +338,8 @@ class Tribe__Tickets__Attendees {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'load_pointers' ] );
-
-		$this->screen_setup();
+		add_action( "load-{$this->page_id}", [ $this, 'screen_setup' ] );
+		add_action( "load-{$attendees_page_hook_suffix}", [ $this, 'screen_setup' ] );
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[GTRIA-1268]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->
When viewing the Attendees table under Tickets -> Attendees a fatal would be thrown if the language was something other than English. 

Rafsun and I found that the issue occured because `Tickets` was being translated and was changing the slug to the translated value instead of `tickets-*`. 


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[GTRIA-1268.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/111b354b-3f6c-4bbc-97bd-05f2c93b12a0)



### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[GTRIA-1268]: https://stellarwp.atlassian.net/browse/GTRIA-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ