### PR TITLE
SLR - fix session persistence

### DIFF
--- a/src/Tickets/Seating/Admin/Ajax.php
+++ b/src/Tickets/Seating/Admin/Ajax.php
@@ -396,8 +396,9 @@ class Ajax extends Controller_Contract {
 		}
 
 		// Remove the `tec-tickets-commerce-cart` cookie.
+		$cookie_name = Cart::$cart_hash_cookie_name;
 		setcookie(
-			Cart::$cart_hash_cookie_name,
+			$cookie_name,
 			'',
 			time() - DAY_IN_SECONDS,
 			COOKIEPATH,
@@ -405,5 +406,6 @@ class Ajax extends Controller_Contract {
 			true,
 			true
 		);
+		unset( $_COOKIE[ $cookie_name ] );
 	}
 }

--- a/src/Tickets/Seating/Frontend/Session.php
+++ b/src/Tickets/Seating/Frontend/Session.php
@@ -83,6 +83,48 @@ class Session {
 	}
 
 	/**
+	 * Returns the cookie string from the entries.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int,string> $entries The entries to convert to a cookie string.
+	 *
+	 * @return string The cookie string.
+	 */
+	public function get_cookie_string( array $entries ): string {
+		return implode(
+			'|||',
+			array_map(
+				static fn( $object_id, $token ) => $object_id . '=' . $token,
+				array_keys( $entries ),
+				$entries
+			)
+		);
+	}
+
+	/**
+	 * Returns the filtered expiration time of the Seating session cookie.
+	 *
+	 * Note the cookie will contain multiple tokens, each one with a possibly different expiration time.
+	 * For this reason, we set the cookie expiration time to 1 day, a value that should be large enough for any token
+	 * contained in it to expire.
+	 *
+	 * @since TBD
+	 *
+	 * @return int The expiration time of the Seating session cookie.
+	 */
+	public function get_cookie_expiration_time(): int {
+		/**
+		 * Filters the expiration time of the Seating session cookie.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $expiration_time The expiration time of the Seating session cookie.
+		 */
+		return apply_filters( 'tec_tickets_seating_session_cookie_expiration_time', DAY_IN_SECONDS );
+	}
+
+	/**
 	 * Adds a new entry to the cookie string.
 	 *
 	 * @since TBD
@@ -94,23 +136,16 @@ class Session {
 		$entries               = $this->get_entries();
 		$entries[ $object_id ] = $token;
 
-		$new_value = implode(
-			'|||',
-			array_map(
-				static fn( $object_id, $token ) => $object_id . '=' . $token,
-				array_keys( $entries ),
-				$entries
-			)
-		);
+		$new_value = $this->get_cookie_string( $entries );
 
 		setcookie(
 			self::COOKIE_NAME,
 			$new_value,
-			0, // Do not set the expiration here, there might be more than one element in the cookie.
+			time() + $this->get_cookie_expiration_time(),
 			COOKIEPATH,
 			COOKIE_DOMAIN,
 			true,
-			false
+			true
 		);
 		$_COOKIE[ self::COOKIE_NAME ] = $new_value;
 	}
@@ -132,25 +167,27 @@ class Session {
 			unset( $entries[ $post_id ] );
 		}
 
-		$new_value = implode(
-			'|||',
-			array_map(
-				static fn( $object_id, $token ) => $object_id . '=' . $token,
-				array_keys( $entries ),
-				$entries
-			)
-		);
+		$new_value = $this->get_cookie_string( $entries );
 
-		setcookie(
-			self::COOKIE_NAME,
-			$new_value,
-			0, // Do not set the expiration here, there might be more than one element in the cookie.
-			COOKIEPATH,
-			COOKIE_DOMAIN,
-			true,
-			false
-		);
-		$_COOKIE[ self::COOKIE_NAME ] = $new_value;
+		if ( empty( $new_value ) ) {
+			setcookie( self::COOKIE_NAME, '', time() - DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, true, true );
+			unset( $_COOKIE[ self::COOKIE_NAME ] );
+		} else {
+			/*
+			 * Cookies will store more than one token, each with, possibly, a different expiration time.
+			 * We set the cookie expiration here to 1 day, to avoid the first expring token from removing it.
+			 */
+			setcookie(
+				self::COOKIE_NAME,
+				$new_value,
+				time() + $this->get_cookie_expiration_time(),
+				COOKIEPATH,
+				COOKIE_DOMAIN,
+				true,
+				true
+			);
+			$_COOKIE[ self::COOKIE_NAME ] = $new_value;
+		}
 
 		return true;
 	}
@@ -176,8 +213,8 @@ class Session {
 				$reservations = $this->sessions->get_reservations_for_token( $entry_token );
 
 				return $this->reservations->cancel( $entry_object_id, $reservations )
-						&& $this->sessions->delete_token_session( $entry_token )
-						&& $this->remove_entry( $entry_object_id, $entry_token );
+				       && $this->sessions->delete_token_session( $entry_token )
+				       && $this->remove_entry( $entry_object_id, $entry_token );
 			}
 		}
 
@@ -270,7 +307,7 @@ class Session {
 			}
 
 			$confirmed &= $this->reservations->confirm( $post_id, $token_reservations )
-				&& $this->sessions->delete_token_session( $token );
+			              && $this->sessions->delete_token_session( $token );
 		}
 
 		return $confirmed;

--- a/src/Tickets/Seating/Frontend/Session.php
+++ b/src/Tickets/Seating/Frontend/Session.php
@@ -51,7 +51,7 @@ class Session {
 	/**
 	 * Session constructor.
 	 *
-	 * since TBD
+	 * @since TBD
 	 *
 	 * @param Sessions     $sessions     A reference to the Sessions table handler.
 	 * @param Reservations $reservations A reference to the Reservations object.
@@ -69,7 +69,7 @@ class Session {
 	 * @return array<string,string> The parsed cookie string, a map from object ID to token.
 	 */
 	public function get_entries(): array {
-		$current = $_COOKIE[ self::COOKIE_NAME ] ?? '';
+		$current = sanitize_text_field( $_COOKIE[ self::COOKIE_NAME ] ?? '' );
 		$parsed  = [];
 		foreach ( explode( '|||', $current ) as $entry ) {
 			[ $object_id, $token ] = array_replace( [ '', '' ], explode( '=', $entry, 2 ) );
@@ -213,8 +213,8 @@ class Session {
 				$reservations = $this->sessions->get_reservations_for_token( $entry_token );
 
 				return $this->reservations->cancel( $entry_object_id, $reservations )
-				       && $this->sessions->delete_token_session( $entry_token )
-				       && $this->remove_entry( $entry_object_id, $entry_token );
+						&& $this->sessions->delete_token_session( $entry_token )
+						&& $this->remove_entry( $entry_object_id, $entry_token );
 			}
 		}
 
@@ -262,7 +262,7 @@ class Session {
 	 * @return array{0: string, 1: int}|null The token and object ID from the cookie, or `null` if not found.
 	 */
 	public function get_session_token_object_id(): ?array {
-		$cookie = $_COOKIE[ self::COOKIE_NAME ] ?? null;
+		$cookie = sanitize_text_field( $_COOKIE[ self::COOKIE_NAME ] ?? '' );
 
 		if ( ! $cookie ) {
 			return null;
@@ -307,7 +307,7 @@ class Session {
 			}
 
 			$confirmed &= $this->reservations->confirm( $post_id, $token_reservations )
-			              && $this->sessions->delete_token_session( $token );
+							&& $this->sessions->delete_token_session( $token );
 		}
 
 		return $confirmed;

--- a/src/Tickets/Seating/Frontend/Timer.php
+++ b/src/Tickets/Seating/Frontend/Timer.php
@@ -515,10 +515,10 @@ class Timer extends Controller_Contract {
 		// Remove the seat selection session cookie entry.
 		$this->session->remove_entry( $post_id, $token );
 
-		// Cancel the reservations for the post ID and token.
+		// Cancel the reservations for the post ID and token, remove the session associated with the token from the database.
 		if ( ! (
 			$this->reservations->cancel( $post_id, $this->sessions->get_reservations_for_token( $token ) )
-			&& $this->sessions->clear_token_reservations( $token )
+			&& $this->sessions->delete_token_session( $token )
 		) ) {
 			wp_send_json_error(
 				[

--- a/src/Tickets/Seating/Frontend/Timer.php
+++ b/src/Tickets/Seating/Frontend/Timer.php
@@ -92,6 +92,26 @@ class Timer extends Controller_Contract {
 	private Session $session;
 
 	/**
+	 * The current token used to render the timer.
+	 * Set on explicit render requests.
+	 *
+	 * @since TBD
+	 *
+	 * @var string|null
+	 */
+	private ?string $current_token = null;
+
+	/**
+	 * The current post ID used to render the timer.
+	 * Set on explicit render requests.
+	 *
+	 * @since TBD
+	 *
+	 * @var int|null
+	 */
+	private ?int $current_post_id = null;
+
+	/**
 	 * Timer constructor.
 	 *
 	 * @since TBD
@@ -246,6 +266,10 @@ class Timer extends Controller_Contract {
 			}
 
 			[ $token, $post_id ] = $cookie_timer_token_post_id;
+		} else {
+			// If a cookie and token were passed, store them for later use.
+			$this->current_token   = $token;
+			$this->current_post_id = $post_id;
 		}
 
 		wp_enqueue_script( 'tec-tickets-seating-session' );
@@ -272,7 +296,7 @@ class Timer extends Controller_Contract {
 	 * @return void
 	 */
 	public function render_to_sync(): void {
-		$this->render( null, null, true );
+		$this->render( $this->current_token, $this->current_post_id, true );
 	}
 
 	/**
@@ -451,7 +475,7 @@ class Timer extends Controller_Contract {
 			$content      = _x(
 				'Your seat selections are no longer reserved, but tickets are still available.',
 				'Seat selection expired timer content',
-				'event-tickets' 
+				'event-tickets'
 			);
 			$button_label = _x( 'Find Seats', 'Seat selection expired timer button label', 'event-tickets' );
 			$redirect_url = get_post_permalink( $post_id );
@@ -512,7 +536,7 @@ class Timer extends Controller_Contract {
 				'content'     => esc_html( $content ),
 				'buttonLabel' => esc_html( $button_label ),
 				'redirectUrl' => esc_url( $redirect_url ),
-			] 
+			]
 		);
 	}
 }

--- a/src/Tickets/Seating/Service/Layouts.php
+++ b/src/Tickets/Seating/Service/Layouts.php
@@ -230,6 +230,7 @@ class Layouts {
 	 */
 	public static function invalidate_cache(): bool {
 		delete_transient( self::update_transient_name() );
+		delete_transient( Seat_Types::update_transient_name() );
 		wp_cache_delete( 'option_format_layouts', 'tec-tickets-seating' );
 
 		$invalidated = Layouts_Table::truncate() !== false &&

--- a/src/Tickets/Seating/app/postcss/_iframe.pcss
+++ b/src/Tickets/Seating/app/postcss/_iframe.pcss
@@ -9,3 +9,7 @@
 	width: 100%;
 	height: calc(100vh - 160px);
 }
+
+.firebase-emulator-warning {
+	display: none;
+}

--- a/tests/slr_integration/Admin/Ajax_Test.php
+++ b/tests/slr_integration/Admin/Ajax_Test.php
@@ -2,9 +2,12 @@
 
 namespace TEC\Tickets\Seating\Admin;
 
+use PHPUnit\Framework\Assert;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 use TEC\Common\StellarWP\DB\DB;
 use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Seating\Meta;
 use TEC\Tickets\Seating\Service\OAuth_Token;
 use TEC\Tickets\Seating\Service\Reservations;
@@ -16,6 +19,7 @@ use TEC\Tickets\Seating\Tables\Sessions;
 use TEC\Tickets\Seating\Tests\Integration\Seat_Types_Factory;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Traits\WP_Remote_Mocks;
+use Tribe__Tickets__Data_API as Data_API;
 
 class Ajax_Test extends Controller_Test_Case {
 	use SnapshotAssertions;
@@ -25,6 +29,22 @@ class Ajax_Test extends Controller_Test_Case {
 	use WP_Remote_Mocks;
 
 	protected string $controller_class = Ajax::class;
+
+	/**
+	 * @before
+	 */
+	public function ensure_tickets_commerce_active(): void {
+		// Ensure the Tickets Commerce module is active.
+		add_filter( 'tec_tickets_commerce_is_enabled', '__return_true' );
+		add_filter( 'tribe_tickets_get_modules', function ( $modules ) {
+			$modules[ Module::class ] = tribe( Module::class )->plugin_name;
+
+			return $modules;
+		} );
+
+		// Reset Data_API object, so it sees Tribe Commerce.
+		tribe_singleton( 'tickets.data_api', new Data_API );
+	}
 
 	/**
 	 * @before
@@ -42,7 +62,7 @@ class Ajax_Test extends Controller_Test_Case {
 	 *
 	 * @test
 	 */
-	public function should_return_ur_ls(): void {
+	public function should_return_urls(): void {
 		$this->set_fn_return( 'wp_create_nonce', function ( string $action ) {
 			if ( $action === 'seat_types_by_layout_id' ) {
 				return '8298ff6616';
@@ -943,4 +963,43 @@ class Ajax_Test extends Controller_Test_Case {
 		$this->assertEquals( 400, $wp_send_json_error_code );
 		$this->assertEquals( [ 'error' => 'Invalid request parameters' ], $wp_send_json_error_data );
 	}
+
+	public function test_clear_commerce_cart_cookie(): void {
+		$cookie_name             = Cart::$cart_hash_cookie_name;
+		$_COOKIE[ $cookie_name ] = 'some-commerce-cart-hash';
+		$setcookie_call          = null;
+		$this->set_fn_return( 'setcookie', function (
+			$name,
+			$value,
+			$expire,
+			$path,
+			$domain,
+			$secure,
+			$httponly
+		) use ( $cookie_name, &$setcookie_call ) {
+			$setcookie_call = true;
+
+			Assert::assertEquals( $cookie_name, $name );
+			Assert::assertEquals( '', $value );
+			Assert::assertEquals( time() - DAY_IN_SECONDS, $expire,'', 5 );
+			Assert::assertEquals( COOKIEPATH, $path );
+			Assert::assertEquals( COOKIE_DOMAIN, $domain );
+			Assert::assertTrue( $secure );
+			Assert::assertTrue( $httponly );
+
+			return true;
+		}, true );
+		$post_id = self::factory()->post->create();
+		/** @var \Tribe__Tickets__Tickets_Handler $tickets_handler */
+		$tickets_handler = tribe( 'tickets.handler' );
+		update_post_meta( $post_id, $tickets_handler->key_provider_field, Module::class );
+
+		$this->make_controller()->register();
+
+		do_action( 'tec_tickets_seating_session_interrupt', $post_id );
+
+		$this->assertFalse( isset( $_COOKIE[ $cookie_name ] ) );
+		$this->assertTrue( $setcookie_call );
+	}
 }
+

--- a/tests/slr_integration/Admin/__snapshots__/Ajax_Test__should_return_urls__0.snapshot.php
+++ b/tests/slr_integration/Admin/__snapshots__/Ajax_Test__should_return_urls__0.snapshot.php
@@ -1,0 +1,3 @@
+array (
+  'seatTypesByLayoutId' => 'http://wordpress.test/wp-admin/admin-ajax.php?action=seat_types_by_layout_id&_ajax_nonce=8298ff6616',
+)

--- a/tests/slr_integration/TEC/Tickets/Seating/Frontend/__snapshots__/Timer_Test__test_render_to_sync_with_previous_render__0.snapshot.html
+++ b/tests/slr_integration/TEC/Tickets/Seating/Frontend/__snapshots__/Timer_Test__test_render_to_sync_with_previous_render__0.snapshot.html
@@ -1,6 +1,6 @@
 
 <div class="tec-tickets-seating__timer tec-tickets-seating__timer--hidden"
-	data-token="{{token}}"
+	data-token="new-token"
 	data-redirect-url="http://wordpress.test/?post_type=post&#038;p={{post_id}}"
 	data-post-id="{{post_id}}"
 			data-sync-on-load

--- a/tests/slr_integration/TEC/Tickets/Seating/Service/Layouts_Test.php
+++ b/tests/slr_integration/TEC/Tickets/Seating/Service/Layouts_Test.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace TEC\Tickets\Seating\Service;
+
+use TEC\Tickets\Seating\Tables\Layouts as Layouts_Table;
+use TEC\Tickets\Seating\Tables\Maps as Maps_Table;
+use TEC\Tickets\Seating\Tables\Seat_Types as Seat_Types_Table;
+use Tribe\Tickets\Test\Traits\WP_Remote_Mocks;
+
+class Layouts_Test extends \Codeception\TestCase\WPTestCase {
+	use WP_Remote_Mocks;
+
+	/**
+	 * @before
+	 * @after
+	 */
+	public function truncate_custom_tables(): void {
+		Seat_Types_Table::truncate();
+		Layouts_Table::truncate();
+		Maps_Table::truncate();
+		delete_transient( Seat_Types::update_transient_name() );
+		delete_transient( Layouts::update_transient_name() );
+	}
+
+	private function given_some_maps_layouts_in_db(): void {
+		Maps_Table::insert_many( [
+			[
+				'id'             => 'some-map-1',
+				'name'           => 'Some Map 1',
+				'seats'          => 10,
+				'screenshot_url' => 'https://example.com/some-map-1.png',
+			],
+			[
+				'id'             => 'some-map-2',
+				'name'           => 'Some Map 2',
+				'seats'          => 20,
+				'screenshot_url' => 'https://example.com/some-map-2.png',
+			],
+			[
+				'id'             => 'some-map-3',
+				'name'           => 'Some Map 3',
+				'seats'          => 30,
+				'screenshot_url' => 'https://example.com/some-map-3.png',
+			],
+		] );
+
+		Layouts_Table::insert_many( [
+			[
+				'id'             => 'some-layout-1',
+				'name'           => 'Some Layout 1',
+				'seats'          => 10,
+				'created_date'   => time() * 1000,
+				'map'            => 'some-map-1',
+				'screenshot_url' => 'https://example.com/some-layouts-1.png',
+			],
+			[
+				'id'             => 'some-layout-2',
+				'name'           => 'Some Layout 2',
+				'seats'          => 20,
+				'created_date'   => time() * 1000,
+				'map'            => 'some-map-2',
+				'screenshot_url' => 'https://example.com/some-layouts-2.png',
+			],
+			[
+				'id'             => 'some-layout-3',
+				'name'           => 'Some Layout 3',
+				'seats'          => 30,
+				'created_date'   => time() * 1000,
+				'map'            => 'some-map-3',
+				'screenshot_url' => 'https://example.com/some-layouts-3.png',
+			],
+		] );
+
+		Seat_Types_Table::insert_many( [
+			[
+				'id'     => 'some-seat-type-1',
+				'name'   => 'Some Seat Type 1',
+				'seats'  => 10,
+				'map'    => 'some-map-1',
+				'layout' => 'some-layout-1',
+			],
+			[
+				'id'     => 'some-seat-type-2',
+				'name'   => 'Some Seat Type 2',
+				'seats'  => 20,
+				'map'    => 'some-map-2',
+				'layout' => 'https://example.com/some-seat-types-2.png',
+			],
+			[
+				'id'     => 'some-seat-type-3',
+				'name'   => 'Some Seat Type 3',
+				'seats'  => 30,
+				'map'    => 'some-map-3',
+				'layout' => 'some-layout-3',
+			],
+		] );
+	}
+
+	public function test_invalidate_cache(): void {
+		$this->assertEmpty( get_transient( Layouts::update_transient_name() ) );
+		$this->assertEmpty( get_transient( Seat_Types::update_transient_name() ) );
+
+		$this->given_some_maps_layouts_in_db();
+		set_transient( Seat_Types::update_transient_name(), time() );
+		set_transient( Layouts::update_transient_name(), time() );
+		set_transient( Maps::update_transient_name(), time() );
+
+		$this->assertCount( 3, iterator_to_array( Maps_Table::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Layouts_Table::fetch_all() ) );
+		$this->assertCount( 3, iterator_to_array( Seat_Types_Table::fetch_all() ) );
+
+		$this->assertTrue( Layouts::invalidate_cache() );
+
+		$this->assertCount( 3, iterator_to_array( Maps_Table::fetch_all() ) );
+		$this->assertCount( 0, iterator_to_array( Layouts_Table::fetch_all() ) );
+		$this->assertCount( 0, iterator_to_array( Seat_Types_Table::fetch_all() ) );
+		$this->assertEmpty( get_transient( Layouts::update_transient_name() ) );
+		$this->assertEmpty( get_transient( Seat_Types::update_transient_name() ) );
+		$this->assertEqualsWithDelta( time(), get_transient( Maps::update_transient_name() ), 5 );
+	}
+}


### PR DESCRIPTION
In this PR:
- **fix(Seating) print the new session token in all the timer instances on initial render**
- **fix(Seating) cs fixes**
- **refactor(Seating) on interrupt, remove token session from DB**

Follow-up on the work done for SL-92 to fix some issues with session persistence and window/tab re-use: going back to the same browser window to start a new seat-selection session would create inconsistent session data, this fixes it.

Also: on interrupt (i.e. when the timer runs out) remove the token session from the db instead of just emptying it.

[Demo](https://share.cleanshot.com/g5ZTY13C)