### PR TITLE
When Apple/Google is selected, fallback to auto properties

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
@@ -72,6 +72,7 @@ class Stripe_Elements {
 
 	/**
 	 * Include the Stripe Card Element form.
+	 * Temp change to trigger github tests
 	 *
 	 * @since 5.3.0
 	 *

--- a/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Stripe_Elements.php
@@ -72,7 +72,6 @@ class Stripe_Elements {
 
 	/**
 	 * Include the Stripe Card Element form.
-	 * Temp change to trigger github tests
 	 *
 	 * @since 5.3.0
 	 *

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -326,6 +326,16 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 * @return {Promise<*>}
 	 */
 	obj.submitMultiPayment = async ( order ) => {
+		// Only if we don't have the address fields to collect
+		if ( 0 === $('#tec-tc-gateway-stripe-render-payment').length ) {
+			return obj.stripeLib.confirmPayment( {
+				elements: obj.stripeElements,
+				redirect: 'if_required',
+				confirmParams: {
+					return_url: order.redirect_url
+				}
+			} ).then( obj.handleConfirmPayment );
+		}
 
 		return obj.stripeLib.confirmPayment( {
 			elements: obj.stripeElements,


### PR DESCRIPTION
### 🎫 Ticket

[ETP-942]

What we change here: 
Even though we have the full Payment Element, we don't need to manually define the shipping fields on Payment Submit, as we do with the other advanced methods. When wallets, we omit that and let it on `auto` to be handled by Stripe.

Follow-up to https://github.com/the-events-calendar/event-tickets/pull/3237

[ETP-942]: https://stellarwp.atlassian.net/browse/ETP-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ