### PR TITLE
Allow filtering of options for`setupCompactCardElement`

### DIFF
--- a/changelog/feature-customize-stripe-checkout-filter
+++ b/changelog/feature-customize-stripe-checkout-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Tweaked `setupCompactCardElement` method to allow filtering of options using the existing `tec_tickets_commerce_stripe_checkout_localized_data` filter. [TECTRIA-295]

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -106,8 +106,11 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 								],
 							],
 							'cardElementOptions' => [
-								// Intentionally empty to allow for filtering of available options from Stripe.
-								// @link https://docs.stripe.com/js/elements_object/create_element?type=card#elements_create-options
+								/**
+								 * Intentionally empty to allow for filtering of available options from Stripe.
+								 *
+								 * @link https://docs.stripe.com/js/elements_object/create_element?type=card#elements_create-options
+								 */
 							]
 						] );
 					},

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -100,13 +100,15 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 									]
 								]
 							],
-							'cardElementOptions' => [
-								'style' => [
-									'base' => [
-										'color' => '#23282d',
-									],
+							'cardElementStyle' => [
+								'base' => [
+									'color' => '#23282d',
 								],
 							],
+							'cardElementOptions' => [
+								// Intentionally empty to allow for filtering of available options from Stripe.
+								// @link https://docs.stripe.com/js/elements_object/create_element?type=card#elements_create-options
+							]
 						] );
 					},
 				],

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -100,11 +100,13 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 									]
 								]
 							],
-							'cardElementStyle' => [
-								'base' => [
-									'color' => '#23282d'
-								]
-							]
+							'cardElementOptions' => [
+								'style' => [
+									'base' => [
+										'color' => '#23282d',
+									],
+								],
+							],
 						] );
 					},
 				],

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -500,15 +500,18 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 * @link https://stripe.com/docs/js/elements_object/create_element?type=card#elements_create-options
 	 *
 	 * @since 5.3.0
+	 * @since TBD Pulled out `options` variable to allow filtering using `tec_tickets_commerce_stripe_checkout_localized_data`.
 	 */
 	obj.setupCompactCardElement = () => {
-		// Instantiate the CardElement with a single field combo.
-		obj.cardElement = obj.stripeElements.create( 'card', {
-			style: obj.checkout.cardElementStyle,
-		} );
-		obj.cardElement.mount( obj.selectors.cardElement );
-		obj.cardElement.on( 'change', obj.onCardChange );
+		// Use localized options
+		const options = obj.checkout.cardElementStyle;
+
+		// Instantiate the CardElement with the options
+		obj.cardElement = obj.stripeElements.create('card', options);
+		obj.cardElement.mount(obj.selectors.cardElement);
+		obj.cardElement.on('change', obj.onCardChange);
 	};
+
 
 	/**
 	 * Configure the PaymentElement with separate fields.
@@ -595,7 +598,6 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 			$('.tribe-tickets__commerce-checkout-section-header').removeClass( obj.selectors.hiddenElement.className() )
 		}, 2000);
 	}
-
 
 	/**
 	 * Setup and initialize Stripe API.

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -476,19 +476,19 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 		obj.cardElement = obj.stripeElements.create( 'cardNumber', {
 			showIcon: true,
 			iconStyle: 'default',
-			style: obj.checkout.cardElementObject.style,
+			style: obj.checkout.cardElementOptions.style,
 		} );
 		obj.cardElement.mount( obj.selectors.cardNumber );
 		obj.cardElement.on( 'change', obj.onCardChange );
 
 		obj.cardExpiry = obj.stripeElements.create( 'cardExpiry', {
-			style: obj.checkout.cardElementObject.style,
+			style: obj.checkout.cardElementOptions.style,
 		} );
 		obj.cardExpiry.mount( obj.selectors.cardExpiry );
 		obj.cardExpiry.on( 'change', obj.onCardChange );
 
 		obj.cardCvc = obj.stripeElements.create( 'cardCvc', {
-			style: obj.checkout.cardElementObject.style,
+			style: obj.checkout.cardElementOptions.style,
 		} );
 		obj.cardCvc.mount( obj.selectors.cardCvc );
 		obj.cardCvc.on( 'change', obj.onCardChange );
@@ -504,7 +504,7 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 */
 	obj.setupCompactCardElement = () => {
 		// Use localized options
-		const options = obj.checkout.cardElementObject;
+		const options = obj.checkout.cardElementOptions;
 
 		// Instantiate the CardElement with the options
 		obj.cardElement = obj.stripeElements.create('card', options);

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -476,19 +476,19 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 		obj.cardElement = obj.stripeElements.create( 'cardNumber', {
 			showIcon: true,
 			iconStyle: 'default',
-			style: obj.checkout.cardElementOptions.style,
+			style: obj.checkout.cardElementStyle,
 		} );
 		obj.cardElement.mount( obj.selectors.cardNumber );
 		obj.cardElement.on( 'change', obj.onCardChange );
 
 		obj.cardExpiry = obj.stripeElements.create( 'cardExpiry', {
-			style: obj.checkout.cardElementOptions.style,
+			style: obj.checkout.cardElementStyle,
 		} );
 		obj.cardExpiry.mount( obj.selectors.cardExpiry );
 		obj.cardExpiry.on( 'change', obj.onCardChange );
 
 		obj.cardCvc = obj.stripeElements.create( 'cardCvc', {
-			style: obj.checkout.cardElementOptions.style,
+			style: obj.checkout.cardElementStyle,
 		} );
 		obj.cardCvc.mount( obj.selectors.cardCvc );
 		obj.cardCvc.on( 'change', obj.onCardChange );
@@ -503,7 +503,14 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 * @since TBD Pulled out `options` variable to allow filtering using `tec_tickets_commerce_stripe_checkout_localized_data`.
 	 */
 	obj.setupCompactCardElement = () => {
-		// Instantiate the CardElement with the options
+		const options = obj.checkout.cardElementOptions;
+
+		// If there are no customized style options being added, use the previously defined default.
+		if( ! options.style ){
+			options.style = obj.checkout.cardElementStyle;
+		}
+
+		// Instantiate the CardElement with the options.
 		obj.cardElement = obj.stripeElements.create( 'card', options );
 		obj.cardElement.mount( obj.selectors.cardElement );
 		obj.cardElement.on( 'change', obj.onCardChange );

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -503,13 +503,10 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 * @since TBD Pulled out `options` variable to allow filtering using `tec_tickets_commerce_stripe_checkout_localized_data`.
 	 */
 	obj.setupCompactCardElement = () => {
-		// Use localized options
-		const options = obj.checkout.cardElementOptions;
-
 		// Instantiate the CardElement with the options
-		obj.cardElement = obj.stripeElements.create('card', options);
-		obj.cardElement.mount(obj.selectors.cardElement);
-		obj.cardElement.on('change', obj.onCardChange);
+		obj.cardElement = obj.stripeElements.create( 'card', options );
+		obj.cardElement.mount( obj.selectors.cardElement );
+		obj.cardElement.on( 'change', obj.onCardChange );
 	};
 
 

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -476,19 +476,19 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 		obj.cardElement = obj.stripeElements.create( 'cardNumber', {
 			showIcon: true,
 			iconStyle: 'default',
-			style: obj.checkout.cardElementStyle,
+			style: obj.checkout.cardElementObject.style,
 		} );
 		obj.cardElement.mount( obj.selectors.cardNumber );
 		obj.cardElement.on( 'change', obj.onCardChange );
 
 		obj.cardExpiry = obj.stripeElements.create( 'cardExpiry', {
-			style: obj.checkout.cardElementStyle,
+			style: obj.checkout.cardElementObject.style,
 		} );
 		obj.cardExpiry.mount( obj.selectors.cardExpiry );
 		obj.cardExpiry.on( 'change', obj.onCardChange );
 
 		obj.cardCvc = obj.stripeElements.create( 'cardCvc', {
-			style: obj.checkout.cardElementStyle,
+			style: obj.checkout.cardElementObject.style,
 		} );
 		obj.cardCvc.mount( obj.selectors.cardCvc );
 		obj.cardCvc.on( 'change', obj.onCardChange );
@@ -504,7 +504,7 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 */
 	obj.setupCompactCardElement = () => {
 		// Use localized options
-		const options = obj.checkout.cardElementStyle;
+		const options = obj.checkout.cardElementObject;
 
 		// Instantiate the CardElement with the options
 		obj.cardElement = obj.stripeElements.create('card', options);


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-295] 

### 🗒️ Description

There are a handful of options available in Stripe for [customizing the Compact Card Checkout](https://docs.stripe.com/js/elements_object/create_element?type=card#elements_create-options). By pulling out the `options` object as a variable we can allow our users to take advantage of the already existing `tec_tickets_commerce_stripe_checkout_localized_data` filter to add to these options. 

For example, to disable the Autofill Link option (by default this is enabled in Tickets Commerce), one could use this snippet:
```php
function my_custom_stripe_checkout_localized_data($data) {
	// Modify the cardElementOptions or add properties as needed
	$data['cardElementOptions']['hidePostalCode'] = true;
    $data['cardElementOptions']['disableLink'] = true;
	return $data;
}
add_filter('tec_tickets_commerce_stripe_checkout_localized_data', 'my_custom_stripe_checkout_localized_data');

```

### 🎥 Artifacts 
![image](https://github.com/user-attachments/assets/dd3abf32-4d67-4efc-9180-adfb83c0bf18)
![image](https://github.com/user-attachments/assets/978e9a63-a2b1-47b7-9109-c0da2c49e611)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TECTRIA-295]: https://stellarwp.atlassian.net/browse/TECTRIA-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ