### PR TITLE
[SL-51] Fixes undefined variables on delete map action

### DIFF
--- a/src/Tickets/Seating/app/admin/maps/actions.js
+++ b/src/Tickets/Seating/app/admin/maps/actions.js
@@ -1,4 +1,4 @@
-import { ajaxUrl, ajaxNonce } from '@tec/tickets/seating/service';
+import { ajaxUrl, ajaxNonce } from '@tec/tickets/seating/ajax';
 import { onReady, getLocalizedString } from '@tec/tickets/seating/utils';
 
 /**
@@ -14,10 +14,12 @@ export function getString(key) {
 
 /**
  * Register delete action on all links with class 'delete-map'.
+ *
+ * @param {HTMLDocument|null} dom The document to use to search for the delete buttons.
  */
-export function registerDeleteAction() {
+export function registerDeleteAction(dom) {
 	// Add click listener to all links with class 'delete'.
-	document.querySelectorAll('.delete-map').forEach(function (link) {
+	dom.querySelectorAll('.delete-map').forEach(function (link) {
 		link.addEventListener('click', async function (event) {
 			event.preventDefault();
 			await handleDelete(event.target);
@@ -74,4 +76,4 @@ async function deleteMap(mapId) {
 
 export { handleDelete, deleteMap };
 
-onReady(registerDeleteAction);
+onReady(() => registerDeleteAction(document));

--- a/tests/slr_jest/_bootstrap.js
+++ b/tests/slr_jest/_bootstrap.js
@@ -178,7 +178,7 @@ global.getTestDocument = function (documentName, transformer) {
 		'seats-selection':
 			'/../slr_integration/__snapshots__/Frontend_Test__should_replace_ticket_block_when_seating_is_enabled__two tickets__0.snapshot.html',
 		'maps-edit':
-			'/../slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_maps_tab_card_listing_with_1_map__0.snapshot.html',
+			'/../slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_maps_tab_card_listing__0.snapshot.html',
 	};
 
 	if (!validDocumentMap[documentName]) {

--- a/tests/slr_jest/_bootstrap.js
+++ b/tests/slr_jest/_bootstrap.js
@@ -177,6 +177,8 @@ global.getTestDocument = function (documentName, transformer) {
 			'/../slr_integration/Orders/__snapshots__/Seats_Report_Test__test_render_page__2_tickets_3_attendees__0.snapshot.html',
 		'seats-selection':
 			'/../slr_integration/__snapshots__/Frontend_Test__should_replace_ticket_block_when_seating_is_enabled__two tickets__0.snapshot.html',
+		'maps-edit':
+			'/../slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_maps_tab_card_listing_with_1_map__0.snapshot.html',
 	};
 
 	if (!validDocumentMap[documentName]) {

--- a/tests/slr_jest/admin/maps/actions.spec.js
+++ b/tests/slr_jest/admin/maps/actions.spec.js
@@ -1,0 +1,188 @@
+import {
+	getString,
+	registerDeleteAction
+} from '@tec/tickets/seating/admin/maps/actions';
+
+require('jest-fetch-mock').enableMocks();
+
+const locationBackup = window.location;
+
+function mockWindowLocation() {
+	delete window.location;
+	window.location = {
+		reload: jest.fn(),
+	};
+}
+
+function getTestDocument() {
+	return new DOMParser().parseFromString(
+		`<div class="event-tickets"">
+					<div class="tec-tickets__seating-tab__card">
+						<a class="button button-secondary add-map"
+							href="/wp-admin/admin.php?action=create&amp;page=tec-tickets-seating&amp;tab=layout-edit&amp;mapId=map-1-uuid">
+							Create Layout
+						</a>
+						<a class="button button-secondary edit-map"
+							href="/wp-admin/admin.php?page=tec-tickets-seating&amp;tab=map-edit&amp;mapId=map-1-uuid">
+							Edit
+						</a>
+						<a class="delete-map" data-map-id="map-1-uuid" href="#">
+							Delete
+						</a>
+					</div>
+					<div class="tec-tickets__seating-tab__card">
+						<a class="button button-secondary add-map"
+							href="/wp-admin/admin.php?action=create&amp;page=tec-tickets-seating&amp;tab=layout-edit&amp;mapId=map-2-uuid">
+							Create Layout
+						</a>
+						<a class="button button-secondary edit-map"
+							href="/wp-admin/admin.php?page=tec-tickets-seating&amp;tab=map-edit&amp;mapId=map-2-uuid">
+							Edit
+						</a>
+						<a class="delete-map" data-map-id="map-2-uuid" href="#">
+							Delete
+						</a>
+					</div>
+					<div class="tec-tickets__seating-tab__card">
+						<a class="button button-secondary add-map"
+							href="/wp-admin/admin.php?action=create&amp;page=tec-tickets-seating&amp;tab=layout-edit&amp;mapId=map-3-uuid">
+							Create Layout
+						</a>
+						<a class="button button-secondary edit-map"
+							href="/wp-admin/admin.php?page=tec-tickets-seating&amp;tab=map-edit&amp;mapId=map-3-uuid">
+							Edit
+						</a>
+						<a class="delete-map" data-map-id="map-3-uuid" href="#">
+							Delete
+						</a>
+					</div>
+				</div>`,
+		'text/html'
+	);
+}
+
+describe('map actions', () => {
+	beforeEach(() => {
+		fetch.resetMocks();
+		jest.resetModules();
+		jest.resetAllMocks();
+		mockWindowLocation();
+	});
+
+	afterEach(() => {
+		fetch.resetMocks();
+		jest.resetModules();
+		jest.resetAllMocks();
+		window.location = locationBackup;
+	});
+
+	describe('delete action', () => {
+		it('should handle delete request correctly', async () => {
+			const dom = getTestDocument();
+			const deleteButtons = dom.querySelectorAll('.delete-map');
+			global.confirm = jest.fn(() => true);
+			fetch.mockIf(
+				/^https:\/\/wordpress\.test\/wp-admin\/admin-ajax\.php?.*$/,
+				JSON.stringify({ success: true })
+			);
+
+			registerDeleteAction(dom);
+
+			// Click the first delete button, the double await is needed to make sure we wait for the fetch to complete.
+			await await deleteButtons[0].click();
+
+			expect(confirm).toHaveBeenCalledWith(
+				getString('delete-confirmation')
+			);
+			expect(fetch).toBeCalledWith(
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-1-uuid&action=tec_tickets_seating_service_delete_map',
+				{
+					method: 'POST',
+				}
+			);
+			expect(window.location.reload).toHaveBeenCalled();
+
+			fetch.resetMocks();
+
+			// Click the second delete button.
+			await await deleteButtons[1].click();
+
+			expect(confirm).toHaveBeenCalledWith(
+				getString('delete-confirmation')
+			);
+			expect(fetch).toBeCalledWith(
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-2-uuid&action=tec_tickets_seating_service_delete_map',
+				{
+					method: 'POST',
+				}
+			);
+			expect(window.location.reload).toHaveBeenCalled();
+
+			fetch.resetMocks();
+
+			// Click the third delete button.
+			await await deleteButtons[2].click();
+
+			expect(confirm).toHaveBeenCalledWith(
+				getString('delete-confirmation')
+			);
+			expect(fetch).toBeCalledWith(
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-3-uuid&action=tec_tickets_seating_service_delete_map',
+				{
+					method: 'POST',
+				}
+			);
+			expect(window.location.reload).toHaveBeenCalled();
+		});
+
+		it('should not delete on backend if not confirmed', async () => {
+			const dom = getTestDocument();
+			const deleteButtons = dom.querySelectorAll('.delete-map');
+			// Do not confirm the delete request.
+			global.confirm = jest.fn(() => false);
+			fetch.mockIf(
+				/^https:\/\/wordpress\.test\/wp-admin\/admin-ajax\.php?.*$/,
+				JSON.stringify({ success: true })
+			);
+
+			registerDeleteAction(dom);
+
+			// Click the first delete button.
+			await await deleteButtons[0].click();
+
+			expect(confirm).toHaveBeenCalledWith(
+				getString('delete-confirmation')
+			);
+			expect(fetch).not.toHaveBeenCalled();
+		});
+
+		it('should fail on backend fail to delete layout', async () => {
+			const dom = getTestDocument();
+			const deleteButtons = dom.querySelectorAll('.delete-map');
+			global.confirm = jest.fn(() => true);
+			fetch.mockIf(
+				/^https:\/\/wordpress\.test\/wp-admin\/admin-ajax\.php?.*$/,
+				JSON.stringify({ success: false }),
+				{ status: 400 }
+			);
+			global.alert = jest.fn();
+
+			registerDeleteAction(dom);
+
+			// Click the first delete button, the double await is needed to make sure we wait for the fetch to complete.
+			await await deleteButtons[0].click();
+
+			expect(confirm).toHaveBeenCalledWith(
+				getString('delete-confirmation')
+			);
+			expect(fetch).toBeCalledWith(
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-1-uuid&action=tec_tickets_seating_service_delete_map',
+				{
+					method: 'POST',
+				}
+			);
+			expect(window.location.reload).not.toHaveBeenCalled();
+			expect(alert).toHaveBeenCalledWith(getString('delete-failed'));
+		});
+	});
+});

--- a/tests/slr_jest/admin/maps/actions.spec.js
+++ b/tests/slr_jest/admin/maps/actions.spec.js
@@ -14,52 +14,17 @@ function mockWindowLocation() {
 	};
 }
 
-function getTestDocument() {
-	return new DOMParser().parseFromString(
-		`<div class="event-tickets"">
-					<div class="tec-tickets__seating-tab__card">
-						<a class="button button-secondary add-map"
-							href="/wp-admin/admin.php?action=create&amp;page=tec-tickets-seating&amp;tab=layout-edit&amp;mapId=map-1-uuid">
-							Create Layout
-						</a>
-						<a class="button button-secondary edit-map"
-							href="/wp-admin/admin.php?page=tec-tickets-seating&amp;tab=map-edit&amp;mapId=map-1-uuid">
-							Edit
-						</a>
-						<a class="delete-map" data-map-id="map-1-uuid" href="#">
-							Delete
-						</a>
-					</div>
-					<div class="tec-tickets__seating-tab__card">
-						<a class="button button-secondary add-map"
-							href="/wp-admin/admin.php?action=create&amp;page=tec-tickets-seating&amp;tab=layout-edit&amp;mapId=map-2-uuid">
-							Create Layout
-						</a>
-						<a class="button button-secondary edit-map"
-							href="/wp-admin/admin.php?page=tec-tickets-seating&amp;tab=map-edit&amp;mapId=map-2-uuid">
-							Edit
-						</a>
-						<a class="delete-map" data-map-id="map-2-uuid" href="#">
-							Delete
-						</a>
-					</div>
-					<div class="tec-tickets__seating-tab__card">
-						<a class="button button-secondary add-map"
-							href="/wp-admin/admin.php?action=create&amp;page=tec-tickets-seating&amp;tab=layout-edit&amp;mapId=map-3-uuid">
-							Create Layout
-						</a>
-						<a class="button button-secondary edit-map"
-							href="/wp-admin/admin.php?page=tec-tickets-seating&amp;tab=map-edit&amp;mapId=map-3-uuid">
-							Edit
-						</a>
-						<a class="delete-map" data-map-id="map-3-uuid" href="#">
-							Delete
-						</a>
-					</div>
-				</div>`,
-		'text/html'
-	);
-}
+const getMapTestDocument = () => {
+	const transformer = (html) => {
+		return (
+			html +
+			html.replaceAll('mapId=1', 'mapId=2').replaceAll('data-map-id="1"', 'data-map-id="2"') +
+			html.replaceAll('mapId=1', 'mapId=3').replaceAll('data-map-id="1"', 'data-map-id="3"')
+		);
+	};
+
+	return getTestDocument('maps-edit', transformer);
+};
 
 describe('map actions', () => {
 	beforeEach(() => {
@@ -78,7 +43,7 @@ describe('map actions', () => {
 
 	describe('delete action', () => {
 		it('should handle delete request correctly', async () => {
-			const dom = getTestDocument();
+			const dom = getMapTestDocument();
 			const deleteButtons = dom.querySelectorAll('.delete-map');
 			global.confirm = jest.fn(() => true);
 			fetch.mockIf(
@@ -95,7 +60,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-1-uuid&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=1&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}
@@ -111,7 +76,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-2-uuid&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=2&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}
@@ -127,7 +92,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-3-uuid&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=3&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}
@@ -136,7 +101,7 @@ describe('map actions', () => {
 		});
 
 		it('should not delete on backend if not confirmed', async () => {
-			const dom = getTestDocument();
+			const dom = getMapTestDocument();
 			const deleteButtons = dom.querySelectorAll('.delete-map');
 			// Do not confirm the delete request.
 			global.confirm = jest.fn(() => false);
@@ -157,7 +122,7 @@ describe('map actions', () => {
 		});
 
 		it('should fail on backend fail to delete layout', async () => {
-			const dom = getTestDocument();
+			const dom = getMapTestDocument();
 			const deleteButtons = dom.querySelectorAll('.delete-map');
 			global.confirm = jest.fn(() => true);
 			fetch.mockIf(
@@ -176,7 +141,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-1-uuid&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=1&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}

--- a/tests/slr_jest/admin/maps/actions.spec.js
+++ b/tests/slr_jest/admin/maps/actions.spec.js
@@ -14,18 +14,6 @@ function mockWindowLocation() {
 	};
 }
 
-const getMapTestDocument = () => {
-	const transformer = (html) => {
-		return (
-			html +
-			html.replaceAll('mapId=1', 'mapId=2').replaceAll('data-map-id="1"', 'data-map-id="2"') +
-			html.replaceAll('mapId=1', 'mapId=3').replaceAll('data-map-id="1"', 'data-map-id="3"')
-		);
-	};
-
-	return getTestDocument('maps-edit', transformer);
-};
-
 describe('map actions', () => {
 	beforeEach(() => {
 		fetch.resetMocks();
@@ -43,7 +31,7 @@ describe('map actions', () => {
 
 	describe('delete action', () => {
 		it('should handle delete request correctly', async () => {
-			const dom = getMapTestDocument();
+			const dom = getTestDocument( 'maps-edit' );
 			const deleteButtons = dom.querySelectorAll('.delete-map');
 			global.confirm = jest.fn(() => true);
 			fetch.mockIf(
@@ -60,7 +48,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=1&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-uuid-1&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}
@@ -76,7 +64,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=2&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-uuid-2&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}
@@ -92,7 +80,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=3&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-uuid-3&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}
@@ -101,7 +89,7 @@ describe('map actions', () => {
 		});
 
 		it('should not delete on backend if not confirmed', async () => {
-			const dom = getMapTestDocument();
+			const dom = getTestDocument( 'maps-edit' );
 			const deleteButtons = dom.querySelectorAll('.delete-map');
 			// Do not confirm the delete request.
 			global.confirm = jest.fn(() => false);
@@ -122,7 +110,7 @@ describe('map actions', () => {
 		});
 
 		it('should fail on backend fail to delete layout', async () => {
-			const dom = getMapTestDocument();
+			const dom = getTestDocument( 'maps-edit' );
 			const deleteButtons = dom.querySelectorAll('.delete-map');
 			global.confirm = jest.fn(() => true);
 			fetch.mockIf(
@@ -141,7 +129,7 @@ describe('map actions', () => {
 				getString('delete-confirmation')
 			);
 			expect(fetch).toBeCalledWith(
-				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=1&action=tec_tickets_seating_service_delete_map',
+				'https://wordpress.test/wp-admin/admin-ajax.php?_ajax_nonce=1234567890&mapId=map-uuid-1&action=tec_tickets_seating_service_delete_map',
 				{
 					method: 'POST',
 				}


### PR DESCRIPTION
### 🎫 Ticket

[SL-51]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The issue was that some variables being used were imported from the wrong location.

**NOTE:** I will rebase after merging #3183 to fix what is broken now.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[SL-51]: https://stellarwp.atlassian.net/browse/SL-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ