### PR TITLE
[ET-2171] Replaces DOMNodeInserted event with a custom built animation

### DIFF
--- a/changelog/fix-TECTRIA-226-replace-DOMNodeInserted-event
+++ b/changelog/fix-TECTRIA-226-replace-DOMNodeInserted-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Replaces `DOMNodeInserted` event with a custom built one. [TECTRIA-226]
+Replaces `DOMNodeInserted` event with a custom built one. [ET-2171]

--- a/changelog/fix-TECTRIA-226-replace-DOMNodeInserted-event
+++ b/changelog/fix-TECTRIA-226-replace-DOMNodeInserted-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replaces `DOMNodeInserted` event with a custom built one. [TECTRIA-226]

--- a/event-tickets.php
+++ b/event-tickets.php
@@ -17,21 +17,21 @@
  */
 
 /*
- Copyright 2010-2022 by The Events Calendar and the contributors
+Copyright 2010-2022 by The Events Calendar and the contributors
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -544,7 +544,7 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * @since TBD Replaced DOMNodeInserted with animationstart event.
 	 */
 	obj.buttonsLoaded = function ( event ) {
-		if ( event.originalEvent.animationName !== 'nodeInserted' ) {
+		if ( event.originalEvent.animationName !== 'node_inserted' ) {
 			return;
 		}
 

--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -541,6 +541,7 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * Handle actions when checkout buttons are loaded.
 	 *
 	 * @since 5.1.10
+	 * @since TBD Replaced DOMNodeInserted with animationstart event.
 	 */
 	obj.buttonsLoaded = function ( event ) {
 		if ( event.originalEvent.animationName !== 'nodeInserted' ) {
@@ -593,6 +594,7 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * Setup the triggers for Ticket Commerce loader view.
 	 *
 	 * @since 5.1.10
+	 * @since TBD Replaced DOMNodeInserted with animationstart event.
 	 *
 	 * @return {void}
 	 */

--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -87,6 +87,7 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 		checkoutScript: '.tec-tc-gateway-paypal-checkout-script',
 		activePayment: '.tec-tc-gateway-paypal-payment-active',
 		buttons: '#tec-tc-gateway-paypal-checkout-buttons',
+		animatedElement: '.paypal-buttons-context-iframe',
 		advancedPayments: {
 			container: '.tribe-tickets__commerce-checkout-paypal-advanced-payments-container',
 			form: '.tribe-tickets__commerce-checkout-paypal-advanced-payments-form',
@@ -541,9 +542,15 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 *
 	 * @since 5.1.10
 	 */
-	obj.buttonsLoaded = function () {
+	obj.buttonsLoaded = function ( event ) {
+		if ( event.originalEvent.animationName !== 'nodeInserted' ) {
+			return;
+		}
+
 		$document.trigger( tribe.tickets.commerce.customEvents.hideLoader );
-		$( tribe.tickets.commerce.selectors.checkoutContainer ).off( 'DOMNodeInserted', obj.selectors.buttons, obj.buttonsLoaded );
+		$( tribe.tickets.commerce.selectors.checkoutContainer ).off( 'animationstart', obj.selectors.animatedElement, obj.buttonsLoaded );
+		$( tribe.tickets.commerce.selectors.checkoutContainer ).off( 'MSAnimationStart', obj.selectors.animatedElement, obj.buttonsLoaded );
+		$( tribe.tickets.commerce.selectors.checkoutContainer ).off( 'webkitAnimationStart', obj.selectors.animatedElement, obj.buttonsLoaded );
 	};
 
 	/**
@@ -593,7 +600,9 @@ tribe.tickets.commerce.gateway.paypal.checkout = {};
 		$document.trigger( tribe.tickets.commerce.customEvents.showLoader );
 
 		// Hide loader when Paypal buttons are added.
-		$( tribe.tickets.commerce.selectors.checkoutContainer ).on( 'DOMNodeInserted', obj.selectors.buttons, obj.buttonsLoaded );
+		$( tribe.tickets.commerce.selectors.checkoutContainer ).on( 'animationstart', obj.selectors.animatedElement, obj.buttonsLoaded );
+		$( tribe.tickets.commerce.selectors.checkoutContainer ).on( 'MSAnimationStart', obj.selectors.animatedElement, obj.buttonsLoaded );
+		$( tribe.tickets.commerce.selectors.checkoutContainer ).on( 'webkitAnimationStart', obj.selectors.animatedElement, obj.buttonsLoaded );
 	};
 
 	/**

--- a/src/resources/postcss/tickets-commerce/gateway/paypal/_all.pcss
+++ b/src/resources/postcss/tickets-commerce/gateway/paypal/_all.pcss
@@ -4,5 +4,6 @@
  * @since 5.2.0
  */
 
+@import "_nodeInsertedEvent.pcss";
 @import "_paypal.pcss";
 @import "_advanced-payments.pcss";

--- a/src/resources/postcss/tickets-commerce/gateway/paypal/_nodeInsertedEvent.pcss
+++ b/src/resources/postcss/tickets-commerce/gateway/paypal/_nodeInsertedEvent.pcss
@@ -1,0 +1,44 @@
+@keyframes nodeInserted {
+    from {
+       opacity: .99
+    }
+    to {
+       opacity: 1
+    }
+}
+
+@-moz-keyframes nodeInserted {
+    from {
+       opacity: .99
+    }
+    to {
+       opacity: 1
+    }
+}
+
+@-webkit-keyframes nodeInserted {
+    from {
+       opacity: .99
+    }
+    to {
+       opacity: 1
+    }
+}
+
+@-ms-keyframes nodeInserted {
+    from {
+       opacity: .99
+    }
+    to {
+       opacity: 1
+    }
+}
+
+@-o-keyframes nodeInserted {
+    from {
+       opacity: .99
+    }
+    to {
+       opacity: 1
+    }
+}

--- a/src/resources/postcss/tickets-commerce/gateway/paypal/_nodeInsertedEvent.pcss
+++ b/src/resources/postcss/tickets-commerce/gateway/paypal/_nodeInsertedEvent.pcss
@@ -1,44 +1,55 @@
-@keyframes nodeInserted {
-    from {
-       opacity: .99
-    }
-    to {
-       opacity: 1
-    }
+/**
+ * Event Tickets - Tickets Commerce PayPal Stylesheet
+ *
+ * @since TBD
+ */
+
+@keyframes node_inserted {
+	from {
+		opacity: 0.99;
+	}
+
+	to {
+		opacity: 1;
+	}
 }
 
-@-moz-keyframes nodeInserted {
-    from {
-       opacity: .99
-    }
-    to {
-       opacity: 1
-    }
+@-moz-keyframes node_inserted {
+	from {
+		opacity: 0.99;
+	}
+
+	to {
+		opacity: 1;
+	}
 }
 
-@-webkit-keyframes nodeInserted {
-    from {
-       opacity: .99
-    }
-    to {
-       opacity: 1
-    }
+@-webkit-keyframes node_inserted {
+	from {
+		opacity: 0.99;
+	}
+
+	to {
+		opacity: 1;
+	}
 }
 
-@-ms-keyframes nodeInserted {
-    from {
-       opacity: .99
-    }
-    to {
-       opacity: 1
-    }
+@-ms-keyframes node_inserted {
+	from {
+		opacity: 0.99;
+	}
+
+	to {
+		opacity: 1;
+	}
 }
 
-@-o-keyframes nodeInserted {
-    from {
-       opacity: .99
-    }
-    to {
-       opacity: 1
-    }
+@-o-keyframes node_inserted {
+	from {
+		opacity: 0.99;
+	}
+
+	to {
+		opacity: 1;
+	}
 }

--- a/src/resources/postcss/tickets-commerce/gateway/paypal/_paypal.pcss
+++ b/src/resources/postcss/tickets-commerce/gateway/paypal/_paypal.pcss
@@ -12,6 +12,16 @@
 
 	.paypal-buttons-context-iframe {
 		background-color: #fafafa !important;
+		animation-duration: 0.01s;
+		-o-animation-duration: 0.01s;
+		-ms-animation-duration: 0.01s;
+		-moz-animation-duration: 0.01s;
+		-webkit-animation-duration: 0.01s;
+		animation-name: nodeInserted;
+		-o-animation-name: nodeInserted;
+		-ms-animation-name: nodeInserted;
+		-moz-animation-name: nodeInserted;
+		-webkit-animation-name: nodeInserted;
 
 		/* @todo: more to be defined for the PayPal Iframe */
 	}

--- a/src/resources/postcss/tickets-commerce/gateway/paypal/_paypal.pcss
+++ b/src/resources/postcss/tickets-commerce/gateway/paypal/_paypal.pcss
@@ -11,17 +11,17 @@
 	}
 
 	.paypal-buttons-context-iframe {
-		background-color: #fafafa !important;
-		animation-duration: 0.01s;
-		-o-animation-duration: 0.01s;
-		-ms-animation-duration: 0.01s;
 		-moz-animation-duration: 0.01s;
+		-ms-animation-duration: 0.01s;
+		-o-animation-duration: 0.01s;
 		-webkit-animation-duration: 0.01s;
-		animation-name: nodeInserted;
-		-o-animation-name: nodeInserted;
-		-ms-animation-name: nodeInserted;
-		-moz-animation-name: nodeInserted;
-		-webkit-animation-name: nodeInserted;
+		animation-duration: 0.01s;
+		-moz-animation-name: node_inserted;
+		-ms-animation-name: node_inserted;
+		-o-animation-name: node_inserted;
+		-webkit-animation-name: node_inserted;
+		animation-name: node_inserted;
+		background-color: #fafafa !important;
 
 		/* @todo: more to be defined for the PayPal Iframe */
 	}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2171]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Replaces DOMNodeInserted event with a custom built one using css.

How does it work ?

We are creating an animation `nodeInserted` which we apply to an element we want to listen for when its injected. We listen for the animation start event.

Why like this ?

This is a widely used technique for replacing `DOMNodeInserted` and its guaranteed that it will continue to work for a long time.

### 🎥 Artifacts <!-- if applicable-->
https://jumpshare.com/embed/uINU2b1hMBjXmwivzsjg

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s).
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2171]: https://stellarwp.atlassian.net/browse/ET-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ