### PR TITLE
Fix SLR meta keys on post/event when user switches between GAC and ASC

### DIFF
--- a/src/Tickets/Seating/app/blockEditor/capacity-form/index.js
+++ b/src/Tickets/Seating/app/blockEditor/capacity-form/index.js
@@ -79,20 +79,30 @@ export default function CapacityForm({ renderDefaultForm, clientId }) {
 		[]
 	);
 
-	const onToggleChange = useCallback(
-		(value) => {
-			if (isLayoutLocked) {
-				return;
-			}
-
-			setUsingAssignedSeating(value === 'seat');
-		},
-		[isLayoutLocked, setUsingAssignedSeating]
-	);
-
 	const [meta, setMeta] = useEntityProp('postType', postType, 'meta', postId);
 	const updateEventMeta = useCallback(
 		(layoutId) => {
+			if (true === layoutId) {
+				const newMeta = {
+					...meta,
+					// We leave [META_KEY_LAYOUT_ID] as it was since that hasn't changed yet.
+					[META_KEY_ENABLED]: '1',
+				};
+				setMeta(newMeta);
+				return;
+			}
+
+			if (false === layoutId) {
+				const newMeta = {
+					...meta,
+					[META_KEY_ENABLED]: '0',
+					// We set [META_KEY_LAYOUT_ID] to an empty string since we're disabling assigned seating.
+					[META_KEY_LAYOUT_ID]: '',
+				};
+				setMeta(newMeta);
+				return;
+			}
+
 			const newMeta = {
 				...meta,
 				[META_KEY_ENABLED]: '1',
@@ -101,6 +111,18 @@ export default function CapacityForm({ renderDefaultForm, clientId }) {
 			setMeta(newMeta);
 		},
 		[meta, setMeta]
+	);
+
+	const onToggleChange = useCallback(
+		(value) => {
+			if (isLayoutLocked) {
+				return;
+			}
+
+			setUsingAssignedSeating(value === 'seat');
+			updateEventMeta(value === 'seat');
+		},
+		[isLayoutLocked, setUsingAssignedSeating, updateEventMeta]
 	);
 
 	const onLayoutChange = useCallback(


### PR DESCRIPTION
### 🎫 Ticket

Issue 110 from gsheet.

This part of the codebase seems completely untested and currently i am not sure myself how to test event driven component functionality :(

If you can help Rafsun would be great, otherwise ill bring it back to Luca next week when he is back.

Demo: https://www.loom.com/share/8fad18da8ca24a3ea287c94132ffd58e