### PR TITLE
Fix/ecp 1826 duplicate events

### DIFF
--- a/changelog/fix-ecp-1826-duplicate-events
+++ b/changelog/fix-ecp-1826-duplicate-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Handle duplicating Tickets during event duplciation [ECP-1826].

--- a/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
@@ -8,6 +8,8 @@ namespace TEC\Tickets\Integrations\Plugins\Events_Pro;
 use TEC\Tickets\Integrations\Integration_Abstract;
 use TEC\Common\Integrations\Traits\Plugin_Integration;
 use Tribe__Tickets__Tickets;
+use Tribe\Tickets\Events\Attendees_List;
+use Tribe__Tickets__Global_Stock as Global_Stock;
 
 /**
  * Class Duplicate_Post
@@ -53,6 +55,10 @@ class Duplicate_Post extends Integration_Abstract {
 			10,
 			2
 		);
+
+		add_filter( 'tec_events_pro_custom_tables_v1_duplicate_meta_data', [ $this, 'add_tickets_meta_to_duplicate' ], 10, 2 );
+
+		add_action( 'tribe_tickets_tickets_duplicated', [ $this, 'fix_post_fields_pointing_to_old_tickets' ], 10, 3 );
 	}
 
 	/**
@@ -74,6 +80,8 @@ class Duplicate_Post extends Integration_Abstract {
 			return;
 		}
 
+		$duplicated_ticket_ids = [];
+
 		// You technically can have multiple providers if you have RSVP + a ticket provider.
 		foreach ( $tickets as $ticket ) {
 
@@ -83,7 +91,90 @@ class Duplicate_Post extends Integration_Abstract {
 				continue;
 			}
 
-			$provider->clone_ticket_to_new_post( $post->ID, $new_post_id, $ticket->ID );
+			$duplicate_ticket_id = $provider->clone_ticket_to_new_post( $post->ID, $new_post_id, $ticket->ID );
+
+			/**
+			 * Fires after a ticket has been duplicated to a new post.
+			 *
+			 * @since TBD
+			 *
+			 * @param int $duplicate_ticket_id The ID of the duplicated ticket.
+			 * @param int $original_ticket_id The ID of the original ticket.
+			 * @param int $new_post_id The ID of the new post.
+			 * @param int $original_post_id The ID of the original post.
+			 */
+			do_action( 'tribe_tickets_ticket_duplicated', $duplicate_ticket_id, $ticket->ID, $new_post_id, $post->ID );
+
+			$duplicated_ticket_ids[ $ticket->ID ] = $duplicate_ticket_id;
 		}
+
+		/**
+		 * Fires after all tickets have been duplicated to a new post.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $duplicated_ticket_ids An array of ticket IDs that were duplicated.
+		 * @param int $new_post_id The ID of the new post.
+		 * @param int $original_post_id The ID of the original post.
+		 */
+		do_action( 'tribe_tickets_tickets_duplicated', $duplicated_ticket_ids, $new_post_id, $post->ID );
+	}
+
+	/**
+	 * Fix post fields pointing to old tickets.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $duplicated_ticket_maps An array of ticket IDs that were duplicated.
+	 * @param int $new_post_id The ID of the new post.
+	 * @param int $original_post_id The ID of the original post.
+	 *
+	 * @return void
+	 */
+	public function fix_post_fields_pointing_to_old_tickets( array $duplicated_ticket_maps, int $new_post_id, int $original_post_id ) {
+		$duplicated_post = get_post( $new_post_id );
+		if ( ! ( $duplicated_post && $duplicated_post->ID && $duplicated_post->post_content ) ) {
+			return;
+		}
+
+		$post_content = $duplicated_post->post_content;
+
+		$tickets_block_locator = static fn( $v ) => '"ticketId":' . $v;
+
+		$new_post_content      = str_replace(
+			array_map( $tickets_block_locator, array_keys( $duplicated_ticket_maps ) ),
+			array_map( $tickets_block_locator, array_values( $duplicated_ticket_maps ) ),
+			$post_content
+		);
+
+		wp_update_post(
+			[
+				'ID'           => $new_post_id,
+				'post_content' => $new_post_content,
+			]
+		);
+	}
+
+	/**
+	 * Add tickets meta to the list of meta keys to duplicate.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $meta Meta keys to duplicate.
+	 *
+	 * @return array
+	 */
+	public function add_tickets_meta_to_duplicate( array $meta ): array {
+		return array_merge(
+			$meta,
+			[
+				tribe( 'tickets.handler' )->key_capacity,
+				tribe( 'tickets.handler' )->key_image_header,
+				tribe( 'tickets.handler' )->key_provider_field,
+				Global_Stock::GLOBAL_STOCK_ENABLED,
+				Global_Stock::GLOBAL_STOCK_LEVEL,
+				Attendees_List::HIDE_META_KEY,
+			],
+		);
 	}
 }

--- a/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
@@ -58,7 +58,7 @@ class Duplicate_Post extends Integration_Abstract {
 
 		add_filter( 'tec_events_pro_custom_tables_v1_duplicate_meta_data', [ $this, 'add_tickets_meta_to_duplicate' ], 10, 2 );
 
-		add_action( 'tribe_tickets_tickets_duplicated', [ $this, 'remap_fields_pointing_to_old_tickets_after_duplicate' ], 10, 3 );
+		add_action( 'tec_tickets_tickets_duplicated', [ $this, 'remap_fields_pointing_to_old_tickets_after_duplicate' ], 10, 3 );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Duplicate_Post extends Integration_Abstract {
 			 * @param int $new_post_id The ID of the new post.
 			 * @param int $original_post_id The ID of the original post.
 			 */
-			do_action( 'tribe_tickets_ticket_duplicated', $duplicate_ticket_id, $ticket->ID, $new_post_id, $post->ID );
+			do_action( 'tec_tickets_ticket_duplicated', $duplicate_ticket_id, $ticket->ID, $new_post_id, $post->ID );
 
 			$duplicated_ticket_ids[ $ticket->ID ] = $duplicate_ticket_id;
 		}
@@ -117,7 +117,7 @@ class Duplicate_Post extends Integration_Abstract {
 		 * @param int $new_post_id The ID of the new post.
 		 * @param int $original_post_id The ID of the original post.
 		 */
-		do_action( 'tribe_tickets_tickets_duplicated', $duplicated_ticket_ids, $new_post_id, $post->ID );
+		do_action( 'tec_tickets_tickets_duplicated', $duplicated_ticket_ids, $new_post_id, $post->ID );
 	}
 
 	/**

--- a/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
+++ b/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
@@ -80,7 +80,7 @@ class Duplicate_PostTest extends WPTestCase {
 			$this->assertNotContains( (string) $ticket_id, $duplicated_event->post_content );
 		}
 
-		foreach( array_reverse( $meta ) as $k => $v ) {
+		foreach( $meta as $k => $v ) {
 			$this->assertEquals( $v, get_post_meta( $event_id, $k, true ), $k );
 			$this->assertEquals( $v, get_post_meta( $duplicated_event->ID, $k, true ), $k );
 		}

--- a/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
+++ b/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace TEC\Tickets\Integrations\Plugins\Events_Pro;
+
+use Codeception\TestCase\WPTestCase;
+use Generator;
+use Closure;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use TEC\Events_Pro\Custom_Tables\V1\Duplicate\Duplicate;
+use Tribe\Tickets\Events\Attendees_List;
+use Tribe__Tickets__Global_Stock as Global_Stock;
+use WP_Post;
+
+class Duplicate_PostTest extends WPTestCase {
+	use Ticket_Maker;
+
+	public function event_with_tickets_provider(): Generator {
+		yield 'event with tickets' => [
+			function () {
+				$event_id = tribe_events()->set_args(
+					[
+						'title'      => 'Test Event',
+						'status'     => 'publish',
+						'start_date' => '2020-01-01 12:00:00',
+						'duration'   => 2 * HOUR_IN_SECONDS,
+					]
+				)->create()->ID;
+
+				$ticket_id_1 = $this->create_tc_ticket( $event_id );
+				$ticket_id_2 = $this->create_tc_ticket( $event_id );
+
+				wp_update_post(
+					[
+						'ID'           => $event_id,
+						'post_content' => '"ticketId":' . $ticket_id_1 . ',"ticketId":' . $ticket_id_2,
+					]
+				);
+
+				$meta = [
+					tribe( 'tickets.handler' )->key_capacity       => 10,
+					tribe( 'tickets.handler' )->key_image_header   => 4,
+					tribe( 'tickets.handler' )->key_provider_field => 'TEC\Tickets\Commerce\Module',
+					Global_Stock::GLOBAL_STOCK_ENABLED             => true,
+					Global_Stock::GLOBAL_STOCK_LEVEL               => 100,
+					Attendees_List::HIDE_META_KEY                  => false,
+				];
+
+				foreach( $meta as $k => $v ) {
+					update_post_meta( $event_id, $k, $v );
+				}
+
+				return [ $event_id, [ $ticket_id_1, $ticket_id_2 ], $meta ];
+			}
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider event_with_tickets_provider
+	 * it should duplicate tickets along with event
+	 */
+	public function it_should_duplicate_tickets_along_with_event( Closure $fixture ) {
+		[ $event_id, $ticket_ids, $meta ] = $fixture();
+
+		$duplicator = tribe( Duplicate::class );
+
+		$event = get_post( $event_id );
+
+		$duplicated_event = $duplicator->duplicate_event( $event );
+
+		$this->assertInstanceOf( WP_Post::class, $duplicated_event );
+
+		$this->assertEquals( count( $ticket_ids ), did_action( 'tec_tickets_ticket_duplicated' ) );
+		$this->assertEquals( 1, did_action( 'tec_tickets_tickets_duplicated' ) );
+
+		// refresh.
+		$duplicated_event = get_post( $duplicated_event->ID );
+		foreach ( $ticket_ids as $ticket_id ) {
+			$this->assertContains( (string) $ticket_id, $event->post_content );
+			$this->assertNotContains( (string) $ticket_id, $duplicated_event->post_content );
+		}
+
+		foreach( array_reverse( $meta ) as $k => $v ) {
+			$this->assertEquals( $v, get_post_meta( $event_id, $k, true ), $k );
+			$this->assertEquals( $v, get_post_meta( $duplicated_event->ID, $k, true ), $k );
+		}
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1826]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

During event duplication, adds more meta for duplicating tickets. Moreover when tickets block is used it replaces the old ticket ids with the new ticket ids.

This PR goes along with [ECP#2570](https://github.com/the-events-calendar/events-pro/pull/2570) and [ETP#1645](https://github.com/the-events-calendar/event-tickets-plus/pull/1645/).

It also registers new actions for enabling integrations.

### 🎥 Artifacts <!-- if applicable-->

https://www.loom.com/share/9487578947154ad5b844dd55a7abaab8

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ECP-1826]: https://stellarwp.atlassian.net/browse/ECP-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ