### PR TITLE
Free Tickets: Allow in Both Editors

### DIFF
--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -132,6 +132,8 @@ class Hooks extends Service_Provider {
 		add_filter( 'wp_redirect', [ $this, 'filter_redirect_url' ] );
 
 		add_filter( 'tec_tickets_editor_configuration_localized_data', [ $this, 'filter_block_editor_localized_data' ] );
+
+		add_action( 'tribe_editor_config', [ $this, 'filter_tickets_editor_config' ] );
 	}
 
 	/**
@@ -792,5 +794,28 @@ class Hooks extends Service_Provider {
 		];
 
 		return $localized;
+	}
+
+	/**
+	 * Filters the data used to render the Tickets Block Editor control.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $data The data used to render the Tickets Block Editor control.
+	 *
+	 * @return array<string,mixed> The data used to render the Tickets Block Editor control.
+	 */
+	public function filter_tickets_editor_config( $data ) {
+		if ( ! isset( $data['tickets'] ) ) {
+			$data['tickets'] = [];
+		}
+
+		if ( ! isset( $data['tickets']['commerce'] ) ) {
+			$data['tickets']['commerce'] = [];
+		}
+
+		$data['tickets']['commerce']['isFreeTicketAllowed'] = tribe( Settings::class )->is_free_ticket_allowed();
+
+		return $data;
 	}
 }

--- a/src/Tickets/Commerce/Settings.php
+++ b/src/Tickets/Commerce/Settings.php
@@ -609,4 +609,22 @@ class Settings {
 
 		return $is_license_valid;
 	}
+
+	/**
+	 * Determine if free ticket is allowed in Tickets Commerce.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public static function is_free_ticket_allowed() {
+		/**
+		 * Filter to allow free tickets in Tickets Commerce.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $is_free_ticket_allowed Whether free tickets are allowed in Tickets Commerce.
+		 */
+		return apply_filters( 'tec_tickets_commerce_is_free_ticket_allowed', true );
+	}
 }

--- a/src/admin-views/editor/fieldset/price.php
+++ b/src/admin-views/editor/fieldset/price.php
@@ -23,11 +23,20 @@ $provider         = ! empty( $ticket_id ) ? tribe_tickets_get_ticket_provider( $
 
 $is_paypal_ticket = $provider instanceof Tribe__Tickets__Commerce__PayPal__Main || $provider instanceof \TEC\Tickets\Commerce\Module;
 
+// Determine whether or not free tickets are allowed.
+$is_free_ticket_allowed = true;
+if ( $provider instanceof Tribe__Tickets__Commerce__PayPal__Main ) {
+	$is_free_ticket_allowed = false;
+}
+if ( $provider instanceof \TEC\Tickets\Commerce\Module ) {
+	$is_free_ticket_allowed = tribe( \TEC\Tickets\Commerce\Settings::class )->is_free_ticket_allowed();
+}
+
 $description_string = sprintf( _x( 'Leave blank for free %s', 'price description', 'event-tickets' ), tribe_get_ticket_label_singular( 'price_description' ) );
 $description_string = esc_html( apply_filters( 'tribe_tickets_price_description', $description_string, $ticket_id ) );
-$price_description  = $is_paypal_ticket ? '' : $description_string;
+$price_description  = ! $is_free_ticket_allowed ? '' : $description_string;
 
-if ( $is_paypal_ticket ) {
+if ( ! $is_free_ticket_allowed ) {
 	$validation_attrs[] = 'data-required';
 	$validation_attrs[] = 'data-validation-is-greater-than="0"';
 }

--- a/src/modules/data/blocks/ticket/constants.js
+++ b/src/modules/data/blocks/ticket/constants.js
@@ -52,3 +52,6 @@ export const PRICE_POSITIONS = [ PREFIX, SUFFIX ];
 // eslint-disable-next-line no-undef
 export const TICKET_LABELS = window?.tribe_editor_config?.tickets?.ticketLabels;
 export const SALE_PRICE_LABELS = window?.tribe_editor_config?.tickets?.salePrice;
+
+// eslint-disable-next-line max-len
+export const IS_FREE_TC_TICKET_ALLOWED = window?.tribe_editor_config?.tickets?.commerce?.isFreeTicketAllowed;

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -17,6 +17,7 @@ const {
 	INDEPENDENT,
 	SHARED,
 	TICKET_TYPES,
+	IS_FREE_TC_TICKET_ALLOWED,
 } = constants;
 const { tickets: ticketsConfig, post: postConfig } = globals;
 
@@ -716,8 +717,16 @@ export const isTempSharedCapacityValid = createSelector(
 export const isZeroPriceValid = createSelector(
 	[ getTicketTempPrice, getTicketsProvider ],
 	( price, provider ) => {
-		return 0 < parseInt( price, 10 ) ||
-			! [ constants.TC_CLASS, constants.TICKETS_COMMERCE_MODULE_CLASS ].includes( provider );
+		if ( 0 < parseInt( price, 10 ) ) {
+			return true;
+		}
+		if ( constants.TC_CLASS === provider ) {
+			return false;
+		}
+		if ( constants.TICKETS_COMMERCE_MODULE_CLASS === provider ) {
+			return IS_FREE_TC_TICKET_ALLOWED;
+		}
+		return true;
 	},
 );
 


### PR DESCRIPTION
### 🎫 Ticket
[ET-2077]
[ET-2078]

### 🗒️ Description
Up until now, we have not allowed free tickets for Tickets Commerce. There was JavaScript validation in place for both the Classic and Block Editors that disallowed it. This PR removed that validation, but for those that want to still disallow the creation of free tickets for Tickets Commerce, we added a filter that puts the validation back in place.

### 🎥 Artifacts <!-- if applicable-->
Free Tickets Allowed:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/f42569ee-ade8-4dfe-be4e-e2cd6a5d3d2d)
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/719f7ebb-2126-4af5-9767-2ebf06d9192d)

Free Tickets Not Allowed (using filter):
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/6ccf91fd-1865-45e6-bcae-31f5ff645aea)
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/94ff8e3e-27a3-4e6e-9bcb-797abc41bc76)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.