### PR TITLE
[ET-2104] Skip webhooks while on sandbox

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Signup.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Signup.php
@@ -49,6 +49,7 @@ class Signup extends Abstract_Signup {
 				'token'          => $this->get_client_id(),
 				'return_url'     => tribe( WhoDat::class )->get_api_url( 'connected' ),
 				'version'        => rawurlencode( Tickets_Plugin::VERSION ),
+				'mode'           => rawurlencode( tec_tickets_commerce_is_sandbox_mode() ? 'sandbox' : 'live' ),
 				// array_keys to expose only webhook ids. in values we have the webhook signing secrets we don't want exposed.
 				'known_webhooks' => array_map( 'rawurlencode', array_keys( tribe( Webhooks::class )->get_known_webhooks() ) ),
 			]
@@ -73,6 +74,7 @@ class Signup extends Abstract_Signup {
 				'stripe_user_id' => tribe( Merchant::class )->get_client_id(),
 				'return_url'     => rest_url( $this->signup_return_path ),
 				'version'        => rawurlencode( Tickets_Plugin::VERSION ),
+				'mode'           => rawurlencode( tec_tickets_commerce_is_sandbox_mode() ? 'sandbox' : 'live' ),
 				'known_webhooks' => array_map( 'rawurlencode', $known_webhooks ),
 			]
 		);

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks.php
@@ -256,6 +256,14 @@ class Webhooks extends Abstract_Webhooks {
 	 * @return bool
 	 */
 	public function handle_webhook_setup() {
+		if ( ! tec_tickets_commerce_is_enabled() ) {
+			return false;
+		}
+
+		if ( tec_tickets_commerce_is_sandbox_mode() ) {
+			return false;
+		}
+
 		if ( ! $this->get_merchant()->is_active() ) {
 			// Bail if Stripe is not active.
 			return false;
@@ -273,6 +281,7 @@ class Webhooks extends Abstract_Webhooks {
 				// We sent this so that WhoDat can check our domain visibility and build the webhook URL.
 				'home_url'       => rawurlencode( tribe( Return_Endpoint::class )->get_route_url() ),
 				'version'        => rawurlencode( Tickets_Plugin::VERSION ),
+				'mode'           => rawurlencode( tec_tickets_commerce_is_sandbox_mode() ? 'sandbox' : 'live' ),
 				// array_keys to expose only webhook ids. in values we have the webhoo signing secrets we don't want exposed.
 				'known_webhooks' => array_map( 'rawurlencode', array_keys( $this->get_known_webhooks() ) ),
 			]
@@ -300,6 +309,14 @@ class Webhooks extends Abstract_Webhooks {
 	 * @return bool
 	 */
 	public function disable_webhook(): bool {
+		if ( ! tec_tickets_commerce_is_enabled() ) {
+			return false;
+		}
+
+		if ( tec_tickets_commerce_is_sandbox_mode() ) {
+			return false;
+		}
+
 		if ( ! $this->get_merchant()->is_active() ) {
 			// Bail if Stripe is not active.
 			return false;
@@ -324,6 +341,7 @@ class Webhooks extends Abstract_Webhooks {
 				'stripe_user_id' => rawurlencode( tribe( Merchant::class )->get_client_id() ),
 				'home_url'       => rawurlencode( tribe( Return_Endpoint::class )->get_route_url() ),
 				'version'        => rawurlencode( Tickets_Plugin::VERSION ),
+				'mode'           => rawurlencode( tec_tickets_commerce_is_sandbox_mode() ? 'sandbox' : 'live' ),
 				'known_webhooks' => array_map( 'rawurlencode', $known_webhooks ),
 			]
 		);

--- a/src/admin-views/settings/tickets-commerce/stripe/webhook-description.php
+++ b/src/admin-views/settings/tickets-commerce/stripe/webhook-description.php
@@ -25,20 +25,31 @@ $webhooks = tribe( Webhooks::class );
 <?php if ( ! $webhooks->has_valid_signing_secret() ) : ?>
 	<p class="tec-tickets__admin-settings-tickets-commerce-gateway-group-description-stripe-webhooks contained">
 		<?php
-		$url = add_query_arg(
-			[
-				'action'   => Webhooks::NONCE_KEY_SETUP,
-				'tc_nonce' => wp_create_nonce( Webhooks::NONCE_KEY_SETUP ),
-			],
-			admin_url( '/admin-ajax.php' )
-		);
-		printf(
-			// Translators: %1$s A link to Stripe's API Webhook Documentation, %2$s closing `</a>` link, %3$s A link to the automatic webhook setup endpoint..
-			esc_html__( 'We can set up your %1$sWebhook automatically%2$s! Save your unsaved changes and then just click %3$shere%2$s!', 'event-tickets' ),
-			'<a target="_blank" rel="noopener noreferrer" href="https://docs.stripe.com/api/webhook_endpoints">',
-			'</a>',
-			'<a id="tec-tickets__admin-settings-webhook-set-up" data-loading-text="' . esc_attr__( 'Setting up your webhook!', 'event-tickets' ) . '" rel="noopener noreferrer" href="' . esc_url( $url ) . '">'
-		);
+		if ( tec_tickets_commerce_is_sandbox_mode() ) {
+			printf(
+				// Translators: %1$s A link to Stripe's API Webhook Documentation, %2$s closing `</a>` link, %3$s Opening <strong> tag, %4$s Closing </strong< tag.
+				esc_html__( 'We can set up your %1$sWebhook automatically%2$s %3$sonly on Production mode%4$s! Please switch your Tickets Commerce to Production if you would like us to set up your webhook.', 'event-tickets' ),
+				'<a target="_blank" rel="noopener noreferrer" href="https://docs.stripe.com/api/webhook_endpoints">',
+				'</a>',
+				'<strong>',
+				'</strong>'
+			);
+		} else {
+			$url = add_query_arg(
+				[
+					'action'   => Webhooks::NONCE_KEY_SETUP,
+					'tc_nonce' => wp_create_nonce( Webhooks::NONCE_KEY_SETUP ),
+				],
+				admin_url( '/admin-ajax.php' )
+			);
+			printf(
+				// Translators: %1$s A link to Stripe's API Webhook Documentation, %2$s closing `</a>` link, %3$s A link to the automatic webhook setup endpoint..
+				esc_html__( 'We can set up your %1$sWebhook automatically%2$s! Save your unsaved changes and then just click %3$shere%2$s!', 'event-tickets' ),
+				'<a target="_blank" rel="noopener noreferrer" href="https://docs.stripe.com/api/webhook_endpoints">',
+				'</a>',
+				'<a id="tec-tickets__admin-settings-webhook-set-up" data-loading-text="' . esc_attr__( 'Setting up your webhook!', 'event-tickets' ) . '" rel="noopener noreferrer" href="' . esc_url( $url ) . '">'
+			);
+		}
 		?>
 	</p>
 <?php endif; ?>


### PR DESCRIPTION
### 🎫 Ticket

[ET-2104]

Additional feature of #3048 

### 🗒️ Description

Now webhook management will be skipped when tickets commerce is disabled or is in staging mode.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2104]: https://stellarwp.atlassian.net/browse/ET-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ