### PR TITLE
Add Shared Capacity Test for Specific Scenario

### DIFF
--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/SharedCapacityTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/SharedCapacityTest.php
@@ -441,4 +441,90 @@ class SharedCapacityTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEqualSets( $expected_ticket_counts, $event_ticket_counts['tickets'] );
 	}
+
+	public function test_tc_total_shared_capacity_should_not_change_after_unlimited_capacity_ticket_purchase() {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Test Event',
+				'status'     => 'publish',
+				'start_date' => '2020-01-01 12:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+		// Enable the global stock on the Event.
+		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
+		// Set the Event shared capacity to 20.
+		update_post_meta( Tickets_Handler::instance()->key_capacity, 20, $event_id );
+		// Set the Event global stock level to 20.
+		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_LEVEL, 20 );
+
+		$ticket_a_id = $this->create_tc_ticket(
+			$event_id,
+			20,
+			[
+				'tribe-ticket' => [
+					'mode'     => Global_Stock::OWN_STOCK_MODE,
+					'capacity' => -1,
+				],
+			]
+		);
+		$ticket_b_id = $this->create_tc_ticket(
+			$event_id,
+			20,
+			[
+				'tribe-ticket' => [
+					'mode'     => Global_Stock::GLOBAL_STOCK_MODE,
+					'capacity' => 20,
+				],
+			]
+		);
+
+		// Get the ticket objects.
+		$ticket_a = tribe( Module::class )->get_ticket( $event_id, $ticket_a_id );
+		$ticket_b = tribe( Module::class )->get_ticket( $event_id, $ticket_b_id );
+
+		$global_stock = new Global_Stock( $event_id );
+
+		$this->assertTrue( $global_stock->is_enabled(), 'Global stock should be enabled.' );
+		$this->assertEquals( -1, tribe_get_event_capacity( $event_id ), 'Total Event capacity should be -1 or unlimited' );
+		$this->assertEquals( 20, $global_stock->get_stock_level(), 'Global stock should be 20' );
+
+		// Make sure both tickets are valid Ticket Object.
+		$this->assertInstanceOf( Ticket_Object::class, $ticket_a );
+		$this->assertInstanceOf( Ticket_Object::class, $ticket_b );
+
+		$this->assertEquals( -1, $ticket_a->capacity() );
+		$this->assertEquals( -1, $ticket_a->stock() );
+		$this->assertEquals( -1, $ticket_a->available() );
+		$this->assertEquals( -1, $ticket_a->inventory() );
+
+		$this->assertEquals( 20, $ticket_b->capacity() );
+		$this->assertEquals( 20, $ticket_b->stock() );
+		$this->assertEquals( 20, $ticket_b->available() );
+		$this->assertEquals( 20, $ticket_b->inventory() );
+
+		// Create order for Unlimited capacity ticket only.
+		$order = $this->create_order(
+			[
+				$ticket_a_id => 5,
+			]
+		);
+
+		// Refresh the ticket objects.
+		$ticket_a = tribe( Module::class )->get_ticket( $event_id, $ticket_a_id );
+		$ticket_b = tribe( Module::class )->get_ticket( $event_id, $ticket_b_id );
+
+		$this->assertEquals( -1, $ticket_a->capacity() );
+		$this->assertEquals( -1, $ticket_a->stock() );
+		$this->assertEquals( -1, $ticket_a->available() );
+		$this->assertEquals( -1, $ticket_a->inventory() );
+
+		// Shared capacity should not change.
+		$this->assertEquals( 20, $ticket_b->capacity() );
+		$this->assertEquals( 20, $ticket_b->stock() );
+		$this->assertEquals( 20, $ticket_b->available() );
+		$this->assertEquals( 20, $ticket_b->inventory() );
+
+		$this->assertEquals( 20, $global_stock->get_stock_level(), 'Global stock should still be 20' );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket
[ETP-920]

### 🗒️ Description
Created a test for a specific scenario that wasn't being tested before. In TC, when purchasing an unlimited capacity ticket, it was decreasing the global stock count for shared capacity tickets. It should not.

The bug fix PR is here: https://github.com/the-events-calendar/event-tickets/pull/3151

Note: No changelog needed as it was added in the above PR.

### 🎥 Artifacts <!-- if applicable-->
Failing test before the bugfix:
![image](https://github.com/user-attachments/assets/542c39ab-0a59-47d8-ac0a-7865322463fe)

Passing test after the bugfix:
![image](https://github.com/user-attachments/assets/22c44221-a789-467e-bec6-8fd1ef953f9b)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s).
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ETP-920]: https://stellarwp.atlassian.net/browse/ETP-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ