### PR TITLE
Adds support for WPML

### DIFF
--- a/src/deprecated/Tribe__Tickets__Integrations__Manager.php
+++ b/src/deprecated/Tribe__Tickets__Integrations__Manager.php
@@ -49,6 +49,7 @@ class Tribe__Tickets__Integrations__Manager {
 	 */
 	public function load_integrations() {
 		tribe_singleton( 'tickets.integrations.freemius', Tribe__Tickets__Integrations__Freemius::class, [ 'setup' ] );
+		tribe_singleton( 'tickets.integrations.wpml', Tribe__Tickets__Integrations__WPML::class );
 		$this->hook();
 	}
 
@@ -63,6 +64,19 @@ class Tribe__Tickets__Integrations__Manager {
 	}
 
 	/**
+	 * Loads our WPML integration.
+	 *
+	 * @since TBD
+	 */
+	public function load_wpml() {
+		if ( ! apply_filters( 'wpml_setting', false, 'setup_complete' ) ) {
+			return false;
+		}
+
+		tribe( 'tickets.integrations.wpml' )->hook();
+	}
+
+	/**
 	 * Hooks for the integrations manager.
 	 *
 	 * @depreacated 5.6.0
@@ -70,5 +84,6 @@ class Tribe__Tickets__Integrations__Manager {
 	 */
 	public function hook() {
 		add_action( 'init', [ $this, 'load_freemius' ], 15 );
+		add_action( 'init', [ $this, 'load_wpml' ], 15 );
 	}
 }

--- a/src/deprecated/Tribe__Tickets__Integrations__WPML.php
+++ b/src/deprecated/Tribe__Tickets__Integrations__WPML.php
@@ -1,0 +1,40 @@
+<?php
+
+class Tribe__Tickets__Integrations__WPML {
+
+	public function hook() {
+		add_filter( 'tribe_tickets_get_tickets_query_args', $this->aggregate_translations( '_tribe_rsvp_for_event_in' ) );
+		add_filter( 'tribe_tickets_get_tickets_query_args', $this->aggregate_translations( '_tribe_wooticket_for_event_in' ) );
+		add_filter( 'tribe_tickets_get_tickets_query_args', $this->aggregate_translations( '_tribe_eddticket_for_event_in' ) );
+		add_filter( 'tribe_tickets_get_tickets_query_args', $this->aggregate_translations( '_tec_tickets_commerce_event_in' ) );
+	}
+
+	public function aggregate_translations( $key ) {
+		return function( $args ) use ( $key ) {
+			if ( ! isset( $args['meta_query'][ $key ]['value'] ) ) {
+				return $args;
+			}
+
+			$event_id = $args['meta_query'][ $key ]['value'];
+
+			if ( is_array( $event_id ) ) {
+				return $args;
+			}
+
+			$type = apply_filters( 'wpml_element_type', get_post_type( $event_id ) );
+			$args['meta_query'][ $key ]['value'] = wp_list_pluck(
+				apply_filters(
+					'wpml_get_element_translations',
+					$event_id,
+					apply_filters( 'wpml_element_trid', false, $event_id, $type ),
+					$type
+				),
+				'element_id'
+			);
+
+			return $args;
+		};
+	}
+
+}
+

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,24 @@
+<wpml-config>
+	<custom-types>
+		<custom-type translate="1">tec_tc_ticket</custom-type>
+	</custom-types>
+	<custom-fields>
+		<custom-field action="copy">_ticket_end_date</custom-field>
+		<custom-field action="copy">_ticket_start_date</custom-field>
+		<custom-field action="copy">_tribe_ticket_capacity</custom-field>
+		<custom-field action="copy">_tribe_ticket_show_description</custom-field>
+		<custom-field action="copy">_tribe_ticket_version</custom-field>
+		<custom-field action="copy">_tribe_tickets_ar_iac</custom-field>
+		<custom-field action="copy">_tribe_tickets_meta</custom-field>
+		<custom-field action="copy">_tribe_rsvp_for_event</custom-field>
+		<custom-field action="copy">_tribe_wooticket_for_event</custom-field>
+		<custom-field action="copy">_tribe_eddticket_for_event</custom-field>
+		<custom-field action="copy">_tec_tickets_commerce_event</custom-field>
+		<custom-field action="copy">_price</custom-field>
+		<custom-field action="copy">_sku</custom-field>
+		<custom-field action="copy">_stock</custom-field>
+		<custom-field action="copy">_stock_status</custom-field>
+		<custom-field action="copy">_manage_stock</custom-field>
+		<custom-field action="copy">_backorders</custom-field>
+	</custom-fields>
+</wpml-config>


### PR DESCRIPTION
The idea is to add the ids for the translation when querying the database. It is done in a way that we can reuse the code for WooCommerce, EDD & built-in tickets.

This is more a proof of concept to get the ball going so I didn't update the changelog and I don't have a ticket id to fill in the template.