### PR TITLE
[ET-2082] Stripe Payment Methods stuck in pending status

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -5,6 +5,7 @@ namespace TEC\Tickets\Commerce\Gateways\Stripe\Webhooks;
 use TEC\Tickets\Commerce\Gateways\Stripe\Status;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
+use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Gateways\Contracts\Webhook_Event_Interface;
 use TEC\Tickets\Commerce\Gateways\Stripe\Payment_Intent;
 use Tribe__Utils__Array as Arr;
@@ -44,6 +45,7 @@ class Charge_Webhook implements Webhook_Event_Interface {
 			$payment_intent
 			&& isset( $payment_intent['status'] )
 			&& Status::SUCCEEDED === $payment_intent['status']
+			&& Tribe( Pending::class )->get_wp_slug() !== $order->post_status
 		) {
 				$response->set_status( 200 );
 				$response->set_data(


### PR DESCRIPTION
### 🎫 Ticket

[ET-2082]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->
I added an additional check to see if the order is in Pending. If it is then ignore race condition check that we added previously. I added logic because with certain payment methods the orders were indefinitely stuck in Pending. [I narrowed it down to the race condition check we added earlier this year.](https://github.com/the-events-calendar/event-tickets/blob/master/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php#L43)

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[ET-2082.webm](https://github.com/the-events-calendar/event-tickets/assets/12241059/3a16c287-f2a0-46f3-ae66-8cc8f4234ca0)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2082]: https://stellarwp.atlassian.net/browse/ET-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ