### PR TITLE
[GTRIA-1236] Avoid Slow Queries 

### DIFF
--- a/changelog/fix-gtria-1236_avoid_slow_queries
+++ b/changelog/fix-gtria-1236_avoid_slow_queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+If users added an index to the `post_meta` table on `meta_value` using `CONCAT()` should speed up queries for them. [GTRIA-1236]

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -80,6 +80,7 @@ class Tribe__Tickets__Query {
 				 * A fast sub-query on the indexed `wp_postmeta.meta_key` column; then a slow comparison on few values
 				 * in the `wp_postmeta.meta_value` column for a fast query.
 				 */
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$query = "SELECT p.ID FROM $wpdb->posts p
 				 JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
 				 WHERE p.post_type IN ('$post_types_in')";

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -151,12 +151,14 @@ class Tribe__Tickets__Query {
 			 * A fast query on the indexed `wp_postmeta.meta_key` column; then a slow comparison on few values
 			 * in the `wp_postmeta.meta_value` column for a fast query.
 			 */
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$query = $wpdb->prepare(
 				"SELECT COUNT(DISTINCT(p.ID)) FROM $wpdb->posts p
 				  JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
 				  WHERE p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
 				$post_type
 			);
+			// phpcs:enable
 		}
 
 		return $wpdb->get_var( $query );
@@ -196,6 +198,7 @@ class Tribe__Tickets__Query {
 			 * The SELECT sub-query to pull ticketed is fast, and then we run a query on `wp_posts.ID`: another
 			 * indexed column for another fast query.
 			 */
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$query = $wpdb->prepare(
 				"SELECT COUNT(DISTINCT(p.ID)) FROM $wpdb->posts p
 					WHERE p.ID NOT IN (
@@ -206,6 +209,7 @@ class Tribe__Tickets__Query {
 				$post_type,
 				$post_type
 			);
+			// phpcs:enable
 		}
 
 		return $wpdb->get_var( $query );

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -80,9 +80,11 @@ class Tribe__Tickets__Query {
 				 * A fast sub-query on the indexed `wp_postmeta.meta_key` column; then a slow comparison on few values
 				 * in the `wp_postmeta.meta_value` column for a fast query.
 				 */
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$query = "SELECT p.ID FROM $wpdb->posts p
-				 JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				 WHERE p.post_type IN ('$post_types_in')";
+    			JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
+    			WHERE p.post_type IN ('$post_types_in')";
+				// phpcs:enable
 			}
 
 			if ( $has_tickets ) {

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -80,9 +80,8 @@ class Tribe__Tickets__Query {
 				 * A fast sub-query on the indexed `wp_postmeta.meta_key` column; then a slow comparison on few values
 				 * in the `wp_postmeta.meta_value` column for a fast query.
 				 */
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$query = "SELECT p.ID FROM $wpdb->posts p
-				 JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
+				 JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				 WHERE p.post_type IN ('$post_types_in')";
 			}
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -81,7 +81,7 @@ class Tribe__Tickets__Query {
 				 * in the `wp_postmeta.meta_value` column for a fast query.
 				 */
 				$query = "SELECT p.ID FROM $wpdb->posts p
-				 JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = p.ID
+				 JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
 				 WHERE p.post_type IN ('$post_types_in')";
 			}
 
@@ -151,7 +151,7 @@ class Tribe__Tickets__Query {
 			 */
 			$query = $wpdb->prepare(
 				"SELECT COUNT(DISTINCT(p.ID)) FROM $wpdb->posts p
-				  JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = p.ID
+				  JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
 				  WHERE p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
 				$post_type
 			);
@@ -198,7 +198,7 @@ class Tribe__Tickets__Query {
 				"SELECT COUNT(DISTINCT(p.ID)) FROM $wpdb->posts p
 					WHERE p.ID NOT IN (
 						SELECT p.ID FROM $wpdb->posts p
-									JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = p.ID
+									JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
 									WHERE p.post_type = %s
 					) AND p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
 				$post_type,


### PR DESCRIPTION
### 🎫 Ticket

[GTRIA-1236]

### 🗒️ Description

A customer has added an index to their `post_meta` table on `meta_value` which is causing severe slowness on their site with a lot (200k+) orders when using ET, ETP, and WC. 

From [this Slack convo](https://lw.slack.com/archives/C0714HQSMEW/p1725568640637249), Matt says "The `CONCAT( p.ID, '' )` would incur a minor performance hit in many use cases, but for folks that have added an index to the `postmeta` table on `meta_value` (which doesn't come default), doing the `CONCAT()` operation would most likely speed things up.
Without the `CONCAT()`, MySQL will attempt to convert the meta_value to an `INT` implicitly, which would cause the index to be ignored and a full table scan to be done." 

This PR is in tandem with one for ETP that will change the `meta_value` from `%d` to `%s`, saving SQL from needing to cast the value to evaluate it. 

### 🎥 Artifacts 
Query getting flagged for them:
```SQL
wp_woocommerce_order_itemmeta - ~4.2M rows

CREATE TABLE `wp_woocommerce_order_itemmeta` (
  `meta_id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `order_item_id` bigint unsigned NOT NULL,
  `meta_key` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `meta_value` longtext COLLATE utf8mb4_unicode_ci,
  PRIMARY KEY (`meta_id`),
  KEY `order_item_id` (`order_item_id`),
  KEY `meta_key_meta_value` (`meta_key`(191),`meta_value`(191)) USING BTREE,
  KEY `meta_key` (`meta_key`(191)) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=4223599 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

wp_postmeta - ~38.5M rows

CREATE TABLE `wp_postmeta` (
  `meta_id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `post_id` bigint unsigned NOT NULL DEFAULT '0',
  `meta_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
  `meta_value` longtext COLLATE utf8mb4_unicode_ci,
  PRIMARY KEY (`post_id`,`meta_key`,`meta_id`),
  UNIQUE KEY `meta_id` (`meta_id`),
  KEY `meta_key` (`meta_key`,`meta_value`(32),`post_id`,`meta_id`),
  KEY `meta_value` (`meta_value`(32),`meta_id`),
  KEY `post_id` (`post_id`)
) ENGINE=InnoDB AUTO_INCREMENT=38517177 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
```

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[GTRIA-1236]: https://stellarwp.atlassian.net/browse/GTRIA-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ