### PR TITLE
Card Element option in Stripe Settings fix

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
@@ -4,6 +4,7 @@ namespace TEC\Tickets\Commerce\Gateways\Stripe;
 
 use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Commerce\Gateways\Stripe\Merchant;
 
 /**
  * Class Payment_Element
@@ -47,7 +48,10 @@ class Stripe_Elements {
 	 * @return bool
 	 */
 	public function include_payment_element() {
-		return tribe_get_option( Settings::$option_checkout_element ) === Settings::PAYMENT_ELEMENT_SLUG;
+		$payment_methods = ( new Merchant() )->get_payment_method_types();
+		$card_only       = ( 1 === count( $payment_methods ) && 'card' === $payment_methods[0] ) ? true : false;
+		$payment_setting = tribe_get_option( Settings::$option_checkout_element ) === Settings::PAYMENT_ELEMENT_SLUG ? true : false;
+		return $payment_setting && ! $card_only;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
@@ -48,10 +48,11 @@ class Stripe_Elements {
 	 * @return bool
 	 */
 	public function include_payment_element() {
+		if ( tribe_get_option( Settings::$option_checkout_element ) !== Settings::PAYMENT_ELEMENT_SLUG  ) {
+			return false;
+		}
 		$payment_methods = ( new Merchant() )->get_payment_method_types();
-		$card_only       = ( 1 === count( $payment_methods ) && 'card' === $payment_methods[0] ) ? true : false;
-		$payment_setting = tribe_get_option( Settings::$option_checkout_element ) === Settings::PAYMENT_ELEMENT_SLUG ? true : false;
-		return $payment_setting && ! $card_only;
+		return ! ( 1 === count( $payment_methods ) && 'card' === $payment_methods[0] );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
@@ -48,10 +48,13 @@ class Stripe_Elements {
 	 * @return bool
 	 */
 	public function include_payment_element() {
-		if ( tribe_get_option( Settings::$option_checkout_element ) !== Settings::PAYMENT_ELEMENT_SLUG  ) {
+		if ( tribe_get_option( Settings::$option_checkout_element ) !== Settings::PAYMENT_ELEMENT_SLUG ) {
 			return false;
 		}
+
 		$payment_methods = ( new Merchant() )->get_payment_method_types();
+
+		// Don't load the Payment Element if just the Credit Card method is selected.
 		return ! ( 1 === count( $payment_methods ) && 'card' === $payment_methods[0] );
 	}
 

--- a/src/admin-views/settings/tickets-commerce/stripe/modal/signup-complete/content.php
+++ b/src/admin-views/settings/tickets-commerce/stripe/modal/signup-complete/content.php
@@ -61,7 +61,7 @@
 		printf(
 			// Translators: %1$s: opening `a` tag to the knowledge base article. %2$s: closing `a` tag.
 			esc_html__( 'If you use certain payment providers with Stripe, including Afterpay, Klarna, or Clearpay, additional Billing Fields will be displayed at checkout as required by Stripe. %1$sLearn More%2$s.', 'event-tickets' ),
-			'<a href="https://theeventscalendar.com/knowledgebase/k/pci-compliance/" target="_blank" rel="noopener noreferrer" class="tribe-common-anchor-alt">',
+			'<a href="https://evnt.is/stripe-info" target="_blank" rel="noopener noreferrer" class="tribe-common-anchor-alt">',
 			'</a>'
 		);
 		?>


### PR DESCRIPTION
### 🎫 Ticket

[ETP-934]

### 🗒️ Description

When we select this option:
![Screenshot_1](https://github.com/user-attachments/assets/0c433242-c2d6-4be5-94df-ee5559d0b9be)
we load the simple `Card Element` from Stripe gateway.

When we select this option, but only the CC method:
![Screenshot_2](https://github.com/user-attachments/assets/744d7687-184f-4383-a07e-660a86ce2316)
we shouldn't load the full `Payment Element` from Stripe, but again the simple `Card Element`.


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s).
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ETP-934]: https://stellarwp.atlassian.net/browse/ETP-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ