### PR TITLE
SLR - fix Service message processing race condition

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,15 @@
-var sharedConfig = require( '@the-events-calendar/product-taskmaster/config/jest.config.js' );
-var pkg = require( './package.json' );
+const sharedConfig = require('@the-events-calendar/product-taskmaster/config/jest.config.js');
+const pkg = require('./package.json');
 
 module.exports = {
 	...sharedConfig,
 	displayName: 'tickets',
-	testMatch: pkg._filePath.jest.map( ( path ) => `<rootDir>/${ path }` ),
-	modulePathIgnorePatterns: [ '<rootDir>/common' ],
+	testMatch: pkg._filePath.jest.map((path) => `<rootDir>/${path}`),
+	modulePathIgnorePatterns: ['<rootDir>/common'],
+	moduleNameMapper: {
+		...sharedConfig.moduleNameMapper,
+		// Seating feature.
+		'^@tec/tickets/seating/tests/(.*)': '<rootDir>/tests/slr_jest/$1',
+		'^@tec/tickets/seating/(.*)': '<rootDir>/src/Tickets/Seating/app/$1',
+	},
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -29,3 +29,5 @@ global.mount = mount;
 global.renderer = renderer;
 
 moment.tz.setDefault( 'UTC' );
+
+import '@tec/tickets/seating/tests/_bootstrap.js';

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     ],
     "jest": [
       "src/modules/**/__tests__/**/*.js",
-      "src/resources/js/**/__tests__/**/*.js"
+      "src/resources/js/**/__tests__/**/*.js",
+      "tests/slr_jest/**/*.spec.js"
     ]
   },
   "scripts": {

--- a/src/Tickets/Seating/Service/Layouts.php
+++ b/src/Tickets/Seating/Service/Layouts.php
@@ -233,7 +233,7 @@ class Layouts {
 		wp_cache_delete( 'option_format_layouts', 'tec-tickets-seating' );
 
 		$invalidated = Layouts_Table::truncate() !== false &&
-		               Seat_Types_Table::truncate() !== false;
+						Seat_Types_Table::truncate() !== false;
 
 		/**
 		 * Fires after the caches and custom tables storing information about Layouts have been

--- a/src/Tickets/Seating/Service/Layouts.php
+++ b/src/Tickets/Seating/Service/Layouts.php
@@ -13,6 +13,7 @@ use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Seating\Meta;
 use TEC\Tickets\Seating\Tables\Layouts as Layouts_Table;
 use TEC\Tickets\Seating\Admin\Tabs\Layout_Card;
+use TEC\Tickets\Seating\Tables\Seat_Types as Seat_Types_Table;
 
 /**
  * Class Layouts.
@@ -231,7 +232,8 @@ class Layouts {
 		delete_transient( self::update_transient_name() );
 		wp_cache_delete( 'option_format_layouts', 'tec-tickets-seating' );
 
-		$invalidated = Layouts_Table::truncate() !== false;
+		$invalidated = Layouts_Table::truncate() !== false &&
+		               Seat_Types_Table::truncate() !== false;
 
 		/**
 		 * Fires after the caches and custom tables storing information about Layouts have been

--- a/src/Tickets/Seating/app/service/service-api/externals.js
+++ b/src/Tickets/Seating/app/service/service-api/externals.js
@@ -18,4 +18,8 @@ const layoutsHomeUrl = externals.layoutsHomeUrl.replace(/\/$/, '');
 const ajaxUrl = externals.ajaxUrl.replace(/\/$/, '');
 const ajaxNonce = externals.ajaxNonce;
 
+export function getBaseUrl(){
+	return baseUrl;
+}
+
 export { baseUrl, mapsHomeUrl, layoutsHomeUrl, ajaxUrl, ajaxNonce };

--- a/src/Tickets/Seating/app/service/service-api/state.js
+++ b/src/Tickets/Seating/app/service/service-api/state.js
@@ -22,20 +22,25 @@ import {
  * @property {string}                    token                 The token used to authenticate the connection.
  */
 
+/*
+ * @type {Object.<string, Function>}
+ */
+const defaultActionsMap = {
+	default: defaultMessageHandler,
+	[MAP_CREATED_UPDATED]: onMapCreatedUpdated,
+	[LAYOUT_CREATED_UPDATED]: onLayoutCreatedUpdated,
+	[SEAT_TYPE_CREATED_UPDATED]: onSeatTypeCreatedUpdated,
+	[GO_TO_MAPS_HOME]: onGoToMapsHome,
+	[GO_TO_LAYOUTS_HOME]: onGoToLayoutsHome,
+};
+
 /**
  * @type {State}
  */
 export const state = {
 	ready: false,
 	establishingReadiness: false,
-	actionsMap: {
-		default: defaultMessageHandler,
-		[MAP_CREATED_UPDATED]: onMapCreatedUpdated,
-		[LAYOUT_CREATED_UPDATED]: onLayoutCreatedUpdated,
-		[SEAT_TYPE_CREATED_UPDATED]: onSeatTypeCreatedUpdated,
-		[GO_TO_MAPS_HOME]: onGoToMapsHome,
-		[GO_TO_LAYOUTS_HOME]: onGoToLayoutsHome,
-	},
+	actionsMap: defaultActionsMap,
 	token: null,
 };
 
@@ -44,13 +49,16 @@ export const state = {
  *
  * @since TBD
  *
- * @param {string}        action         The action to get the handler for.
- * @param {Function|null} defaultHandler The default handler to use if none is found.
+ * @param {string} action The action to get the handler for.
  *
  * @return {Function|null} The handler for the action, or the default handler if none is found.
  */
-export function getHandlerForAction(action, defaultHandler) {
-	return state.actionsMap[action] || defaultHandler;
+export function getHandlerForAction(action) {
+	return (
+		state.actionsMap[action] ||
+		state.actionsMap.default ||
+		defaultMessageHandler
+	);
 }
 
 /**
@@ -99,6 +107,17 @@ export function setIsReady(isReady) {
 }
 
 /**
+ * Returns whether the Service is ready or not.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the Service is ready or not.
+ */
+export function getIsReady() {
+	return state.ready;
+}
+
+/**
  * Sets whether the Service is establishing readiness or not.
  *
  * @since TBD
@@ -107,6 +126,17 @@ export function setIsReady(isReady) {
  */
 export function setEstablishingReadiness(establishingReadiness) {
 	state.establishingReadiness = establishingReadiness;
+}
+
+/**
+ * Returns whether the Service is establishing readiness or not.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the Service is establishing readiness or not.
+ */
+export function getEstablishingReadiness() {
+	return state.establishingReadiness;
 }
 
 /**
@@ -129,4 +159,20 @@ export function setToken(token) {
  */
 export function getToken() {
 	return state.token;
+}
+
+/**
+ * Resets the state to its default values.
+ *
+ * This is useful for testing and should not be used in production.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+export function reset() {
+	state.ready = false;
+	state.establishingReadiness = false;
+	state.actionsMap = defaultActionsMap;
+	state.token = null;
 }

--- a/tests/slr_integration/Admin/Ajax_Test.php
+++ b/tests/slr_integration/Admin/Ajax_Test.php
@@ -20,74 +20,12 @@ class Ajax_Test extends Controller_Test_Case {
 
 	/**
 	 * @before
-	 */
-	protected function become_administator(): void {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
-	}
-
-	/**
-	 * @before
 	 * @after
 	 */
 	public function truncate_tables(): void {
 		Maps::truncate();
 		Seat_Types_Table::truncate();
 		Layouts::truncate();
-	}
-
-	private function given_maps_in_db(): void {
-		\TEC\Tickets\Seating\Service\Maps::insert_rows_from_service( [
-			[
-				'id'            => 'some-map-1',
-				'name'          => 'Some Map 1',
-				'seats'         => 10,
-				'screenshotUrl' => 'https://example.com/some-map-1.png',
-			],
-			[
-				'id'            => 'some-map-2',
-				'name'          => 'Some Map 2',
-				'seats'         => 20,
-				'screenshotUrl' => 'https://example.com/some-map-2.png',
-			],
-			[
-				'id'            => 'some-map-3',
-				'name'          => 'Some Map 3',
-				'seats'         => 30,
-				'screenshotUrl' => 'https://example.com/some-map-3.png',
-			],
-		] );
-	}
-
-
-	private function given_maps_and_layouts_in_db(): void {
-		$this->given_maps_in_db();
-
-		\TEC\Tickets\Seating\Service\Layouts::insert_rows_from_service( [
-			[
-				'id'            => 'some-layouts-1',
-				'name'          => 'Some Layout 1',
-				'seats'         => 10,
-				'createdDate'   => time() * 1000,
-				'mapId'         => 'some-map-1',
-				'screenshotUrl' => 'https://example.com/some-layouts-1.png',
-			],
-			[
-				'id'            => 'some-layouts-2',
-				'name'          => 'Some Layout 2',
-				'seats'         => 20,
-				'createdDate'   => time() * 1000,
-				'mapId'         => 'some-map-2',
-				'screenshotUrl' => 'https://example.com/some-layouts-2.png',
-			],
-			[
-				'id'            => 'some-layouts-3',
-				'name'          => 'Some Layout 3',
-				'seats'         => 30,
-				'createdDate'   => time() * 1000,
-				'mapId'         => 'some-map-3',
-				'screenshotUrl' => 'https://example.com/some-layouts-3.png',
-			],
-		] );
 	}
 
 	/**
@@ -243,6 +181,91 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
 	}
 
+	private function given_maps_and_layouts_in_db(): void {
+		$this->given_maps_in_db();
+
+		\TEC\Tickets\Seating\Service\Layouts::insert_rows_from_service( [
+			[
+				'id'            => 'some-layout-1',
+				'name'          => 'Some Layout 1',
+				'seats'         => 10,
+				'createdDate'   => time() * 1000,
+				'mapId'         => 'some-map-1',
+				'screenshotUrl' => 'https://example.com/some-layouts-1.png',
+			],
+			[
+				'id'            => 'some-layout-2',
+				'name'          => 'Some Layout 2',
+				'seats'         => 20,
+				'createdDate'   => time() * 1000,
+				'mapId'         => 'some-map-2',
+				'screenshotUrl' => 'https://example.com/some-layouts-2.png',
+			],
+			[
+				'id'            => 'some-layout-3',
+				'name'          => 'Some Layout 3',
+				'seats'         => 30,
+				'createdDate'   => time() * 1000,
+				'mapId'         => 'some-map-3',
+				'screenshotUrl' => 'https://example.com/some-layouts-3.png',
+			],
+		] );
+
+		\TEC\Tickets\Seating\Tables\Seat_Types::insert_many( [
+			[
+				'id'     => 'some-seat-type-1',
+				'name'   => 'Some Seat Type 1',
+				'seats'  => 10,
+				'map'    => 'some-map-1',
+				'layout' => 'some-layout-1',
+			],
+			[
+				'id'     => 'some-seat-type-2',
+				'name'   => 'Some Seat Type 2',
+				'seats'  => 20,
+				'map'    => 'some-map-2',
+				'layout' => 'https://example.com/some-seat-types-2.png',
+			],
+			[
+				'id'     => 'some-seat-type-3',
+				'name'   => 'Some Seat Type 3',
+				'seats'  => 30,
+				'map'    => 'some-map-3',
+				'layout' => 'some-layout-3',
+			],
+		] );
+	}
+
+	/**
+	 * @before
+	 */
+	protected function become_administator(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	private function given_maps_in_db(): void {
+		\TEC\Tickets\Seating\Service\Maps::insert_rows_from_service( [
+			[
+				'id'            => 'some-map-1',
+				'name'          => 'Some Map 1',
+				'seats'         => 10,
+				'screenshotUrl' => 'https://example.com/some-map-1.png',
+			],
+			[
+				'id'            => 'some-map-2',
+				'name'          => 'Some Map 2',
+				'seats'         => 20,
+				'screenshotUrl' => 'https://example.com/some-map-2.png',
+			],
+			[
+				'id'            => 'some-map-3',
+				'name'          => 'Some Map 3',
+				'seats'         => 30,
+				'screenshotUrl' => 'https://example.com/some-map-3.png',
+			],
+		] );
+	}
+
 	public function test_invalidate_maps_layouts_cache_with_invalid_nonce(): void {
 		$this->given_maps_and_layouts_in_db();
 		$this->become_administator();
@@ -264,6 +287,7 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 403, $sent_code );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_maps_layouts_cache_with_valid_nonce(): void {
@@ -285,6 +309,7 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertTrue( $success );
 		$this->assertCount( 0, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 0, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 0, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_maps_layouts_cache_with_maps_invalidation_failure(): void {
@@ -311,6 +336,7 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 403, $sent_code );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_maps_layouts_cache_with_layouts_invalidation_failure(): void {
@@ -337,6 +363,7 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 403, $sent_code );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_layouts_cache_without_nonce(): void {
@@ -359,12 +386,13 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 403, $sent_code );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_layouts_cache_with_invalid_nonce(): void {
 		$this->given_maps_and_layouts_in_db();
 		$this->become_administator();
-		$invalid_nonce         = wp_create_nonce( 'something_else' );
+		$invalid_nonce           = wp_create_nonce( 'something_else' );
 		$_REQUEST['_ajax_nonce'] = $invalid_nonce;
 		$_POST['_ajax_nonce']    = $invalid_nonce;
 		$sent_data               = null;
@@ -383,6 +411,7 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 403, $sent_code );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_layouts_cache_with_valid_nonce(): void {
@@ -404,6 +433,7 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertTrue( $success );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 0, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 0, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 
 	public function test_invalidate_layouts_cache_with_layouts_invalidation_failure(): void {
@@ -430,5 +460,6 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 403, $sent_code );
 		$this->assertCount( 3, iterator_to_array( Maps::fetch_all() ) );
 		$this->assertCount( 3, iterator_to_array( Layouts::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
 	}
 }

--- a/tests/slr_jest/_bootstrap.js
+++ b/tests/slr_jest/_bootstrap.js
@@ -1,0 +1,14 @@
+// This file will be loaded by the Jest setup file.
+global.tec = global.tec || {};
+global.tec.tickets = global.tec.tickets || {};
+global.tec.tickets.seating = {
+	service: {
+		baseUrl: 'https://wordpress.test',
+		mapsHomeUrl:
+			'https://wordpress.test/wp-admin/admin.php?page=tec-tickets-seating&tab=layouts',
+		layoutsHomeUrl:
+			'https://wordpress.test/wp-admin/admin.php?page=tec-tickets-seating&tab=layouts',
+		ajaxUrl: 'https://wordpress.test/wp-admin/admin-ajax.php',
+		ajaxNonce: '1234567890',
+	},
+};

--- a/tests/slr_jest/service-api.spec.js
+++ b/tests/slr_jest/service-api.spec.js
@@ -1,0 +1,345 @@
+import {
+	registerAction,
+	reset,
+	setToken,
+} from '@tec/tickets/seating/service/service-api/state';
+import {
+	catchMessage,
+	getHandlerQueue,
+	sendPostMessage,
+	emptyHandlerQueue,
+} from '@tec/tickets/seating/service/service-api';
+
+describe('Service API', () => {
+	beforeEach(() => {
+		reset();
+		emptyHandlerQueue();
+	});
+
+	afterAll(() => {
+		reset();
+		emptyHandlerQueue();
+	});
+
+	it('should reject messages missing origin', () => {
+		setToken('test-token');
+		const event = {
+			origin: null,
+			data: {
+				token: 'test-token',
+				action: 'test-action',
+				data: 'test-data',
+			},
+		};
+
+		const callback = jest.fn();
+		registerAction('test-action', callback);
+		catchMessage(event);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('should reject messages with origin not matching base URL', () => {
+		setToken('test-token');
+		const event = {
+			origin: 'https://wordpress.test/foo',
+			data: {
+				token: 'test-token',
+				action: 'test-action',
+				data: 'test-data',
+			},
+		};
+
+		const callback = jest.fn();
+		registerAction('test-action', callback);
+		catchMessage(event);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('should reject messages with missing token', () => {
+		const event = {
+			origin: 'https://wordpress.test',
+			data: {
+				action: 'test-action',
+				data: 'test-data',
+			},
+		};
+
+		const callback = jest.fn();
+		registerAction('test-action', callback);
+		catchMessage(event);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('should reject messages with mismatching token', () => {
+		setToken('test-token');
+		const event = {
+			origin: 'https://wordpress.test',
+			data: {
+				token: 'test-token-mismatch',
+				action: 'test-action',
+				data: 'test-data',
+			},
+		};
+
+		const callback = jest.fn();
+		registerAction('test-action', callback);
+		catchMessage(event);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('should allow catching messages', () => {
+		setToken('test-token');
+		const message = new MessageEvent('message', {
+			origin: 'https://wordpress.test',
+			data: {
+				action: 'test-action',
+				token: 'test-token',
+				data: {
+					test: 'data',
+				},
+			},
+		});
+
+		const callback = jest.fn();
+		registerAction('test-action', callback);
+		catchMessage(message);
+
+		expect(callback).toHaveBeenCalledWith({
+			test: 'data',
+		});
+	});
+
+	it('should allow sending messages to an iframe', () => {
+		const iframe = {
+			closest: jest.fn().mockReturnValue({
+				dataset: {
+					token: 'test-token',
+				},
+			}),
+			contentWindow: {
+				postMessage: jest.fn(),
+			},
+		};
+
+		sendPostMessage(iframe, 'test-action', {
+			test: 'data',
+		});
+
+		expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+			{
+				action: 'test-action',
+				token: 'test-token',
+				data: {
+					test: 'data',
+				},
+			},
+			'https://wordpress.test'
+		);
+	});
+
+	it('should run actions for catched messages sequentially', async () => {
+		setToken('test-token');
+		const iframe = {
+			closest: jest.fn().mockReturnValue({
+				dataset: {
+					token: 'test-token',
+				},
+			}),
+			contentWindow: {
+				postMessage: jest.fn(),
+			},
+		};
+
+		const callback1 = jest.fn();
+		const callback2 = jest.fn();
+		const callback3 = jest.fn();
+		registerAction('test-action-1', callback1);
+		registerAction('test-action-2', callback2);
+		registerAction('test-action-3', callback3);
+
+		expect(callback1).not.toHaveBeenCalled();
+		expect(callback2).not.toHaveBeenCalled();
+		expect(callback3).not.toHaveBeenCalled();
+
+		catchMessage(
+			new MessageEvent('message', {
+				origin: 'https://wordpress.test',
+				data: {
+					action: 'test-action-2',
+					token: 'test-token',
+					data: {
+						test: 'data-2',
+					},
+				},
+			})
+		);
+
+		expect(callback1).not.toHaveBeenCalled();
+		expect(callback2).toHaveBeenCalledWith({
+			test: 'data-2',
+		});
+		expect(callback3).not.toHaveBeenCalled();
+
+		catchMessage(
+			new MessageEvent('message', {
+				origin: 'https://wordpress.test',
+				data: {
+					action: 'test-action-3',
+					token: 'test-token',
+					data: {
+						test: 'data-3',
+					},
+				},
+			})
+		);
+
+		// Wait 10 ms to let the queue process asynchronously.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(callback1).not.toHaveBeenCalled();
+		expect(callback2).toHaveBeenCalledWith({
+			test: 'data-2',
+		});
+		expect(callback3).toHaveBeenCalledWith({
+			test: 'data-3',
+		});
+
+		catchMessage(
+			new MessageEvent('message', {
+				origin: 'https://wordpress.test',
+				data: {
+					action: 'test-action-1',
+					token: 'test-token',
+					data: {
+						test: 'data-1',
+					},
+				},
+			})
+		);
+
+		// Wait 10 ms to let the queue process asynchronously.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(callback1).toHaveBeenCalledWith({
+			test: 'data-1',
+		});
+		expect(callback2).toHaveBeenCalledWith({
+			test: 'data-2',
+		});
+		expect(callback3).toHaveBeenCalledWith({
+			test: 'data-3',
+		});
+	});
+
+	it('should wait resolution and call async handlers in sequence', async () => {
+		setToken('test-token');
+
+		let resolvePromise1;
+		let resolvePromise2;
+		let resolvePromise3;
+
+		const asyncHandler1 = async () => {
+			return new Promise((resolve) => {
+				resolvePromise1 = resolve;
+			});
+		};
+		const asyncHandler2 = async () => {
+			return new Promise((resolve) => {
+				resolvePromise2 = resolve;
+			});
+		};
+		const asyncHandler3 = async () => {
+			return new Promise((resolve) => {
+				resolvePromise3 = resolve;
+			});
+		};
+
+		registerAction('test-action-1', asyncHandler1);
+		registerAction('test-action-2', asyncHandler2);
+		registerAction('test-action-3', asyncHandler3);
+
+		expect(getHandlerQueue()).toStrictEqual([]);
+
+		const messageEvent1 = new MessageEvent('message', {
+			origin: 'https://wordpress.test',
+			data: {
+				action: 'test-action-1',
+				token: 'test-token',
+				data: {
+					test: 'data-1',
+				},
+			},
+		});
+		catchMessage(messageEvent1);
+
+		expect(getHandlerQueue()).toStrictEqual([
+			['test-action-1', asyncHandler1, messageEvent1],
+		]);
+
+		const messageEvent2 = new MessageEvent('message', {
+			origin: 'https://wordpress.test',
+			data: {
+				action: 'test-action-2',
+				token: 'test-token',
+				data: {
+					test: 'data-2',
+				},
+			},
+		});
+		catchMessage(messageEvent2);
+
+		// Wait 10 ms to let the queue process asynchronously.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(getHandlerQueue()).toStrictEqual([
+			['test-action-1', asyncHandler1, messageEvent1],
+			['test-action-2', asyncHandler2, messageEvent2],
+		]);
+
+		resolvePromise1();
+
+		// Wait 10 ms to let the queue process asynchronously.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(getHandlerQueue()).toStrictEqual([
+			['test-action-2', asyncHandler2, messageEvent2],
+		]);
+
+		const messageEvent3 = new MessageEvent('message', {
+			origin: 'https://wordpress.test',
+			data: {
+				action: 'test-action-3',
+				token: 'test-token',
+				data: {
+					test: 'data-3',
+				},
+			},
+		});
+		catchMessage(messageEvent3);
+
+		expect(getHandlerQueue()).toStrictEqual([
+			['test-action-2', asyncHandler2, messageEvent2],
+			['test-action-3', asyncHandler3, messageEvent3],
+		]);
+
+		resolvePromise2();
+
+		// Wait 10 ms to let the queue process asynchronously.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(getHandlerQueue()).toStrictEqual([
+			['test-action-3', asyncHandler3, messageEvent3],
+		]);
+
+		resolvePromise3();
+
+		// Wait 10 ms to let the queue process asynchronously.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(getHandlerQueue()).toStrictEqual([]);
+	});
+});

--- a/tests/slr_jest/state.spec.js
+++ b/tests/slr_jest/state.spec.js
@@ -1,0 +1,110 @@
+import {
+	getEstablishingReadiness,
+	getHandlerForAction,
+	getIsReady,
+	getToken,
+	registerAction,
+	removeAction,
+	setEstablishingReadiness,
+	setIsReady,
+	setToken,
+	reset,
+} from '@tec/tickets/seating/service/service-api/state';
+import {
+	GO_TO_LAYOUTS_HOME,
+	GO_TO_MAPS_HOME,
+	INBOUND_APP_READY,
+	INBOUND_APP_READY_FOR_DATA,
+	INBOUND_SEATS_SELECTED,
+	LAYOUT_CREATED_UPDATED,
+	MAP_CREATED_UPDATED,
+	OUTBOUND_HOST_READY,
+	OUTBOUND_SEAT_TYPE_TICKETS,
+	SEAT_TYPE_CREATED_UPDATED,
+} from '@tec/tickets/seating/service/service-api/service-actions';
+import {
+	defaultMessageHandler,
+	onGoToLayoutsHome,
+	onGoToMapsHome,
+	onLayoutCreatedUpdated,
+	onMapCreatedUpdated,
+	onSeatTypeCreatedUpdated,
+} from '@tec/tickets/seating/service/service-api/message-handlers';
+
+describe('State', () => {
+	beforeEach(() => {
+		reset();
+	});
+
+	afterAll(() => {
+		reset();
+	});
+
+	it('should register some actions by default', () => {
+		expect(getHandlerForAction('default')).toBe(defaultMessageHandler);
+		expect(getHandlerForAction(INBOUND_APP_READY)).toBe(
+			defaultMessageHandler
+		);
+		expect(getHandlerForAction(INBOUND_APP_READY_FOR_DATA)).toBe(
+			defaultMessageHandler
+		);
+		expect(getHandlerForAction(INBOUND_SEATS_SELECTED)).toBe(
+			defaultMessageHandler
+		);
+		expect(getHandlerForAction(OUTBOUND_HOST_READY)).toBe(
+			defaultMessageHandler
+		);
+		expect(getHandlerForAction(OUTBOUND_SEAT_TYPE_TICKETS)).toBe(
+			defaultMessageHandler
+		);
+		expect(getHandlerForAction(MAP_CREATED_UPDATED)).toBe(
+			onMapCreatedUpdated
+		);
+		expect(getHandlerForAction(LAYOUT_CREATED_UPDATED)).toBe(
+			onLayoutCreatedUpdated
+		);
+		expect(getHandlerForAction(SEAT_TYPE_CREATED_UPDATED)).toBe(
+			onSeatTypeCreatedUpdated
+		);
+		expect(getHandlerForAction(GO_TO_MAPS_HOME)).toBe(onGoToMapsHome);
+		expect(getHandlerForAction(GO_TO_LAYOUTS_HOME)).toBe(onGoToLayoutsHome);
+	});
+
+	it('should return the default handler for an action that is not registered', () => {
+		expect(getHandlerForAction('unknown')).toBe(defaultMessageHandler);
+	});
+
+	it('should allow registering and deregistering an action', () => {
+		const callback = () => {};
+		registerAction('test-action', callback);
+
+		expect(getHandlerForAction('test-action')).toBe(callback);
+
+		removeAction('test-action');
+
+		expect(getHandlerForAction('test-action')).toBe(defaultMessageHandler);
+	});
+
+	it('should allow controlling ready and establishing readiness state', () => {
+		expect(getIsReady()).toBe(false);
+		expect(getEstablishingReadiness()).toBe(false);
+
+		setIsReady(true);
+		setEstablishingReadiness(true);
+
+		expect(getIsReady()).toBe(true);
+		expect(getEstablishingReadiness()).toBe(true);
+	});
+
+	it('should allow setting and unsetting the ephemeral token', () => {
+		expect(getToken()).toBe(null);
+
+		setToken('test-token');
+
+		expect(getToken()).toBe('test-token');
+
+		setToken(null);
+
+		expect(getToken()).toBe(null);
+	});
+});


### PR DESCRIPTION
The service will send messages in order to sync with the site.

The previous message queue implementation relied on the actions associated to the messages being all sync, thus processing them as soon as they arrived it made sense.

A sync message processing system is not able, though, to process sync and `async` handlers correctly though, as illustrated by this case:

1. The user edits a layout and clicks save.
2. The service sends the `LAYOUT_CREATED_UPDATED` message
3. The site message processing system fires the handler starting an AJAX request to the backend to trigger invalidation of the caches.  This call takes time and is done by an `async` handler waiting on the `fetch` response with `await fetch( ... )`
3. The service sends the `GO_TO_LAYOUTS_HOME` message
4. The site immediately calles the sync handler that will redirect the user to the maps home

Depending on the situation, 3 and 4 might happen before the AJAX-calling function in 2 is done, or even started. This will cause the effect of 2 (cache invalidation) to never happen.

To fix this I've rewritten the message processing sytem to treat **all** message handlers are `async` and wait for one to be done to call the next. This creates a queue that is processed in asynchronous mode.  The implementation relies on the fact that one can `wait` on **any** function, not just `async` functions.

This code will log `23`:

```javascript
const getNum = () => 23;
const number = await getNum();
console.log(number);
```

Since I felt queasy setting up things without tests, I've extended the current Jest tests to include the Seating feature in the `tests/slr_jest` directory.
