### PR TITLE
SLR Feature - Typescript support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,8 @@
         "husky": "^1.3.1",
         "redux-devtools-extension": "^2.13.7",
         "redux-mock-store": "^1.5.3",
+        "ts-loader": "^8.1.0",
+        "typescript": "^5.4.5",
         "webpack": "^4.26.1",
         "webpack-bundle-analyzer": "^4.7.0",
         "webpack-cli": "^3.1.2",
@@ -27653,6 +27655,108 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-loader": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
+      "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^2.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "*"
+      }
+    },
+    "node_modules/ts-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ts-loader/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-loader/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-loader/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -27801,11 +27905,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -51817,6 +51920,76 @@
       "dev": true,
       "requires": {}
     },
+    "ts-loader": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
+      "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^2.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -51937,11 +52110,10 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "peer": true
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.33",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "husky": "^1.3.1",
     "redux-devtools-extension": "^2.13.7",
     "redux-mock-store": "^1.5.3",
+    "ts-loader": "^8.1.0",
+    "typescript": "^5.4.5",
     "webpack": "^4.26.1",
     "webpack-bundle-analyzer": "^4.7.0",
     "webpack-cli": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
   "_glotPressUrl": "https://translate.wordpress.org",
   "_glotPressSlug": "wp-plugins/event-tickets/stable",
   "_glotPressFileFormat": "%textdomain%-%wp_locale%.%format%",
-  "_glotPressFormats": [
-    "po",
-    "mo"
-  ],
+  "_glotPressFormats": ["po", "mo"],
   "_glotPressFilter": {
     "translation_sets": false,
     "minimum_percentage": 30,
@@ -82,10 +79,7 @@
     "zip": "node node_modules/@the-events-calendar/product-taskmaster/util/zip.js",
     "glotpress": "gulp glotpress"
   },
-  "engines": {
-    "node": "18.13.0",
-    "npm": "8.19.3"
-  },
+  "engines": { "node": "18.13.0", "npm": "8.19.3" },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@the-events-calendar/product-taskmaster": "^3.0.0",

--- a/src/Tickets/Seating/app/typescript-test/index.ts
+++ b/src/Tickets/Seating/app/typescript-test/index.ts
@@ -1,0 +1,17 @@
+type SelectedTicket = {
+	ticket_id: number;
+	quantity: number;
+	optout: boolean;
+};
+
+function createSelectedTicket(
+	ticketId: number,
+	quantity: number,
+	optout: boolean
+): SelectedTicket {
+	return {
+		ticket_id: ticketId,
+		quantity,
+		optout,
+	};
+}

--- a/src/Tickets/Seating/app/typescript-test/index.ts
+++ b/src/Tickets/Seating/app/typescript-test/index.ts
@@ -1,3 +1,8 @@
+import {
+	getIframeElement,
+	initServiceIframe,
+} from '@tec/tickets/seating/iframe';
+
 type SelectedTicket = {
 	ticket_id: number;
 	quantity: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true, // Throw an error if an expression does not have a type annotation.
+    "alwaysStrict": true, // Parse in strict mode and emit "use strict" for each source file.
+    "strictNullChecks": true,  // When type checking, take into account null and undefined.
+    "exactOptionalPropertyTypes": true, // When using an optional property, its value must be allowed.
+    "module": "es6", // When emitting modules, output ES6 modules.
+    "target": "es6", // When targeting ES6, use the ES6 JavaScript dialect.
+    "jsx": "react", // Specify JSX code generation, use React.
+    "allowJs": true, // Allow JavaScript files to be compiled.
+    "checkJs": false, // Do not report errors in .js files.
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
     "checkJs": false, // Do not report errors in .js files.
   },
   "include": [
-    "./src/**/*.ts",
-    "./src/**/*.tsx"
-  ]
+    "src/**/*",
+  ],
+  "moduleResolution": "bundler",
+  "paths": {
+    "@tec/tickets/seating/iframe*": ["./src/Tickets/Seating/app/service/iframe.js"],
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -201,6 +201,18 @@ const targets = [
 				'build/Seating/frontend/tickets-block.css',
 		},
 	},
+	{
+		name: 'typescript-test-bundle',
+		entry: './src/Tickets/Seating/app/typescript-test/index.ts',
+		outputScript: './build/Seating/typescript-test.min.js',
+		outputStyle: `build/Seating/typescript-test.${postfix}`,
+		moveFromTo: {
+			'src/resources/js/app/typescript-test-bundle.js':
+				'build/Seating/typescript-test.js',
+			'src/resources/css/app/typescript-test-bundle.css':
+				'build/Seating/typescript-test.css',
+		},
+	},
 ];
 
 // A function cannot be spread directly, we need this temporary variable.
@@ -227,8 +239,23 @@ const config = merge(common, {
 			'@tec/tickets/seating/currency': 'tec.tickets.seating.currency',
 		},
 	],
+
 	// Configure multiple entry points.
 	entry: targetEntries,
+
+	// Typescript support.
+	module: {
+		rules: [
+			{
+				test: /\.tsx?$/,
+				loader: 'ts-loader',
+				exclude: /node_modules/,
+			},
+		],
+	},
+	resolve: {
+		extensions: ['.ts', '.tsx', '.js', '.jsx'],
+	},
 });
 
 // WebPack 4 does support multiple entry and output points, but the plugins used by the build do not.


### PR DESCRIPTION
Add the `ts-loader` and `typescript` dependencies to work on WebPack 4
to allow using Typescript (`.ts` and `.tsx` files) in the project.

The current set up allows the co-existence and one-step compilation of
JS and Typescript files one along the other allowing for an incremental
refactoring.
