### PR TITLE
Fix stripe refunds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "event-tickets",
-  "version": "5.9.1",
+  "version": "5.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "event-tickets",
-      "version": "5.9.1",
+      "version": "5.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.15.3",

--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - ensure Stripe refunds are recorded in WordPress. [ET-2142]
+
 = [5.11.0.3] 2024-06-14 =
 
 * Fix - Issue where scripts would not be enqueued as modules. [TECTRIA-86]

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -39,11 +39,13 @@ class Charge_Webhook implements Webhook_Event_Interface {
 		 * @link https://stellarwp.atlassian.net/browse/ET-1792
 		 *
 		 * @since 5.7.1
+		 * @since TBD - Process Refunds requests always.
 		 */
 		if (
 			$payment_intent
 			&& isset( $payment_intent['status'] )
 			&& Status::SUCCEEDED === $payment_intent['status']
+			&& Events::CHARGE_REFUNDED !== Arr::get( $event, 'type' )
 		) {
 				$response->set_status( 200 );
 				$response->set_data(

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -38,6 +38,11 @@ class Charge_Webhook implements Webhook_Event_Interface {
 		 *
 		 * @link https://stellarwp.atlassian.net/browse/ET-1792
 		 *
+		 * Second iteration see below for more information.
+		 *
+		 * @link https://stellarwp.atlassian.net/browse/ET-2142
+		 * @link https://github.com/the-events-calendar/event-tickets/pull/3095
+		 *
 		 * @since 5.7.1
 		 * @since TBD - Process Refunds requests always.
 		 */

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -137,7 +137,8 @@ abstract class Status_Abstract implements Status_Interface {
 		$current_status = tribe( Status_Handler::class )->get_by_wp_slug( $order->post_status );
 
 		if ( $current_status->get_wp_slug() === $new_status->get_wp_slug() ) {
-			return false;
+			// Allow from refunded to refunded in order to support multiple refunds.
+			return 'refunded' === $current_status->get_slug();
 		}
 
 		if ( $current_status->is_final() ) {

--- a/tests/commerce_integration/TEC/Gateways/Stripe/RefundTest.php
+++ b/tests/commerce_integration/TEC/Gateways/Stripe/RefundTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace TEC\Tickets\Commerce\Gateways\Stripe;
 
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
@@ -9,7 +8,7 @@ use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Tribe\Tests\Traits\With_Uopz;
 use TEC\Tickets\Commerce\Status\Status_Handler;
 
-class OrderTest extends \Codeception\TestCase\WPTestCase {
+class RefundTest extends \Codeception\TestCase\WPTestCase {
 
 	use Ticket_Maker;
 	use Attendee_Maker;
@@ -27,7 +26,7 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'post_title'   => 'TEC-TC-T-5',
 				'post_content' => '',
-				'post_status'  => 'tec-tc-created',
+				'post_status'  => 'tec-tc-refunded',
 				'post_author'  => 0,
 				'post_type'    => 'tec_tc_order',
 			]

--- a/tests/integration/Deprecated_Test.php
+++ b/tests/integration/Deprecated_Test.php
@@ -39,8 +39,8 @@ class Tribe_Deprecated_Test extends WPTestCase {
 
 	public function deprecated_classes_5_6_5() {
 		return [
-			[ 'Tribe__Tickets__Cache__Abstract_Cache' ],
 			[ 'Tribe__Tickets__Cache__Cache_Interface' ],
+			[ 'Tribe__Tickets__Cache__Abstract_Cache' ],
 			[ 'Tribe__Tickets__Cache__Central' ],
 			[ 'Tribe__Tickets__Cache__Transient_Cache' ],
 		];


### PR DESCRIPTION
### 🎫 Ticket

[ET-2142]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We were facing 2 issues with Stripe refunds.

1. Refunds would never reflect in WP. Reason is that in part of fixing ET-1792 we introduced a new bug. In ET-1792 before processing an incoming webhook we would check if there was already a successful payment intent present in Stripe. Overcoming that way Race conditions. BUT webhooks for refunds always did have a successful payment intent and we were wrongly ignoring them. We are overcoming this one by also checking against the type of incoming webhook.

2. Multiple refunds from stripe would fail to be registered in WP. Reason was that the code was failing early because it could not update the order status from `refunded` to `refunded`. Fixing this by allowing explicitly this status update.

Pending/possible second PR
- Check the same bug for PayPal and if it's present fix it.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2142]: https://stellarwp.atlassian.net/browse/ET-2142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ