### PR TITLE
Revert "Account for a blank global mode string"

### DIFF
--- a/changelog/fix-ET-920-global-stock-being-reduced-on-unlimited-sales-tickets
+++ b/changelog/fix-ET-920-global-stock-being-reduced-on-unlimited-sales-tickets
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Shared capacity will no longer be affected by any of the unlimited sales tickets on the same event. [ETP-920]

--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -917,7 +917,7 @@ class Ticket {
 			$updated_total_sales
 		);
 
-		if (  'own' !== $shared_capacity && $global_stock instanceof \Tribe__Tickets__Global_Stock ) {
+		if ( 'own' !== $shared_capacity && $global_stock instanceof \Tribe__Tickets__Global_Stock ) {
 			$this->update_global_stock( $global_stock, $quantity );
 		}
 

--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -893,7 +893,6 @@ class Ticket {
 	 * @todo  TribeCommerceLegacy: This should be moved into using a Flag Action.
 	 *
 	 * @since 5.1.9
-	 * @since TBD Added a check to make sure shared capacity is not empty before updating global stock.
 	 *
 	 * @param int                                $ticket_id       The ticket post ID.
 	 * @param int                                $quantity        The quantity to increase the ticket sales by.
@@ -918,7 +917,7 @@ class Ticket {
 			$updated_total_sales
 		);
 
-		if ( ! empty( $shared_capacity ) && 'own' !== $shared_capacity && $global_stock instanceof \Tribe__Tickets__Global_Stock ) {
+		if (  'own' !== $shared_capacity && $global_stock instanceof \Tribe__Tickets__Global_Stock ) {
 			$this->update_global_stock( $global_stock, $quantity );
 		}
 


### PR DESCRIPTION
Reverts the-events-calendar/event-tickets#3145

This should have gone into chupacabra. Not centaur.

Replaced by https://github.com/the-events-calendar/event-tickets/pull/3151