### PR TITLE
Tickets Home > Optimize Calls to `get_edit_post_link()` Function

### DIFF
--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -408,7 +408,7 @@ class List_Table extends WP_List_Table {
 			$this->events_by_id[ $event_id ] = $event;
 		}
 
-		$ecp_installed = class_exists( Custom_Tables_Links_Provider::class );
+		$ecp_installed = has_action( 'tribe_common_loaded', 'tribe_register_pro' );
 		if ( $ecp_installed ) {
 			remove_filter( 'get_edit_post_link', [ tribe( Custom_Tables_Links_Provider::class ), 'update_event_edit_link' ], 10 );
 		}

--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -1049,6 +1049,7 @@ class List_Table extends WP_List_Table {
 
 		$attendee_query = new WP_Query(
 			[
+				// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 				'posts_per_page' => 250,
 				'post_type'      => $this->get_attendee_post_type(),
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -1049,7 +1049,7 @@ class List_Table extends WP_List_Table {
 
 		$attendee_query = new WP_Query(
 			[
-				'posts_per_page' => count( $ticket_ids ),
+				'posts_per_page' => 250,
 				'post_type'      => $this->get_attendee_post_type(),
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'     => [

--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -404,7 +404,7 @@ class List_Table extends WP_List_Table {
 		if ( isset( $this->events_by_id[ $event_id ] ) ) {
 			$event = $this->events_by_id[ $event_id ];
 		} else {
-			$event = get_post( $event_id );
+			$event                           = get_post( $event_id );
 			$this->events_by_id[ $event_id ] = $event;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket
[ET-2212]

### 🗒️ Description
We found that calling `get_edit_post_link()` was making extra queries for each unique event that tickets were attached to, so we added more caching and also removed the ECP filter that the extra query was originating from.

### 🎥 Artifacts <!-- if applicable-->
N/A

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2212]: https://stellarwp.atlassian.net/browse/ET-2212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ