### PR TITLE
[ET-2078] Allow Blank Price Field in Block Editor

### DIFF
--- a/src/Tickets/Blocks/Ticket/app/editor/container-content/price/style.pcss
+++ b/src/Tickets/Blocks/Ticket/app/editor/container-content/price/style.pcss
@@ -6,12 +6,6 @@
 .tribe-editor__ticket__price-label {
 	flex: none;
 	width: 140px;
-
-	&:after {
-		color: var(--tec-color-icon-error);
-		content: "*";
-		margin-left: var(--tec-spacer-0);
-	}
 }
 
 .tribe-editor__input.tribe-editor__ticket__price-input {

--- a/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
+++ b/src/Tribe/Editor/REST/V1/Endpoints/Single_Ticket.php
@@ -256,8 +256,13 @@ class Tribe__Tickets__Editor__REST__V1__Endpoints__Single_ticket
 			);
 		}
 
+		// If price field is left blank, we create a free ticket.
+		if ( isset( $body['price'] ) && '' === trim( $body['price'] ) ) {
+			$body['price'] = '0';
+		}
+
 		$is_paypal_ticket = $provider instanceof Tribe__Tickets__Commerce__PayPal__Main || $provider instanceof \TEC\Tickets\Commerce\Module;
-		$is_invalid_price = ( '' === trim( $body['price'] ) || ! is_numeric( $body['price'] ) || (float) $body['price'] < 0 );
+		$is_invalid_price = ! is_numeric( $body['price'] ) || (float) $body['price'] < 0;
 
 		if (
 			$is_paypal_ticket

--- a/tests/restv1/PayPal/SingleTicketCest.php
+++ b/tests/restv1/PayPal/SingleTicketCest.php
@@ -631,56 +631,6 @@ class SingleTicketCest extends BaseRestCest {
 			'post_id'          => $post_id,
 			'name'             => 'Test ticket name test 213',
 			'description'      => 'Test description text',
-			'price'            => '',
-			'start_date'       => '2023-08-24',
-			'start_time'       => '08:00:00',
-			'end_date'         => '2023-12-31',
-			'end_time'         => '20:00:00',
-			'sku'              => 'TKT-555',
-			'menu_order'       => 1,
-			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
-			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
-			'ticket' => [
-				'mode' => 'capped',
-				'capacity' => 100,
-				'event_capacity' => 100
-			]
-		];
-
-		$I->sendPOST( $ticket_create_rest_url, $create_args );
-
-		$I->seeResponseCodeIs( 400 );
-		$I->seeResponseIsJson();
-
-		$create_args = [
-			'post_id'          => $post_id,
-			'name'             => 'Test ticket name test 213',
-			'description'      => 'Test description text',
-			'price'            => ' ',
-			'start_date'       => '2023-08-24',
-			'start_time'       => '08:00:00',
-			'end_date'         => '2023-12-31',
-			'end_time'         => '20:00:00',
-			'sku'              => 'TKT-444',
-			'menu_order'       => 1,
-			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
-			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
-			'ticket' => [
-				'mode' => 'capped',
-				'capacity' => 100,
-				'event_capacity' => 100
-			]
-		];
-
-		$I->sendPOST( $ticket_create_rest_url, $create_args );
-
-		$I->seeResponseCodeIs( 400 );
-		$I->seeResponseIsJson();
-
-		$create_args = [
-			'post_id'          => $post_id,
-			'name'             => 'Test ticket name test 213',
-			'description'      => 'Test description text',
 			'price'            => "0,0",
 			'start_date'       => '2023-08-24',
 			'start_time'       => '08:00:00',
@@ -795,6 +745,56 @@ class SingleTicketCest extends BaseRestCest {
 			'name'             => 'Test ticket name test 213',
 			'description'      => 'Test description text',
 			'price'            => "0.00",
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-444',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 202 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => '',
+			'start_date'       => '2023-08-24',
+			'start_time'       => '08:00:00',
+			'end_date'         => '2023-12-31',
+			'end_time'         => '20:00:00',
+			'sku'              => 'TKT-555',
+			'menu_order'       => 1,
+			'add_ticket_nonce' => wp_create_nonce( 'add_ticket_nonce' ),
+			'provider'         => 'Tribe__Tickets__Commerce__PayPal__Main',
+			'ticket' => [
+				'mode' => 'capped',
+				'capacity' => 100,
+				'event_capacity' => 100
+			]
+		];
+
+		$I->sendPOST( $ticket_create_rest_url, $create_args );
+
+		$I->seeResponseCodeIs( 202 );
+		$I->seeResponseIsJson();
+
+		$create_args = [
+			'post_id'          => $post_id,
+			'name'             => 'Test ticket name test 213',
+			'description'      => 'Test description text',
+			'price'            => ' ',
 			'start_date'       => '2023-08-24',
 			'start_time'       => '08:00:00',
 			'end_date'         => '2023-12-31',


### PR DESCRIPTION
### 🎫 Ticket
[ET-2078]

### 🗒️ Description
Aside from entering '0' into the price field, we want to allow ticket creators to leave the price field blank within the Block Editor much like we do within the Classic Editor. This means that we also need to remove the asterisk that tells the user it's a required field.

### 🎥 Artifacts <!-- if applicable-->
Before:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/6e40460a-d43f-4c02-86d3-420cc0697bcf)

After:
![image](https://github.com/the-events-calendar/event-tickets/assets/7432506/3b3bb954-b658-4bf6-8cd9-30ce4b4ef64f)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2078]: https://stellarwp.atlassian.net/browse/ET-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ