### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
       - 'src/modules/**.js'
       - 'src/resources/js/**.js'
       - 'src/resources/postcss/**.pcss'
+      - '.github/**/*'
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'src/modules/**.js'
       - 'src/resources/js/**.js'
+      - '.github/**/*'
 jobs:
   jest:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-php-ct1.yml
+++ b/.github/workflows/tests-php-ct1.yml
@@ -22,7 +22,7 @@ jobs:
       # Checkout the repo
       # ------------------------------------------------------------------------------
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           token: ${{ secrets.GH_BOT_TOKEN }}
@@ -35,17 +35,20 @@ jobs:
         run: |
           num_php_files=$(git diff ${{ github.event.pull_request.base.sha }} HEAD --name-only | grep -P "\.php" | wc -l)
           if [[ -z "$num_php_files" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           elif [[ "$num_php_files" == "0" || "$num_php_files" == "" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=value::0"
+            echo "value=0" >> $GITHUB_OUTPUT
+            echo "## Found PHP file changes, running PHP tests." >> $GITHUB_STEP_SUMMARY
           fi
       # ------------------------------------------------------------------------------
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
@@ -170,7 +173,7 @@ jobs:
       # Clone and init TEC
       # ------------------------------------------------------------------------------
       - name: Clone TEC
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           fetch-depth: 1
@@ -206,7 +209,7 @@ jobs:
       # Clone and init ECP
       # ------------------------------------------------------------------------------
       - name: Clone ECP
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           fetch-depth: 1

--- a/.github/workflows/tests-php-ct1.yml
+++ b/.github/workflows/tests-php-ct1.yml
@@ -8,7 +8,7 @@ on:
       - 'composer.json'
       - 'composer.lock'
       - 'codeception.dist.yml'
-      - '.github/workflows/tests-php-ct1.yaml'
+      - '.github/**/*'
 jobs:
   test:
     strategy:

--- a/.github/workflows/tests-php-ct1.yml
+++ b/.github/workflows/tests-php-ct1.yml
@@ -284,7 +284,7 @@ jobs:
       # Upload artifacts (On failure)
       # ------------------------------------------------------------------------------
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: steps.skip.outputs.value != 1 && failure()
         with:
           name: output ${{ matrix.suite }}

--- a/.github/workflows/tests-php-ft.yml
+++ b/.github/workflows/tests-php-ft.yml
@@ -24,7 +24,7 @@ jobs:
       # Checkout the repo
       # ------------------------------------------------------------------------------
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           token: ${{ secrets.GH_BOT_TOKEN }}
@@ -37,17 +37,20 @@ jobs:
         run: |
           num_php_files=$(git diff ${{ github.event.pull_request.base.sha }} HEAD --name-only | grep -P "\.php" | wc -l)
           if [[ -z "$num_php_files" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           elif [[ "$num_php_files" == "0" || "$num_php_files" == "" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=value::0"
+            echo "value=0" >> $GITHUB_OUTPUT
+            echo "## Found PHP file changes, running PHP tests." >> $GITHUB_STEP_SUMMARY
           fi
       # ------------------------------------------------------------------------------
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
@@ -172,7 +175,7 @@ jobs:
       # Clone and init TEC
       # ------------------------------------------------------------------------------
       - name: Clone TEC
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           fetch-depth: 1
@@ -208,7 +211,7 @@ jobs:
       # Clone and init ECP
       # ------------------------------------------------------------------------------
       - name: Clone ECP
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           fetch-depth: 1

--- a/.github/workflows/tests-php-ft.yml
+++ b/.github/workflows/tests-php-ft.yml
@@ -286,7 +286,7 @@ jobs:
       # Upload artifacts (On failure)
       # ------------------------------------------------------------------------------
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: steps.skip.outputs.value != 1 && failure()
         with:
           name: output ${{ matrix.suite }}

--- a/.github/workflows/tests-php-ft.yml
+++ b/.github/workflows/tests-php-ft.yml
@@ -8,7 +8,7 @@ on:
       - 'composer.json'
       - 'composer.lock'
       - 'codeception.dist.yml'
-      - '.github/workflows/tests-php-ft.yaml'
+      - '.github/**/*'
 jobs:
   test:
     strategy:

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -8,7 +8,7 @@ on:
       - 'composer.json'
       - 'composer.lock'
       - 'codeception.dist.yml'
-      - '.github/workflows/tests-php.yaml'
+      - '.github/**/*'
 jobs:
   test:
     strategy:

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -240,7 +240,7 @@ jobs:
       # Upload artifacts (On failure)
       # ------------------------------------------------------------------------------
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: steps.skip.outputs.value != 1 && failure()
         with:
           name: output ${{ matrix.suite }}

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -28,7 +28,7 @@ jobs:
       # Checkout the repo
       # ------------------------------------------------------------------------------
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           token: ${{ secrets.GH_BOT_TOKEN }}
@@ -41,17 +41,20 @@ jobs:
         run: |
           num_php_files=$(git diff ${{ github.event.pull_request.base.sha }} HEAD --name-only | grep -P "\.php" | wc -l)
           if [[ -z "$num_php_files" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           elif [[ "$num_php_files" == "0" || "$num_php_files" == "" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=value::0"
+            echo "value=0" >> $GITHUB_OUTPUT
+            echo "## Found PHP file changes, running PHP tests." >> $GITHUB_STEP_SUMMARY
           fi
       # ------------------------------------------------------------------------------
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
@@ -154,7 +157,7 @@ jobs:
       # Clone and init TEC
       # ------------------------------------------------------------------------------
       - name: Clone TEC
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           fetch-depth: 1

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -45,7 +45,7 @@ jobs:
       # Checkout the repo
       # ------------------------------------------------------------------------------
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           token: ${{ secrets.GH_BOT_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       # Checkout tut
       # ------------------------------------------------------------------------------
       - name: Checkout tut
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
           repository: the-events-calendar/tut
@@ -78,7 +78,7 @@ jobs:
           path: tut
           fetch-depth: 1
       - name: Checkout jenkins-scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
           repository: the-events-calendar/jenkins-scripts


### PR DESCRIPTION
to avoid issues with deprecated artifact upload/download actions.

Add summary output to test skip check.

Requires: https://github.com/the-events-calendar/tribe-common/pull/2203