### PR TITLE
Update attendee search cache behavior

### DIFF
--- a/changelog/bug-ET-2218-attendee-search-object-cache
+++ b/changelog/bug-ET-2218-attendee-search-object-cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix attendee search caching, and add search-related filters. [ET-2218]

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -1148,8 +1148,15 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		 */
 		$search_keys = apply_filters( 'tribe_tickets_search_attendees_by', $search_keys, [], $search );
 
-		// Default selection.
-		$search_key = 'purchaser_name';
+		/**
+		 * Filters the default key to search attendees by.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $search_key  The default key to search attendees by.
+		 * @param array  $search_keys The keys that can be used to search attendees.
+		 */
+		$search_key = apply_filters( 'tribe_tickets_search_attendees_default', 'purchaser_name', $search_keys );
 
 		$search_type = sanitize_text_field( tribe_get_request_var( 'tribe_attendee_search_type' ) );
 

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -1092,6 +1092,16 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		$cache     = tribe( 'cache' );
 		$cache_key = __METHOD__ . '-' . md5( wp_json_encode( $args ) . $event_id );
 
+		/**
+		 * Filters the cache key used to store the attendees table items.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $cache_key The cache key used to store the attendees table items.
+		 * @param array  $args      The arguments used to query the attendees for the Attendees Table.
+		 * @param int    $event_id  The event ID for the Attendees Table.
+		 */
+		$cache_key = apply_filters( 'tec_tickets_attendees_table_cache_key', $cache_key, $args, $event_id );
 
 		// If we have a cached version of the attendees, use that.
 		$cached = $cache->get( $cache_key );

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -1156,7 +1156,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		 * @param string $search_key  The default key to search attendees by.
 		 * @param array  $search_keys The keys that can be used to search attendees.
 		 */
-		$search_key = apply_filters( 'tribe_tickets_search_attendees_default', 'purchaser_name', $search_keys );
+		$search_key = apply_filters( 'tec_tickets_search_attendees_default', 'purchaser_name', $search_keys );
 
 		$search_type = sanitize_text_field( tribe_get_request_var( 'tribe_attendee_search_type' ) );
 

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -1105,7 +1105,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		// If we have a cached version of the attendees, use that.
 		$cached = $cache->get( $cache_key );
-		if ( $cached ) {
+		if ( false !== $cached ) {
 			$this->items = $cached;
 			return;
 		}

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -1070,63 +1070,9 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			return $cached;
 		}
 
+		// Set up the search args if we have a search term.
 		if ( ! empty( $search ) ) {
-			$search_keys = array_keys( $this->get_search_options() );
-
-			/**
-			 * Filters the item keys that can be used to filter attendees while searching them.
-			 *
-			 * @since 4.7
-			 * @since 4.10.6 Deprecated usage of $items attendees list.
-			 *
-			 * @param array  $search_keys The keys that can be used to search attendees.
-			 * @param array  $items       (deprecated) The attendees list.
-			 * @param string $search      The current search string.
-			 */
-			$search_keys = apply_filters( 'tribe_tickets_search_attendees_by', $search_keys, [], $search );
-
-			// Default selection.
-			$search_key = 'purchaser_name';
-
-			$search_type = sanitize_text_field( tribe_get_request_var( 'tribe_attendee_search_type' ) );
-
-			if (
-				$search_type
-				&& in_array( $search_type, $search_keys, true )
-			) {
-				$search_key = $search_type;
-			}
-
-			$search_like_keys = [
-				'purchaser_name',
-				'purchaser_email',
-				'holder_name',
-				'holder_email',
-			];
-
-			/**
-			 * Filters the item keys that support LIKE matching to filter attendees while searching them.
-			 *
-			 * @since 4.10.6
-			 *
-			 * @param array  $search_like_keys The keys that support LIKE matching.
-			 * @param array  $search_keys      The keys that can be used to search attendees.
-			 * @param string $search           The current search string.
-			 */
-			$search_like_keys = apply_filters( 'tribe_tickets_search_attendees_by_like', $search_like_keys, $search_keys, $search );
-
-			// Update search key if it supports LIKE matching.
-			if ( in_array( $search_key, $search_like_keys, true ) ) {
-				$search_key .= '__like';
-				$search      = '%' . $search . '%';
-			}
-
-			// Only get matches that have search phrase in the key.
-			$args['by'] = [
-				$search_key => [
-					$search,
-				],
-			];
+			$args = $this->set_up_search_args( $search, $args );
 		}
 
 		// Setup sorting args.
@@ -1164,6 +1110,77 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		$cache->set( $cache_key, $items, 60 );
 
 		$this->set_pagination_args( $pagination_args );
+	}
+
+	/**
+	 * Set up the search arguments for the attendees table.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $search The search string.
+	 * @param array  $args   The current arguments.
+	 *
+	 * @return array The updated arguments.
+	 */
+	private function set_up_search_args( string $search, array $args ) {
+		$search_keys = array_keys( $this->get_search_options() );
+
+		/**
+		 * Filters the item keys that can be used to filter attendees while searching them.
+		 *
+		 * @since 4.7
+		 * @since 4.10.6 Deprecated usage of $items attendees list.
+		 *
+		 * @param array  $search_keys The keys that can be used to search attendees.
+		 * @param array  $items       (deprecated) The attendees list.
+		 * @param string $search      The current search string.
+		 */
+		$search_keys = apply_filters( 'tribe_tickets_search_attendees_by', $search_keys, [], $search );
+
+		// Default selection.
+		$search_key = 'purchaser_name';
+
+		$search_type = sanitize_text_field( tribe_get_request_var( 'tribe_attendee_search_type' ) );
+
+		if (
+			$search_type
+			&& in_array( $search_type, $search_keys, true )
+		) {
+			$search_key = $search_type;
+		}
+
+		$search_like_keys = [
+			'purchaser_name',
+			'purchaser_email',
+			'holder_name',
+			'holder_email',
+		];
+
+		/**
+		 * Filters the item keys that support LIKE matching to filter attendees while searching them.
+		 *
+		 * @since 4.10.6
+		 *
+		 * @param array  $search_like_keys The keys that support LIKE matching.
+		 * @param array  $search_keys      The keys that can be used to search attendees.
+		 * @param string $search           The current search string.
+		 */
+		$search_like_keys = apply_filters( 'tribe_tickets_search_attendees_by_like', $search_like_keys, $search_keys, $search );
+
+		// Update search key if it supports LIKE matching.
+		if ( in_array( $search_key, $search_like_keys, true ) ) {
+			$search_key .= '__like';
+			$search      = "%{$search}%";
+		}
+
+		// Only get matches that have search phrase in the key.
+		$args['by'] = [
+			$search_key => [
+				$search,
+			],
+		];
+
+		return $args;
 	}
 
 	/**

--- a/src/resources/js/v2/rsvp-block.js
+++ b/src/resources/js/v2/rsvp-block.js
@@ -61,7 +61,7 @@ tribe.tickets.rsvp.block = {};
 					action: 'tribe_tickets_rsvp_handle',
 					ticket_id: rsvpId,
 					step: 'going',
-					nonce: TribeRsvp.nonces.rsvpHandle
+					nonce: TribeRsvp.nonces.rsvpHandle,
 				};
 
 				tribe.tickets.rsvp.manager.request( data, $container );

--- a/src/resources/postcss/tickets-commerce/admin/orders/single.pcss
+++ b/src/resources/postcss/tickets-commerce/admin/orders/single.pcss
@@ -20,14 +20,6 @@ body.wp-admin.post-type-tec_tc_order {
 	 * End Temporary hide
 	 */
 
-	#submitdiv {
-		display: none;
-	}
-
-	.tec-tickets-commerce-single-order--details--item--label a {
-		display: none;
-	}
-
 	.tribe-mobile-hidden {
 		display: none;
 	}

--- a/src/resources/postcss/tickets-commerce/admin/orders/single.pcss
+++ b/src/resources/postcss/tickets-commerce/admin/orders/single.pcss
@@ -4,25 +4,30 @@
  * @since TBD
  */
 
-/**
- * Temporary hide
- */
 body.wp-admin.post-type-tec_tc_order {
-	.tec-tickets-commerce-single-order--items button, .tec-tickets-commerce-single-order--items a {
-		display: none;
-	}
-	#submitdiv {
-		display: none;
-	}
+	/**
+	 * Temporary hide
+	 */
+
+	.tec-tickets-commerce-single-order--items button,
+	.tec-tickets-commerce-single-order--items a,
+	#submitdiv,
 	.tec-tickets-commerce-single-order--details--item--label a {
 		display: none;
 	}
-}
-/**
- * End Temporary hide
- */
 
-body.wp-admin.post-type-tec_tc_order {
+	/**
+	 * End Temporary hide
+	 */
+
+	#submitdiv {
+		display: none;
+	}
+
+	.tec-tickets-commerce-single-order--details--item--label a {
+		display: none;
+	}
+
 	.tribe-mobile-hidden {
 		display: none;
 	}
@@ -306,6 +311,7 @@ body.wp-admin.post-type-tec_tc_order {
 			}
 		}
 	}
+
 	&--breadcrumb--order--edit {
 		margin-top: 1em;
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-2218]

### 🗒️ Description

This updates the behavior of caching for the Attendees items.

It also adds the following new filters:

* `tec_tickets_search_attendees_default` – Filter the default search key
* `tec_tickets_attendees_table_cache_key` - Filter the cache key used for retrieving items


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2218]: https://stellarwp.atlassian.net/browse/ET-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ