### PR TITLE
SLR - no timer in TC checkout if not ASC tickets in cart

### DIFF
--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -9,11 +9,9 @@
 
 namespace TEC\Tickets\Seating\Commerce;
 
-use Closure;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Cart;
-use TEC\Tickets\Commerce\Checkout;
 use TEC\Tickets\Commerce\Module;
 
 /**
@@ -57,11 +55,11 @@ class Controller extends Controller_Contract {
 	 *
 	 * @since TBD
 	 *
-	 * @parma array<string,string> $session_entries The entries from the cookie. A map from object ID to token.
+	 * @param array<string,string> $session_entries The entries from the cookie. A map from object ID to token.
 	 *
 	 * @return array<string,string> The entries from the cookie. A map from object ID to token.
 	 */
-	public function filter_timer_token_object_id_entries( $session_entries ):array {
+	public function filter_timer_token_object_id_entries( $session_entries ): array {
 		$tickets_commerce = tribe( Module::class );
 
 		if ( empty( $session_entries ) || ! $tickets_commerce->is_checkout_page() ) {
@@ -72,10 +70,10 @@ class Controller extends Controller_Contract {
 		// Get the post IDs in the cart.
 		global $wpdb;
 		/** @var Cart $cart */
-		$cart          = tribe( Cart::class );
-		$cart_items    = array_keys( $cart->get_items_in_cart() );
+		$cart       = tribe( Cart::class );
+		$cart_items = array_keys( $cart->get_items_in_cart() );
 
-		if( empty( $cart_items ) ) {
+		if ( empty( $cart_items ) ) {
 			return [];
 		}
 
@@ -83,7 +81,7 @@ class Controller extends Controller_Contract {
 			implode( ',', array_fill( 0, count( $cart_items ), '%d' ) ),
 			...$cart_items
 		);
-		$cart_post_ids = DB::get_col(
+		$cart_post_ids       = DB::get_col(
 			DB::prepare(
 				"SELECT DISTINCT( meta_value ) FROM %i WHERE post_id IN ({$ticket_ids_interval}) AND meta_key = %s ",
 				$wpdb->postmeta,
@@ -104,9 +102,12 @@ class Controller extends Controller_Contract {
 
 		return array_combine(
 			$cart_and_session_ids,
-			array_map( static function ( $item ) use ( $session_entries ) {
-				return $session_entries[ $item ];
-			}, $cart_and_session_ids )
+			array_map(
+				static function ( $item ) use ( $session_entries ) {
+					return $session_entries[ $item ];
+				},
+				$cart_and_session_ids
+			)
 		);
 	}
 }

--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Handles the integration with the Tickets Commerce module.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Seating\Commerce;
+ */
+
+namespace TEC\Tickets\Seating\Commerce;
+
+use Closure;
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\StellarWP\DB\DB;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Checkout;
+use TEC\Tickets\Commerce\Module;
+
+/**
+ * Class Controller.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Seating\Commerce;
+ */
+class Controller extends Controller_Contract {
+	/**
+	 * Subscribes to the WordPress hooks and actions required by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		add_filter(
+			'tec_tickets_seating_timer_token_object_id_entries',
+			[ $this, 'filter_timer_token_object_id_entries' ],
+		);
+	}
+
+	/**
+	 * Unregisters the controller by unsubscribing from WordPress hooks.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		remove_filter(
+			'tec_tickets_seating_timer_token_object_id_entries',
+			[ $this, 'filter_timer_token_object_id_entries' ],
+		);
+	}
+
+	/**
+	 * Filters the handler used to get the token and object ID from the cookie.
+	 *
+	 * @since TBD
+	 *
+	 * @parma array<string,string> $session_entries The entries from the cookie. A map from object ID to token.
+	 *
+	 * @return array<string,string> The entries from the cookie. A map from object ID to token.
+	 */
+	public function filter_timer_token_object_id_entries( $session_entries ):array {
+		$tickets_commerce = tribe( Module::class );
+
+		if ( empty( $session_entries ) || ! $tickets_commerce->is_checkout_page() ) {
+			// Not a Tickets Commerce checkout page: return the original entries.
+			return $session_entries;
+		}
+
+		// Get the post IDs in the cart.
+		global $wpdb;
+		/** @var Cart $cart */
+		$cart          = tribe( Cart::class );
+		$cart_items    = array_keys( $cart->get_items_in_cart() );
+
+		if( empty( $cart_items ) ) {
+			return [];
+		}
+
+		$ticket_ids_interval = DB::prepare(
+			implode( ',', array_fill( 0, count( $cart_items ), '%d' ) ),
+			...$cart_items
+		);
+		$cart_post_ids = DB::get_col(
+			DB::prepare(
+				"SELECT DISTINCT( meta_value ) FROM %i WHERE post_id IN ({$ticket_ids_interval}) AND meta_key = %s ",
+				$wpdb->postmeta,
+				Module::ATTENDEE_EVENT_KEY
+			)
+		);
+
+		// Get the post IDs in the session.
+		$session_post_ids = array_keys( $session_entries );
+
+		// Find out the post IDs part of both the cart and the seat selection session.
+		$cart_and_session_ids = array_intersect( $cart_post_ids, $session_post_ids );
+
+		if ( empty( $cart_and_session_ids ) ) {
+			// There are no Tickets for posts using Seat Assignment in the cart.
+			return [];
+		}
+
+		return array_combine(
+			$cart_and_session_ids,
+			array_map( static function ( $item ) use ( $session_entries ) {
+				return $session_entries[ $item ];
+			}, $cart_and_session_ids )
+		);
+	}
+}

--- a/src/Tickets/Seating/Controller.php
+++ b/src/Tickets/Seating/Controller.php
@@ -137,6 +137,10 @@ class Controller extends Controller_Contract {
 		} else {
 			$this->container->register( Frontend::class );
 		}
+
+		if ( tec_tickets_commerce_is_enabled() ) {
+			$this->container->register( Commerce\Controller::class );
+		}
 	}
 
 	/**

--- a/src/Tickets/Seating/Frontend/Session.php
+++ b/src/Tickets/Seating/Frontend/Session.php
@@ -208,7 +208,7 @@ class Session {
 			return true;
 		}
 
-		foreach ( $this->get_entries( $_COOKIE[ self::COOKIE_NAME ] ) as $entry_object_id => $entry_token ) {
+		foreach ( $this->get_entries() as $entry_object_id => $entry_token ) {
 			if ( $entry_object_id === $object_id ) {
 				$reservations = $this->sessions->get_reservations_for_token( $entry_token );
 
@@ -262,13 +262,24 @@ class Session {
 	 * @return array{0: string, 1: int}|null The token and object ID from the cookie, or `null` if not found.
 	 */
 	public function get_session_token_object_id(): ?array {
-		$cookie = sanitize_text_field( $_COOKIE[ self::COOKIE_NAME ] ?? '' );
+		$entries = $this->get_entries();
 
-		if ( ! $cookie ) {
+		/**
+		 * Filters the session entries used to get the token and object ID from the cookie for the purpose of
+		 * tracking the seat selection session.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string,string> $entries The entries from the cookie. A map from object ID to token.
+		 */
+		$entries = apply_filters(
+			'tec_tickets_seating_timer_token_object_id_entries',
+			$entries,
+		);
+
+		if ( empty( $entries ) ) {
 			return null;
 		}
-
-		$entries = $this->get_entries( $cookie );
 
 		/**
 		 * Filters the handler used to get the token and object ID from the cookie.

--- a/src/Tickets/Seating/Frontend/Timer.php
+++ b/src/Tickets/Seating/Frontend/Timer.php
@@ -267,9 +267,19 @@ class Timer extends Controller_Contract {
 
 			[ $token, $post_id ] = $cookie_timer_token_post_id;
 		} else {
+			if ( ! tec_tickets_seating_enabled( $post_id ) ) {
+				// The post is not using assigned seating, do not render the timer.
+				return;
+			}
+
 			// If a cookie and token were passed, store them for later use.
 			$this->current_token   = $token;
 			$this->current_post_id = $post_id;
+		}
+
+		if ( ! tec_tickets_seating_enabled( $post_id ) ) {
+			// The post is not using assigned seating, do not render the timer.
+			return;
 		}
 
 		wp_enqueue_script( 'tec-tickets-seating-session' );
@@ -538,5 +548,27 @@ class Timer extends Controller_Contract {
 				'redirectUrl' => esc_url( $redirect_url ),
 			]
 		);
+	}
+
+	/**
+	 * Returns the current token set from a previous render in the context of this request.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null The current token, or `null` if not set.
+	 */
+	public function get_current_token(): ?string {
+		return $this->current_token;
+	}
+
+	/**
+	 * Returns the current post ID set from a previous render in the context of this request.
+	 *
+	 * @since TBD
+	 *
+	 * @return int|null The current post ID, or `null` if not set.
+	 */
+	public function get_current_post_id(): ?int {
+		return $this->current_post_id;
 	}
 }

--- a/tests/slr_integration/TEC/Tickets/Seating/Commerce/Controller_Test.php
+++ b/tests/slr_integration/TEC/Tickets/Seating/Commerce/Controller_Test.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace TEC\Tickets\Seating\Commerce;
+
+use Closure;
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Seating\Meta;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe__Tickets__Data_API as Data_API;
+
+class Controller_Test extends Controller_Test_Case {
+	use Ticket_Maker;
+
+	protected string $controller_class = Controller::class;
+
+	/**
+	 * @before
+	 */
+	public function ensure_ticketable_post_types(): void {
+		$ticketable   = tribe_get_option( 'ticket-enabled-post-types', [] );
+		$ticketable[] = 'post';
+		tribe_update_option( 'ticket-enabled-post-types', array_values( array_unique( $ticketable ) ) );
+	}
+
+	/**
+	 * @before
+	 */
+	public function ensure_tickets_commerce_active(): void {
+		// Ensure the Tickets Commerce module is active.
+		add_filter( 'tec_tickets_commerce_is_enabled', '__return_true' );
+		add_filter( 'tribe_tickets_get_modules', function ( $modules ) {
+			$modules[ Module::class ] = tribe( Module::class )->plugin_name;
+
+			return $modules;
+		} );
+
+		// Reset Data_API object, so it sees Tribe Commerce.
+		tribe_singleton( 'tickets.data_api', new Data_API );
+	}
+
+	public function filter_timer_token_object_id_entries_data_provider(): \Generator {
+		yield 'no entries' => [
+			function (): array {
+				return [
+					[],
+					[],
+				];
+			}
+		];
+
+		yield 'not on checkout page' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+				add_filter( 'tec_tickets_commerce_checkout_is_current_page', '__return_false' );
+
+				return [
+					[ $post_id => 'test-token' ],
+					[ $post_id => 'test-token' ],
+				];
+			}
+		];
+
+		yield 'on checkout page but no ASC post in cart' => [
+			function (): array {
+				add_filter( 'tec_tickets_commerce_checkout_is_current_page', '__return_true' );
+				$no_asc_post_id = static::factory()->post->create();
+				$ticket_id      = $this->create_tc_ticket( $no_asc_post_id, 10 );
+				/** @var Cart $cart */
+				$cart = tribe( Cart::class );
+				$cart->add_ticket( $ticket_id, 1 );
+				$asc_post_id = static::factory()->post->create();
+				update_post_meta( $asc_post_id, Meta::META_KEY_LAYOUT_ID, 'some-layout-id' );
+				$asc_ticket_id = $this->create_tc_ticket( $asc_post_id, 10 );
+				$this->create_tc_ticket( $asc_post_id, 10 );
+
+				return [
+					[ $asc_post_id => 'test-token' ],
+					[],
+				];
+			}
+		];
+
+		yield 'on checkout page with ASC post in cart' => [
+			function (): array {
+				add_filter( 'tec_tickets_commerce_checkout_is_current_page', '__return_true' );
+				$no_asc_post_id   = static::factory()->post->create();
+				$no_asc_ticket_id = $this->create_tc_ticket( $no_asc_post_id, 10 );
+				/** @var Cart $cart */
+				$cart = tribe( Cart::class );
+				$cart->add_ticket( $no_asc_ticket_id, 1 );
+				$asc_post_id = static::factory()->post->create();
+				update_post_meta( $asc_post_id, Meta::META_KEY_LAYOUT_ID, 'some-layout-id' );
+				$asc_ticket_id = $this->create_tc_ticket( $asc_post_id, 10 );
+				$cart->add_ticket( $asc_ticket_id, 1 );
+
+				return [
+					[ $asc_post_id => 'test-token' ],
+					[ $asc_post_id => 'test-token' ],
+				];
+			}
+		];
+	}
+
+	/**
+	 * @dataProvider filter_timer_token_object_id_entries_data_provider
+	 * @return void
+	 */
+	public function test_filter_timer_token_object_id_entries( Closure $fixture ): void {
+		[ $input_entries, $expected_entries ] = $fixture();
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$filtered_entries = apply_filters( 'tec_tickets_seating_timer_token_object_id_entries', $input_entries );
+
+		$this->assertEquals(
+			$expected_entries,
+			$filtered_entries,
+		);
+	}
+}

--- a/tests/slr_integration/TEC/Tickets/Seating/Frontend/__snapshots__/Timer_Test__test_render_with_args__0.snapshot.html
+++ b/tests/slr_integration/TEC/Tickets/Seating/Frontend/__snapshots__/Timer_Test__test_render_with_args__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="tec-tickets-seating__timer tec-tickets-seating__timer--hidden"
 	data-token="{{token}}"
-	data-redirect-url=""
+	data-redirect-url="http://wordpress.test/?post_type=post&#038;p={{post_id}}"
 	data-post-id="{{post_id}}"
 	>
 	<div class="dashicons dashicons-clock"></div>


### PR DESCRIPTION
This fixes the timer appearing, and interrupting, during the TC checkout for posts and tickets that are not using ASC.

[Demo](https://share.cleanshot.com/dHnR6lh0)

The code is isolated to a TC dedicated controller, and covered by new tests.
