### PR TITLE
Avoid TEC dependency in orders page

### DIFF
--- a/src/Tickets/Commerce/Admin/Orders_Page.php
+++ b/src/Tickets/Commerce/Admin/Orders_Page.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Commerce\Admin;
 
 use TEC\Tickets\Commerce\Order;
 use Tribe\Admin\Pages;
+use Exception;
 
 /**
  * Class Orders_Page.
@@ -51,6 +52,21 @@ class Orders_Page {
 			[],
 			[ 'admin_enqueue_scripts' ],
 			[ 'conditionals' => [ $this, 'is_admin_orders_page' ] ]
+		);
+
+		// We only want to load this script if The Events Calendar is not active.
+		tribe_asset(
+			tribe( 'tickets.main' ),
+			'event-tickets-commerce-admin-orders',
+			'admin/orders/table.js',
+			[
+				'jquery',
+				'jquery-ui-dialog',
+				'jquery-ui-datepicker',
+				'tribe-attrchange',
+			],
+			[ 'admin_enqueue_scripts' ],
+			[ 'conditionals' => [ $this, 'is_admin_orders_page_and_no_TEC' ] ]
 		);
 	}
 
@@ -163,5 +179,28 @@ class Orders_Page {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if the current screen is the orders page and the Tickets Events Calendar is not active.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_admin_orders_page_and_no_TEC() {
+		if ( ! $this->is_admin_orders_page() ) {
+			return false;
+		}
+
+		try {
+			tribe( 'tec.main' );
+		} catch ( Exception $e ) {
+			// If the Tickets Events Calendar is not active, return true.
+			return true;
+		}
+
+		// If the Tickets Events Calendar is active, return false.
+		return false;
 	}
 }

--- a/src/Tickets/Commerce/Admin/Orders_Page.php
+++ b/src/Tickets/Commerce/Admin/Orders_Page.php
@@ -193,14 +193,6 @@ class Orders_Page {
 			return false;
 		}
 
-		try {
-			tribe( 'tec.main' );
-		} catch ( Exception $e ) {
-			// If the Tickets Events Calendar is not active, return true.
-			return true;
-		}
-
-		// If the Tickets Events Calendar is active, return false.
-		return false;
+		return ! defined( 'TRIBE_EVENTS_FILE' );
 	}
 }

--- a/src/Tickets/Commerce/Admin/Orders_Page.php
+++ b/src/Tickets/Commerce/Admin/Orders_Page.php
@@ -188,7 +188,7 @@ class Orders_Page {
 	 *
 	 * @return bool
 	 */
-	public function is_admin_orders_page_and_no_TEC() {
+	public function is_admin_orders_page_and_no_TEC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		if ( ! $this->is_admin_orders_page() ) {
 			return false;
 		}

--- a/src/Tickets/Commerce/Admin/Orders_Page.php
+++ b/src/Tickets/Commerce/Admin/Orders_Page.php
@@ -11,7 +11,6 @@ namespace TEC\Tickets\Commerce\Admin;
 
 use TEC\Tickets\Commerce\Order;
 use Tribe\Admin\Pages;
-use Exception;
 
 /**
  * Class Orders_Page.

--- a/src/resources/js/admin/orders/table.js
+++ b/src/resources/js/admin/orders/table.js
@@ -1,0 +1,139 @@
+( function( $ ) {
+	/**
+	 * Setup Datepicker
+	 */
+	const $dateFormat = $( '[data-datepicker_format]' );
+	const _MS_PER_DAY = 1000 * 60 * 60 * 24;
+	let datepickerFormat = 0;
+
+	/**
+	 * Returns the number of months to display in
+	 * the datepicker based on the viewport width
+	 *
+	 * @returns {number} The number of months to display
+	 */
+	function getDatepickerNumMonths() {
+		const windowWidth = $( window ).width();
+
+		if ( windowWidth < 800 ) {
+			return 1;
+		}
+
+		if ( windowWidth <= 1100 ) {
+			return 2;
+		}
+
+		return 3;
+	}
+
+	function dateDiffInDays( a, b ) {
+		const utc1 = Date.UTC( a.getFullYear(), a.getMonth(), a.getDate() );
+		const utc2 = Date.UTC( b.getFullYear(), b.getMonth(), b.getDate() );
+
+		return Math.floor( ( utc2 - utc1 ) / _MS_PER_DAY );
+	}
+
+	if ( typeof tribe_l10n_datatables.datepicker !== 'undefined' ) { // eslint-disable-line no-undef
+		let tribeDatepickerOpts = {};
+
+		let dateFormat = 'yy-mm-dd';
+
+		if ( $dateFormat.length && $dateFormat.attr( 'data-datepicker_format' ).length >= 1 ) {
+			datepickerFormat = $dateFormat.attr( 'data-datepicker_format' );
+			dateFormat = datepicker_formats.main[ datepickerFormat ]; // eslint-disable-line no-undef
+		}
+
+		const $startDate = $( document.getElementById( 'EventStartDate' ) );
+		const $endDate = $( document.getElementById( 'EventEndDate' ) );
+		const $eventDetails = $( document.getElementById( 'tribe_events_event_details' ) );
+
+		tribeDatepickerOpts = {
+			dateFormat: dateFormat,
+			showAnim: 'fadeIn',
+			changeMonth: true,
+			changeYear: true,
+			numberOfMonths: getDatepickerNumMonths(),
+			showButtonPanel: false,
+			beforeShow: function( element, object ) {
+				object.input.datepicker( 'option', 'numberOfMonths', getDatepickerNumMonths() );
+				object.input.data( 'prevDate', object.input.datepicker( 'getDate' ) );
+
+				// allow single datepicker fields to specify a min or max date
+				// using the `data-datapicker-(min|max)Date` attribute
+				if ( undefined !== object.input.data( 'datepicker-min-date' ) ) {
+					object.input.datepicker(
+						'option',
+						'minDate',
+						object.input.data( 'datepicker-min-date' ),
+					);
+				}
+
+				if ( undefined !== object.input.data( 'datepicker-max-date' ) ) {
+					object.input.datepicker(
+						'option',
+						'maxDate',
+						object.input.data( 'datepicker-max-date' ),
+					);
+				}
+
+				// Capture the datepicker div here; it's dynamically generated so best to grab here instead
+				// of elsewhere.
+				const $dpDiv = $( object.dpDiv );
+
+				// "Namespace" our CSS a bit so that our custom jquery-ui-datepicker styles don't interfere
+				// with other plugins'/themes'.
+				$dpDiv.addClass( 'tribe-ui-datepicker' );
+
+				$eventDetails.trigger( 'tribe.ui-datepicker-div-beforeshow', [ object ] );
+
+				$dpDiv.attrchange( {
+					trackValues: true,
+					callback: function( attr ) {
+						// This is a non-ideal, but very reliable way to look for the closing of the ui-datepicker box,
+						// since onClose method is often occluded by other plugins, including Events Calender PRO.
+						if (
+							'string' === typeof attr.newValue &&
+							(
+								attr.newValue.indexOf( 'display: none' ) >= 0 ||
+								attr.newValue.indexOf( 'display:none' ) >= 0
+							)
+						) {
+							$dpDiv.removeClass( 'tribe-ui-datepicker' );
+							$eventDetails.trigger( 'tribe.ui-datepicker-div-closed', [ object ] );
+						}
+					},
+				} );
+			},
+			onSelect: function( selectedDate ) {
+				const instance = $( this ).data( 'datepicker' );
+				const date = $.datepicker.parseDate(
+					instance.settings.dateFormat || $.datepicker._defaults.dateFormat,
+					selectedDate,
+					instance.settings,
+				);
+
+				// If the start date was adjusted, then let's modify the minimum acceptable end date
+				if ( this.id === 'EventStartDate' ) {
+					const startDate = $( document.getElementById( 'EventStartDate' ) ).data( 'prevDate' );
+					// eslint-disable-next-line max-len
+					const dateDiff = null == startDate ? 0 : dateDiffInDays( startDate, $endDate.datepicker( 'getDate' ) );
+					const endDate = new Date( date.setDate( date.getDate() + dateDiff ) );
+
+					$endDate
+						.datepicker( 'option', 'minDate', $startDate.datepicker( 'getDate' ) )
+						.datepicker( 'setDate', endDate )
+						.datepicker_format;
+				}
+
+				// fire the change and blur handlers on the field
+				$( this ).trigger( 'change' );
+				$( this ).trigger( 'blur' );
+			},
+		};
+
+		// eslint-disable-next-line no-undef
+		$.extend( tribeDatepickerOpts, tribe_l10n_datatables.datepicker );
+
+		$( '.tribe-datepicker' ).datepicker( tribeDatepickerOpts );
+	}
+} )( jQuery );

--- a/tests/commerce_integration/TEC/Tickets/Commerce/TicketTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/TicketTest.php
@@ -7,13 +7,13 @@ use TEC\Tickets\Commerce\Utils\Value;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 class TicketTest extends WPTestCase {
 	use Ticket_Maker;
-	
+
 	public function is_on_sale_provider(): \Generator {
 		yield 'regular ticket => false' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 1 );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -21,15 +21,15 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'ticket with sale price => true' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -37,15 +37,15 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'ticket has sale price but inactive sale check => false' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, false );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -53,16 +53,16 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'if sale start date is in past => true' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, '2010-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -70,16 +70,16 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'if sale start date is in future => false' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, '2040-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -87,16 +87,16 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'if sale end date is in past => false' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, '2010-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -104,16 +104,16 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'if sale end date is in future => true' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, '2040-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -121,17 +121,17 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'if sale start date is in past and end date is in future => true' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, '2010-03-01' );
 				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, '2040-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -139,17 +139,17 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'sale start date and end date in past => false' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, '2010-03-01' );
 				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, '2010-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -157,17 +157,17 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'sale start date in future, end date in past => false' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, '2040-03-01' );
 				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, '2010-03-01' );
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -175,18 +175,20 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'sale start date and end date is today => true' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				$today     = gmdate( 'Y-m-d' );
-				
+				$today     = gmdate( 'Y-m-d H:i:s' );
+
+				$today_in_an_hour = gmdate( 'Y-m-d H:i:s', strtotime( '+1 hour' ) );
+
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
 				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, $today );
-				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, $today );
-				
+				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, $today_in_an_hour );
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -195,7 +197,7 @@ class TicketTest extends WPTestCase {
 			},
 		];
 	}
-	
+
 	/**
 	 * @test
 	 * @dataProvider is_on_sale_provider
@@ -204,14 +206,14 @@ class TicketTest extends WPTestCase {
 	 */
 	public function test_is_on_sale( \Closure $ticket_data_provider ): void {
 		[ $post_id, $ticket_id, $expected ] = $ticket_data_provider();
-		
+
 		$provider     = tribe( Module::class );
 		$ticket       = $provider->get_ticket( $post_id, $ticket_id );
 		$ticket_class = tribe( Ticket::class );
-		
+
 		$this->assertEquals( $expected, $ticket_class->is_on_sale( $ticket ) );
 	}
-	
+
 	/**
 	 * Provides data for the process_sale_price_data test.
 	 *
@@ -225,7 +227,7 @@ class TicketTest extends WPTestCase {
 					$post_id,
 					20,
 				);
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -236,7 +238,7 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'sale price data added' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
@@ -250,7 +252,7 @@ class TicketTest extends WPTestCase {
 						'ticket_sale_end_date'   => '2040-03-01',
 					]
 				);
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -261,7 +263,7 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'sale price data added but sale price option unchecked' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
@@ -274,7 +276,7 @@ class TicketTest extends WPTestCase {
 						'ticket_sale_end_date'   => '2040-03-01',
 					]
 				);
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -285,7 +287,7 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'sale price data is greater than regular price' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
@@ -299,7 +301,7 @@ class TicketTest extends WPTestCase {
 						'ticket_sale_end_date'   => '2040-03-01',
 					]
 				);
-				
+
 				// The sale price is greater than the regular price, so it should be ignored and not saved.
 				return [
 					$post_id,
@@ -311,7 +313,7 @@ class TicketTest extends WPTestCase {
 				];
 			},
 		];
-		
+
 		yield 'added a ticket with sale price then saved again with unchecked sale price' => [
 			function (): array {
 				$post_id   = static::factory()->post->create();
@@ -325,7 +327,7 @@ class TicketTest extends WPTestCase {
 						'ticket_sale_end_date'   => '2040-03-01',
 					]
 				);
-				
+
 				// Save the ticket again with the sale price option unchecked, this should remove all previously saved sale price data.
 				$this->create_tc_ticket(
 					$post_id,
@@ -337,7 +339,7 @@ class TicketTest extends WPTestCase {
 						'ticket_sale_end_date'   => '2040-03-01',
 					]
 				);
-				
+
 				return [
 					$post_id,
 					$ticket_id,
@@ -349,7 +351,7 @@ class TicketTest extends WPTestCase {
 			},
 		];
 	}
-	
+
 	/**
 	 * @test
 	 * @covers \TEC\Tickets\Commerce\Ticket::process_sale_price_data
@@ -359,7 +361,7 @@ class TicketTest extends WPTestCase {
 	 */
 	public function test_process_sale_price_data( \Closure $data ): void {
 		[ $post_id, $ticket_id, $expected_checked, $expected_price, $expected_start_date, $expected_end_date ] = $data();
-		
+
 		$this->assertEquals( $expected_checked, get_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true ) );
 		$this->assertEquals( $expected_price, get_post_meta( $ticket_id, Ticket::$sale_price_key, true ) );
 		$this->assertEquals( $expected_start_date, get_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, true ) );

--- a/tests/commerce_integration/TEC/Tickets/Commerce/TicketTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/TicketTest.php
@@ -5,6 +5,9 @@ use Codeception\TestCase\WPTestCase;
 use TEC\Tickets\Commerce\Ticket;
 use TEC\Tickets\Commerce\Utils\Value;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe__Tickets__Ticket_Object;
+use DateTime;
+
 class TicketTest extends WPTestCase {
 	use Ticket_Maker;
 
@@ -180,14 +183,17 @@ class TicketTest extends WPTestCase {
 			function (): array {
 				$post_id   = static::factory()->post->create();
 				$ticket_id = $this->create_tc_ticket( $post_id, 20 );
-				$today     = gmdate( 'Y-m-d H:i:s' );
 
-				$today_in_an_hour = gmdate( 'Y-m-d H:i:s', strtotime( '+1 hour' ) );
+				$today            = tribe( Tribe__Tickets__Ticket_Object::class )->get_date( 'today' );
+				$today_in_an_hour = $today + HOUR_IN_SECONDS;
+
+				$today_obj            = new DateTime( "@$today" );
+				$today_in_an_hour_obj = new DateTime( "@$today_in_an_hour" );
 
 				update_post_meta( $ticket_id, Ticket::$sale_price_checked_key, true );
 				update_post_meta( $ticket_id, Ticket::$sale_price_key, 10 );
-				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, $today );
-				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, $today_in_an_hour );
+				update_post_meta( $ticket_id, Ticket::$sale_price_start_date_key, $today_obj->format( 'Y-m-d H:i:s' ) );
+				update_post_meta( $ticket_id, Ticket::$sale_price_end_date_key, $today_in_an_hour_obj->format( 'Y-m-d H:i:s' ) );
 
 				return [
 					$post_id,

--- a/tests/integration/TEC/Tickets/Commerce/Admin/Orders_PageTest.php
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/Orders_PageTest.php
@@ -81,11 +81,13 @@ class Orders_PageTest extends \Codeception\TestCase\WPTestCase {
 		$new_sub_menu = array( $orders_page->get_menu_title(), $orders_page->get_capability(), $orders_page->get_menu_slug(), $orders_page->get_page_title() );
 
 		$this->assertFalse( tribe( 'assets' )->exists( 'event-tickets-commerce-admin-orders-css' ) );
+		$this->assertFalse( tribe( 'assets' )->exists( 'event-tickets-commerce-admin-orders' ) );
 		$this->assertFalse( in_array( $new_sub_menu, $submenu[ Orders_Page::$parent_slug ], true ) );
 
 		$orders_page->add_orders_page();
 
 		$this->assertTrue( tribe( 'assets' )->exists( 'event-tickets-commerce-admin-orders-css' ) );
+		$this->assertTrue( tribe( 'assets' )->exists( 'event-tickets-commerce-admin-orders' ) );
 
 		$this->assertTrue( in_array( $new_sub_menu, $submenu[ Orders_Page::$parent_slug ], true ) );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2117]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Avoid Dependency on TEC. The date range dropdowns were only being initiated while TEC was active. Now ET can initiate those on its own.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2117]: https://stellarwp.atlassian.net/browse/ET-2117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ