### PR TITLE
Account for a blank global mode string

### DIFF
--- a/changelog/fix-ET-920-global-stock-being-reduced-on-unlimited-sales-tickets
+++ b/changelog/fix-ET-920-global-stock-being-reduced-on-unlimited-sales-tickets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Shared capacity will no longer be affected by any of the unlimited sales tickets on the same event. [ETP-920]

--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -682,7 +682,7 @@ class Ticket {
 			$data['stock'] = - 1;
 		}
 
-		$mode = isset( $data['mode'] ) ? $data['mode'] : 'own';
+		$mode = ! empty( $data['mode'] ) ? $data['mode'] : 'own';
 
 		if ( '' !== $mode ) {
 			if ( 'update' === $save_type ) {
@@ -917,7 +917,7 @@ class Ticket {
 			$updated_total_sales
 		);
 
-		if (  'own' !== $shared_capacity && $global_stock instanceof \Tribe__Tickets__Global_Stock ) {
+		if ( ! empty( $shared_capacity ) && 'own' !== $shared_capacity && $global_stock instanceof \Tribe__Tickets__Global_Stock ) {
 			$this->update_global_stock( $global_stock, $quantity );
 		}
 

--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -893,6 +893,7 @@ class Ticket {
 	 * @todo  TribeCommerceLegacy: This should be moved into using a Flag Action.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Added a check to make sure shared capacity is not empty before updating global stock.
 	 *
 	 * @param int                                $ticket_id       The ticket post ID.
 	 * @param int                                $quantity        The quantity to increase the ticket sales by.

--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -682,7 +682,7 @@ class Ticket {
 			$data['stock'] = - 1;
 		}
 
-		$mode = ! empty( $data['mode'] ) ? $data['mode'] : 'own';
+		$mode = isset( $data['mode'] ) ? $data['mode'] : 'own';
 
 		if ( '' !== $mode ) {
 			if ( 'update' === $save_type ) {


### PR DESCRIPTION
### 🎫 Ticket
[ETP-920]

### 🗒️ Description
It was found that using Tickets Commerce and having shared capacity and unlimited capacity ticket on the same event/post, the global stock value was being decreased even when purchasing an unlimited ticket. Global stock should only be decreased on shared capacity tickets. I found that unlimited capacity tickets have their "ticket stock mode" set to either 'own' or a blank string. When a ticket is purchased, we weren't checking for the blank string before updating the global stock.

### 🎥 Artifacts <!-- if applicable-->
[Screencast](https://share.zight.com/2Nu8ng1P)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s).
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ETP-920]: https://stellarwp.atlassian.net/browse/ETP-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ