### PR TITLE
TECTRIA-193 - Change admin menu item priority for TC test mode notice

### DIFF
--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -83,7 +83,7 @@ class Hooks extends Service_Provider {
 
 		add_action( 'tec_tickets_commerce_order_status_transition', [ $this, 'modify_tickets_counters_by_status', ], 15, 3 );
 
-		add_action( 'admin_bar_menu', [ $this, 'include_admin_bar_test_mode' ], 1000, 1 );
+		add_action( 'admin_bar_menu', [ $this, 'include_admin_bar_test_mode' ], 5, 1 );
 
 		add_action( 'tribe_template_before_include:tickets/v2/commerce/checkout', [ $this, 'include_assets_checkout_shortcode' ] );
 


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-193]

### 🗒️ Description

When Tickets Commerce Test Mode is enabled, a notice with a yellow background is added to the admin bar, to the left of the user info (“Howdy user”).
After the WordPress 6.6 update the notice is moved to the right side of the user info.

### 🎥 Artifacts <!-- if applicable-->
[Before WordPress 6.6](https://www.dropbox.com/scl/fi/ijvo07xni1idw7py5r3l4/shot_240722_141117.jpg?rlkey=2alejtcbucfhtabfv2ag6aa4y&dl=0)
[After WordPress 6.6](https://www.dropbox.com/scl/fi/6052yswnx5jvc25u4ry9f/shot_240722_141341.jpg?rlkey=k3toj4d7bex57hpa419wi35l1&dl=0)
  

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s).
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[TECTRIA-193]: https://stellarwp.atlassian.net/browse/TECTRIA-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ