### PR TITLE
[TECTRA-303] Make string in `getting-started` translatable

### DIFF
--- a/changelog/tweak-tectria-303_settings_string_translatable
+++ b/changelog/tweak-tectria-303_settings_string_translatable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Made a string translatable in `getting-started.php` file. (props to @DAnn2012) [TECTRIA-303]

--- a/src/admin-views/settings/getting-started.php
+++ b/src/admin-views/settings/getting-started.php
@@ -25,7 +25,7 @@ $help_text = $etp_enabled
 			<ul class="tec-tickets__admin-banner-kb-list">
 				<?php
 				foreach ( $et_resource_links as $link ) {
-					$new_label = isset( $link['new'] ) ? '<span class="tec-tickets__admin-banner-links-link-label--new">' . esc_html( 'New!', 'event-tickets' ) . '</span>' : '';
+					$new_label = isset( $link['new'] ) ? '<span class="tec-tickets__admin-banner-links-link-label--new">' . esc_html__( 'New!', 'event-tickets' ) . '</span>' : '';
 					printf( '<li><a href="%s" target="_blank" rel="noopener noreferrer">%s%s</a></li>', esc_url( $link['href'] ), esc_html( $link['label'] ), $new_label );
 				}
 				?>


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-303]

### 🗒️ Description

Clone of #3052 - props to @DAnn2012 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TECTRIA-303]: https://stellarwp.atlassian.net/browse/TECTRIA-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ