### PR TITLE
Fix ID column text wrap

### DIFF
--- a/.puprc
+++ b/.puprc
@@ -13,7 +13,7 @@
 		"npm ci",
 		"npm run build"
 	],
-	"workflow": {
+	"workflows": {
 		"build-common": [
 			"echo 'building common (no-dev) in: '$(pwd)",
 			"cd common && pup build"

--- a/.puprc
+++ b/.puprc
@@ -1,21 +1,18 @@
 {
 	"build": [
 		"pup do build-common",
-		"echo 'building Event Tickets in: '$(pwd)",
 		"composer install --no-dev",
 		"npm ci",
 		"npm run build"
 	],
 	"build_dev": [
 		"pup do build-common",
-		"echo 'building Event Tickets in: '$(pwd)",
 		"composer install",
 		"npm ci",
 		"npm run build"
 	],
 	"workflows": {
 		"build-common": [
-			"echo 'building common (no-dev) in: '$(pwd)",
 			"cd common && pup build"
 		]
 	},

--- a/src/Tickets/Commerce/Admin_Tables/Orders_Table.php
+++ b/src/Tickets/Commerce/Admin_Tables/Orders_Table.php
@@ -597,7 +597,7 @@ class Orders_Table extends WP_Posts_List_Table {
 		}
 
 		return sprintf(
-			'<a class="tribe-external-link" href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			'<br><a class="tribe-external-link tribe-external-link--code" href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
 			$order_url,
 			$item->gateway_order_id
 		);

--- a/src/resources/postcss/rsvp-v1.pcss
+++ b/src/resources/postcss/rsvp-v1.pcss
@@ -78,7 +78,7 @@ div.tec__tickets-my-tickets-rsvp-attendee-list-wrapper {
 	padding: 0;
 
 	> .tribe-item {
-		align-items: start;
+		align-items: flex-start;
 		background-color: var(--tec-color-background);
 		border: 1px solid var(--tec-color-border-default);
 		border-bottom: 0;

--- a/src/resources/postcss/tickets-admin/settings/_banners.pcss
+++ b/src/resources/postcss/tickets-admin/settings/_banners.pcss
@@ -83,7 +83,7 @@
 .tec-tickets__admin-tc-banner-header {
 	align-items: center;
 	display: flex;
-	justify-content: start;
+	justify-content: flex-start;
 	padding-top: var(--tec-spacer-4);
 }
 
@@ -96,7 +96,7 @@
 .tec-tickets__admin-tc-banner-footer {
 	align-items: center;
 	display: flex;
-	justify-content: start;
+	justify-content: flex-start;
 	padding-bottom: var(--tec-spacer-4);
 	padding-top: var(--tec-spacer-3);
 }

--- a/src/resources/postcss/tickets-commerce/admin/orders/table.pcss
+++ b/src/resources/postcss/tickets-commerce/admin/orders/table.pcss
@@ -73,10 +73,7 @@ body.wp-admin.post-type-tec_tc_order {
 }
 
 .tribe-external-link {
-	align-items: center;
-	display: flex;
-	flex-flow: row nowrap;
-	justify-content: flex-start;
+	margin-left: 1ch;
 
 	&:after {
 		content: url("../../../../images/tribe-external-link.svg");

--- a/src/resources/postcss/tickets-commerce/admin/orders/table.pcss
+++ b/src/resources/postcss/tickets-commerce/admin/orders/table.pcss
@@ -73,7 +73,10 @@ body.wp-admin.post-type-tec_tc_order {
 }
 
 .tribe-external-link {
-	margin-left: 1ch;
+
+	&--code {
+		font-family: monospace;
+	}
 
 	&:after {
 		content: url("../../../../images/tribe-external-link.svg");

--- a/src/resources/postcss/tickets/_block-extras.pcss
+++ b/src/resources/postcss/tickets/_block-extras.pcss
@@ -45,7 +45,7 @@
 	}
 
 	.tribe-tickets__tickets-item-extra-price {
-		align-items: end;
+		align-items: flex-end;
 		display: flex;
 		flex-direction: row;
 		gap: var(--tec-spacer-1);


### PR DESCRIPTION
### 🎫 Ticket

[ET-2144]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Makes the ID wrap in cases where the column is too narrow to fit it.

### 🎥 Artifacts <!-- if applicable-->
Old (bad)
<img width="233" alt="Screenshot 2024-07-09 at 10 42 47 AM" src="https://github.com/the-events-calendar/event-tickets/assets/929375/0305d230-d6ff-48b7-99c7-4da468e579f4">

Proposal (good - wrap ID) 
<img width="1274" alt="Screenshot 2024-07-09 at 11 36 58 AM" src="https://github.com/the-events-calendar/event-tickets/assets/929375/c8aa495b-045e-4764-9b84-59de95316f21">

Final (better - line break and font to offset)
<img width="1271" alt="Screenshot 2024-07-09 at 12 24 45 PM" src="https://github.com/the-events-calendar/event-tickets/assets/929375/d3d5c9b6-7232-4e18-ad70-214ab5ff6762">



[ET-2144]: https://stellarwp.atlassian.net/browse/ET-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ