### PR TITLE
All Tickets Page > Display Search and Filters on Mobile

### DIFF
--- a/src/Tickets/Admin/Tickets/Assets.php
+++ b/src/Tickets/Admin/Tickets/Assets.php
@@ -50,9 +50,6 @@ class Assets extends Service_Provider {
 	 * @return bool
 	 */
 	public function should_enqueue_assets(): bool {
-		/**  @var Page $page */
-		$page = tribe( Page::class );
-
-		return $page->is_on_page();
+		return tribe( Page::class )->is_on_page();
 	}
 }

--- a/src/resources/postcss/tickets-admin-tickets.pcss
+++ b/src/resources/postcss/tickets-admin-tickets.pcss
@@ -55,6 +55,25 @@
 			table-layout: auto;
 		}
 	}
+
+	@media (max-width: 782px) {
+		.tablenav.top {
+			margin-top: var(--tec-spacer-1);
+
+			.actions {
+				display: flex;
+				flex-direction: column;
+				gap: var(--tec-spacer-0);
+				width: 100%;
+
+				select,
+				input {
+					max-width: 100%;
+					width: 100%;
+				}
+			}
+		}
+	}
 }
 
 .tec-tickets-admin-all-tickets-no-tickets-wrap {


### PR DESCRIPTION
### 🎫 Ticket
[ET-2180]

### 🗒️ Description
By default, WordPress hides the search and filters on mobile. We want to show them.

### 🎥 Artifacts <!-- if applicable-->
![image](https://github.com/user-attachments/assets/75c7a6cf-ceab-4ff7-aafd-66c75bf3ed4e)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2180]: https://stellarwp.atlassian.net/browse/ET-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ