### PR TITLE
Add variables to docblock

### DIFF
--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -647,7 +647,9 @@ class Tribe__Tickets__Attendees {
 
 		/**
 		 * Used to modify what columns should be shown on the CSV export.
-		 * The column name should be the Array Index and the Header is the array Value.
+		 * The column name should be the Array Index, and the Header should be the array Value.
+		 *
+		 * @since TBD
 		 *
 		 * @param array $export_columns Columns, associative array
 		 * @param array $items          Items to be exported

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -646,12 +646,12 @@ class Tribe__Tickets__Attendees {
 		);
 
 		/**
-		 * Used to modify what columns should be shown on the CSV export
-		 * The column name should be the Array Index and the Header is the array Value
+		 * Used to modify what columns should be shown on the CSV export.
+		 * The column name should be the Array Index and the Header is the array Value.
 		 *
-		 * @param array Columns, associative array
-		 * @param array Items to be exported
-		 * @param int   Event ID
+		 * @param array $export_columns Columns, associative array
+		 * @param array $items          Items to be exported
+		 * @param int   $event_id       Event ID
 		 */
 		$export_columns = apply_filters( 'tribe_events_tickets_attendees_csv_export_columns', $export_columns, $items, $event_id );
 


### PR DESCRIPTION
Variables were missing from the docblock. This likely influenced that our documentation on this filter was incompolete. https://www.dropbox.com/scl/fi/qqgf8qvjetg8inw1bs18b/shot_240502_160124.jpg?rlkey=ctce8mev4d8bp56f75kgxxiu6&dl=0

