### PR TITLE
SLR - Fix replay session issue

### DIFF
--- a/src/Tickets/Seating/Frontend/Timer.php
+++ b/src/Tickets/Seating/Frontend/Timer.php
@@ -413,7 +413,7 @@ class Timer extends Controller_Contract {
 		$timeout = $this->get_timeout( $post_id );
 
 		// When starting a new session, we need to remove the previous sessions for the same post.
-		$this->session->cancel_previous_for_object( $post_id );
+		$this->session->cancel_previous_for_object( $post_id, $token );
 
 		// We're in the context of an XHR/AJAX request: the browser will set the cookie for us.
 		$now        = microtime( true );

--- a/src/Tickets/Seating/Tables/Sessions.php
+++ b/src/Tickets/Seating/Tables/Sessions.php
@@ -86,7 +86,7 @@ class Sessions extends Table {
 
 			return (int) DB::query( $query );
 		} catch ( \Exception $e ) {
-			( new self )->log_error(
+			( new self() )->log_error(
 				'Failed to remove expired sessions.',
 				[
 					'source' => __METHOD__,
@@ -264,11 +264,12 @@ class Sessions extends Table {
 			return false;
 		}
 
-		try {/*
-		 * The UPDATE operation will return the number of updated rows.
-		 * A value of 0 means that the row was either not found, or it did not need to be updated.
-		 * We want to fail the update if the row did not exist in the first place.
-		 */
+		try {
+			/*
+			* The UPDATE operation will return the number of updated rows.
+			* A value of 0 means that the row was either not found, or it did not need to be updated.
+			* We want to fail the update if the row did not exist in the first place.
+			*/
 			$exists = DB::get_var(
 				DB::prepare(
 					'SELECT token FROM %i WHERE token = %s',
@@ -276,20 +277,22 @@ class Sessions extends Table {
 					$token
 				)
 			);
+
 			if ( empty( $exists ) ) {
 				return false;
-			}/*
+			}
+
+			/*
 			 * The result of this query might be 0 to indicate that the row was not updated.
 			 * We want to fail the update if the row was not updated.
 			 */
-
 			return DB::update(
-					self::table_name(),
-					[ 'reservations' => $reservations_json ],
-					[ 'token' => $token ],
-					[ '%s' ],
-					[ '%s' ]
-				) !== false;
+				self::table_name(),
+				[ 'reservations' => $reservations_json ],
+				[ 'token' => $token ],
+				[ '%s' ],
+				[ '%s' ]
+			) !== false;
 		} catch ( \Exception $e ) {
 			$this->log_error(
 				'Failed to update the reservations for the token.',

--- a/src/Tickets/Seating/app/frontend/session/index.js
+++ b/src/Tickets/Seating/app/frontend/session/index.js
@@ -353,7 +353,7 @@ function startHealthCheckLoop() {
 	healthCheckLoopId = setTimeout(async () => {
 		await syncWithBackend();
 		startHealthCheckLoop();
-	}, 5 * 1000);
+	}, 3 * 1000);
 }
 
 /**
@@ -381,6 +381,9 @@ export async function syncWithBackend() {
 	}
 
 	startCountdownLoop(secondsLeft);
+	if (!healthCheckLoopId) {
+		startHealthCheckLoop();
+	}
 }
 
 /**

--- a/src/Tickets/Seating/app/frontend/session/index.js
+++ b/src/Tickets/Seating/app/frontend/session/index.js
@@ -353,7 +353,7 @@ function startHealthCheckLoop() {
 	healthCheckLoopId = setTimeout(async () => {
 		await syncWithBackend();
 		startHealthCheckLoop();
-	}, 60 * 1000);
+	}, 5 * 1000);
 }
 
 /**

--- a/src/Tickets/Seating/app/service/api/index.js
+++ b/src/Tickets/Seating/app/service/api/index.js
@@ -181,8 +181,12 @@ export async function establishReadiness(iframe) {
 	// Before setting the iframe source, start listening for messages from the service.
 	startListeningForServiceMessages(iframe);
 
+	let promiseReject;
+
 	// Build a promise that will resolve when the Service sends the ready message.
-	const promise = new Promise((resolve) => {
+	const promise = new Promise((resolve, reject) => {
+		promiseReject = reject;
+
 		const acknowledge = () => {
 			removeAction(INBOUND_APP_READY);
 
@@ -206,7 +210,7 @@ export async function establishReadiness(iframe) {
 
 	// Seat a 10s timeout to reject the promise if the connection is not established.
 	const timeoutId = setTimeout(() => {
-		promise.reject(new Error('Connection to service timed out'));
+		promiseReject(new Error('Connection to service timed out'));
 	}, 10000);
 
 	// Finally start loading the service in the iframe and wait for its ready message.

--- a/tests/slr_integration/Admin/Ajax_Test.php
+++ b/tests/slr_integration/Admin/Ajax_Test.php
@@ -1252,8 +1252,10 @@ class Ajax_Test extends Controller_Test_Case {
 		$_REQUEST['token']       = 'test-token';
 		$_REQUEST['postId']      = 23;
 		update_post_meta( 23, Meta::META_KEY_UUID, 'test-post-uuid' );
-		// Do not add a token entry in the sessions table: this will trigger a failure in the `clear_token_reservations` method.
-		$sessions = tribe( Sessions::class );
+		// Mock the session table to return false on clear_token_reservations.
+		$this->test_services->singleton( Sessions::class, $this->make( Sessions::class, [
+			'clear_token_reservations' => false
+		] ) );
 		$this->set_oauth_token( 'auth-token' );
 		$this->mock_wp_remote(
 			'post',

--- a/tests/slr_integration/_bootstrap.php
+++ b/tests/slr_integration/_bootstrap.php
@@ -20,9 +20,13 @@ tribe_register_provider( Commerce_Provider::class );
 
 tribe()->get( \TEC\Tickets\Seating\Service\Service::class );
 
+tribe()->get( Maps::class )->update();
 tribe()->get( Maps::class )->truncate();
+tribe()->get( Layouts::class )->update();
 tribe()->get( Layouts::class )->truncate();
+tribe()->get( Seat_Types::class )->update();
 tribe()->get( Seat_Types::class )->truncate();
+tribe()->get( Sessions::class )->update();
 tribe()->get( Sessions::class )->truncate();
 
 define( 'JSON_SNAPSHOT_OPTIONS', JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );


### PR DESCRIPTION
Rebase of #3107.

[Demo](https://github.com/the-events-calendar/event-tickets/pull/3106)

Based on #3106, this PR fixes an issue where the session timer would be reset, thus granting infinite time, on each seat selection flow restart (see video for clarity).

