### PR TITLE
Coupons & Fees - Classic Editor

### DIFF
--- a/src/Tickets/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
+++ b/src/Tickets/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
@@ -93,9 +93,35 @@ class Order_Modifier_Fee_Metabox {
 	 * @since TBD
 	 */
 	public function register(): void {
-		add_action( 'tribe_events_tickets_metabox_edit_main', [ $this, 'add_fee_section' ], 10, 2 );
+		add_action( 'tribe_events_tickets_metabox_edit_main', [ $this, 'add_fee_section' ], 30, 2 );
 		add_action( 'tec_tickets_commerce_after_save_ticket', [ $this, 'save_ticket_fee' ], 10, 3 );
 		add_action( 'tec_tickets_commerce_ticket_deleted', [ $this, 'delete_ticket_fee' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_order_modifiers_fee_scripts' ] );
+	}
+
+	/**
+	 * Enqueue custom JS for the Order Modifiers Fee functionality.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function enqueue_order_modifiers_fee_scripts() {
+		/** @var Tribe__Tickets__Main $tickets_main */
+		$tickets_main = tribe( 'tickets.main' );
+
+		// Define the path to your JS files.
+		$assets = [
+			[
+				'order-modifiers-fees-js',
+				'admin/order-modifiers/fees.js',
+				[ 'jquery', 'tribe-dropdowns', 'tribe-select2' ],
+				'admin_enqueue_scripts',
+			],
+		];
+
+		// Use tribe_assets to register and enqueue the JS file.
+		tribe_assets( $tickets_main, $assets );
 	}
 
 	/**
@@ -112,6 +138,7 @@ class Order_Modifier_Fee_Metabox {
 	 * @return void
 	 */
 	public function add_fee_section( int $post_id, ?int $ticket_id ): void {
+
 		$related_ticket_fees = [];
 
 		// If ticket_id is provided, retrieve associated fee relationships for the ticket.

--- a/src/Tickets/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
+++ b/src/Tickets/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
@@ -94,8 +94,8 @@ class Order_Modifier_Fee_Metabox {
 	 */
 	public function register(): void {
 		add_action( 'tribe_events_tickets_metabox_edit_main', [ $this, 'add_fee_section' ], 10, 2 );
-		add_action( 'tec_tickets_commerce_after_save_ticket', [ $this, 'save_ticket_fee' ], 10, 4 );
-		add_action( 'tec_tickets_commerce_ticket_deleted', [ $this, 'delete_ticket_fee' ], 10, 3 );
+		add_action( 'tec_tickets_commerce_after_save_ticket', [ $this, 'save_ticket_fee' ], 10, 3 );
+		add_action( 'tec_tickets_commerce_ticket_deleted', [ $this, 'delete_ticket_fee' ] );
 	}
 
 	/**
@@ -172,15 +172,13 @@ class Order_Modifier_Fee_Metabox {
 	 * @param int    $post_id The post ID of the ticket.
 	 * @param object $ticket The ticket object.
 	 * @param array  $raw_data The raw form data.
-	 * @param string $class The class name.
 	 *
 	 * @return void
 	 */
-	public function save_ticket_fee( int $post_id, object $ticket, array $raw_data, string $class ): void {
+	public function save_ticket_fee( int $post_id, object $ticket, array $raw_data ): void {
 		// Delete existing relationships for the ticket.
 		$this->manager->delete_relationships_by_post( $ticket->ID );
 
-		// @todo redscar - It would make sense to check 'all' fees and reapply them here.
 		// Get available fees with specific meta values.
 		$fees = $this->order_modifiers_repository->find_by_modifier_type_and_meta(
 			$this->modifier_type,
@@ -220,12 +218,10 @@ class Order_Modifier_Fee_Metabox {
 	 * @since TBD
 	 *
 	 * @param int $ticket_id The ticket ID.
-	 * @param int $event_id The event ID.
-	 * @param int $product_id The product ID.
 	 *
 	 * @return void
 	 */
-	public function delete_ticket_fee( int $ticket_id, int $event_id, int $product_id ): void {
+	public function delete_ticket_fee( int $ticket_id ): void {
 		// Delete all fee relationships for the ticket.
 		$this->manager->delete_relationships_by_post( $ticket_id );
 	}

--- a/src/Tickets/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
+++ b/src/Tickets/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
@@ -119,11 +119,11 @@ class Order_Modifier_Fee_Metabox {
 			$related_ticket_fees = $this->order_modifiers_relationship_repository->find_by_post_id( $ticket_id );
 		}
 
-		// Extract modifier IDs from the related fees for the ticket.
-		$related_fee_ids = array_map(
+		// Ensure that $related_ticket_fees is an array and extract modifier IDs from the related fees for the ticket.
+		$related_fee_ids = is_array( $related_ticket_fees ) ? array_map(
 			fn( $relationship ) => $relationship->modifier_id,
 			$related_ticket_fees
-		);
+		) : [];
 
 		// Retrieve all fees based on modifier type and specific meta conditions.
 		$available_fees = $this->order_modifiers_repository->find_by_modifier_type_and_meta(

--- a/src/Tickets/Order_Modifiers/Controller.php
+++ b/src/Tickets/Order_Modifiers/Controller.php
@@ -18,7 +18,7 @@ use TEC\Tickets\Order_Modifiers\Custom_Tables\Order_Modifiers_Meta;
 use TEC\Tickets\Order_Modifiers\Modifiers\Coupon;
 use TEC\Tickets\Order_Modifiers\Modifiers\Fee;
 use TEC\Tickets\Order_Modifiers\Modifiers\Modifier_Strategy_Interface;
-use TEC\Tickets\Order_Modifiers\Admin\Classic_Modifier;
+use TEC\Tickets\Order_Modifiers\Admin\Order_Modifier_Fee_Metabox;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 
 /**
@@ -63,7 +63,7 @@ class Controller extends Controller_Contract {
 	 */
 	protected function hook() {
 		tribe( Modifier_Admin_Handler::class )->register();
-		tribe( Classic_Modifier::class )->register();
+		tribe( Order_Modifier_Fee_Metabox::class )->register();
 	}
 
 	/**
@@ -169,7 +169,8 @@ class Controller extends Controller_Contract {
 	 *
 	 * @return Modifier_Strategy_Interface The strategy class if found.
 	 *
-	 * @throws \InvalidArgumentException If the modifier strategy class is not found or does not implement Modifier_Strategy_Interface.
+	 * @throws \InvalidArgumentException If the modifier strategy class is not found or does not implement
+	 *     Modifier_Strategy_Interface.
 	 */
 	public function get_modifier( string $modifier ): Modifier_Strategy_Interface {
 		// Sanitize the modifier parameter to ensure it's a valid string.

--- a/src/Tickets/Order_Modifiers/Custom_Tables/Order_Modifiers_Meta.php
+++ b/src/Tickets/Order_Modifiers/Custom_Tables/Order_Modifiers_Meta.php
@@ -115,6 +115,7 @@ class Order_Modifiers_Meta extends Table {
 		$results = $this->check_and_add_index( $wpdb, $results, $table_name, 'tec_order_modifier_meta_inx_order_modifier_id', 'order_modifier_id' );
 		$results = $this->check_and_add_index( $wpdb, $results, $table_name, 'tec_order_modifier_meta_inx_meta_key', 'meta_key' );
 		$results = $this->check_and_add_index( $wpdb, $results, $table_name, 'tec_order_modifier_meta_inx_order_modifier_id_meta_key', 'order_modifier_id, meta_key' );
+		$results = $this->check_and_add_index( $wpdb, $results, $table_name, 'tec_order_modifier_meta_inx_meta_key_meta_value', 'meta_key,meta_value(255)' );
 
 		return $results;
 	}

--- a/src/Tickets/Order_Modifiers/Modifiers/Fee.php
+++ b/src/Tickets/Order_Modifiers/Modifiers/Fee.php
@@ -354,5 +354,4 @@ class Fee extends Modifier_Abstract {
 	public function get_active_on( $modifier_id ) {
 		return $this->order_modifiers_relationship_repository->find_by_modifier_id( $modifier_id );
 	}
-
 }

--- a/src/Tickets/Order_Modifiers/Modifiers/Modifier_Abstract.php
+++ b/src/Tickets/Order_Modifiers/Modifiers/Modifier_Abstract.php
@@ -583,7 +583,7 @@ abstract class Modifier_Abstract implements Modifier_Strategy_Interface {
 	 *
 	 * @return void
 	 */
-	protected function delete_relationship_by_modifier( int $modifier_id ): void {
+	public function delete_relationship_by_modifier( int $modifier_id ): void {
 		$data = [
 			'modifier_id' => $modifier_id,
 		];
@@ -602,7 +602,7 @@ abstract class Modifier_Abstract implements Modifier_Strategy_Interface {
 	 *
 	 * @return void
 	 */
-	protected function delete_relationship_by_post( int $post_id ): void {
+	public function delete_relationship_by_post( int $post_id ): void {
 		$data = [
 			'post_id'   => $post_id,
 			'post_type' => get_post_type( $post_id ),
@@ -720,5 +720,22 @@ abstract class Modifier_Abstract implements Modifier_Strategy_Interface {
 		}
 
 		return false; // Return false if the modifier deletion failed.
+	}
+
+	/**
+	 * Retrieves the meta value for a specific order modifier and meta key.
+	 *
+	 * This method fetches the meta data associated with the given order modifier ID and meta key.
+	 * It queries the `order_modifiers_meta` table to find the relevant meta data for the modifier.
+	 *
+	 * @since TBD
+	 *
+	 * @param int    $order_modifier_id The ID of the order modifier to retrieve meta for.
+	 * @param string $meta_key          The meta key to look up (e.g., 'fee_applied_to').
+	 *
+	 * @return mixed|null The meta data found, or null if no matching record is found.
+	 */
+	public function get_order_modifier_meta_by_key( int $order_modifier_id, string $meta_key ) {
+		return $this->order_modifiers_meta_repository->find_by_order_modifier_id_and_meta_key( $order_modifier_id, $meta_key );
 	}
 }

--- a/src/Tickets/Order_Modifiers/Modifiers/Modifier_Manager.php
+++ b/src/Tickets/Order_Modifiers/Modifiers/Modifier_Manager.php
@@ -118,4 +118,35 @@ class Modifier_Manager {
 	public function sync_modifier_relationships( array $modifier_ids, array $new_post_ids ): void {
 		$this->strategy->handle_relationship_update( $modifier_ids, $new_post_ids );
 	}
+
+	/**
+	 * Deletes all relationships associated with a given modifier ID.
+	 *
+	 * This method allows the manager to clear relationships based on the modifier ID.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $modifier_id The ID of the modifier for which relationships should be deleted.
+	 *
+	 * @return void
+	 */
+	public function delete_relationships_by_modifier( int $modifier_id ): void {
+		$this->strategy->delete_relationship_by_modifier( $modifier_id );
+	}
+
+	/**
+	 * Deletes all relationships associated with a given post ID.
+	 *
+	 * This method allows the manager to clear relationships based on the post ID.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $post_id The ID of the post for which relationships should be deleted.
+	 *
+	 * @return void
+	 */
+	public function delete_relationships_by_post( int $post_id ): void {
+		$this->strategy->delete_relationship_by_post( $post_id );
+	}
+
 }

--- a/src/Tickets/Order_Modifiers/Repositories/Order_Modifier_Relationship.php
+++ b/src/Tickets/Order_Modifiers/Repositories/Order_Modifier_Relationship.php
@@ -201,10 +201,10 @@ class Order_Modifier_Relationship extends Repository implements Insertable, Upda
 	 *
 	 * @return array|null The data from the Order Modifier and wp_posts tables.
 	 */
-	public function find_by_post_id( int $post_id ): ?Order_Modifier_Model {
+	public function find_by_post_id( int $post_id ): ?array {
 		return $this->build_base_query()
 					->where( 'p.ID', $post_id )
-					->get();
+					->getAll();
 	}
 
 	/**

--- a/src/Tickets/Order_Modifiers/Table_Views/Fee_Table.php
+++ b/src/Tickets/Order_Modifiers/Table_Views/Fee_Table.php
@@ -92,10 +92,12 @@ class Fee_Table extends Order_Modifier_Table {
 	 * @return string The HTML output for the "Active On" column, depending on where the modifier is applied.
 	 */
 	protected function render_active_on_column( $item ): string {
-		$apply_to = $this->order_modifier_meta_repository->find_by_order_modifier_id_and_meta_key( $item->id, 'fee_applied_to' )->meta_value ?? '';
+		// If there is no relationship type, we assume the fee is assigned to all tickets.
+		$relationship_type = $this->modifier->get_order_modifier_meta_by_key( $item->id, 'fee_applied_to' )->meta_value ?? '';
 
-		switch ( $apply_to ) {
+		switch ( $relationship_type ) {
 			case 'all':
+			case '':
 				return $this->display_all_tickets();
 			case 'per':
 				return $this->display_per_tickets( $item->id );

--- a/src/admin-views/order_modifiers/classic-fee-edit.php
+++ b/src/admin-views/order_modifiers/classic-fee-edit.php
@@ -16,7 +16,7 @@ if ( empty( $automatic_fees ) && empty( $selectable_fees ) ) {
 }
 ?>
 
-<div class="input_block">
+<div class="input_block" id="ticket_order_modifier_ticket_fees">
 	<label class="ticket_form_label ticket_form_left" for="ticket_fees">
 		<?php esc_html_e( 'Ticket Fees:', 'event-tickets' ); ?>
 	</label>
@@ -27,7 +27,7 @@ if ( empty( $automatic_fees ) && empty( $selectable_fees ) ) {
 			<!-- Display automatically applied fees if meta_value is 'all' or empty -->
 			<?php if ( ! empty( $automatic_fees ) ) : ?>
 				<div class="automatic-fees">
-					<h4><?php esc_html_e( 'The following fees will be automatically applied:', 'event-tickets' ); ?></h4>
+					<strong><?php esc_html_e( 'The following fees will be automatically applied:', 'event-tickets' ); ?></strong>
 					<ul>
 						<?php foreach ( $automatic_fees as $automatic_fee ) : ?>
 							<li><?php echo esc_html( $automatic_fee->display_name ); ?></li>
@@ -38,22 +38,27 @@ if ( empty( $automatic_fees ) && empty( $selectable_fees ) ) {
 
 			<!-- Display checkboxes for fees that are not 'all' -->
 			<?php if ( ! empty( $selectable_fees ) ) : ?>
-				<?php foreach ( $selectable_fees as $selectable_fee ) : ?>
-					<div class="fee-checkbox">
-						<input
-							type="checkbox"
-							id="fee_<?php echo esc_attr( $selectable_fee->id ); ?>"
-							name="ticket_order_modifier_fees[]"
-							value="<?php echo esc_attr( $selectable_fee->id ); ?>"
-							<?php if ( in_array( $selectable_fee->id, $related_fee_ids ) ) : ?>
-								checked="checked"
-							<?php endif; ?>
-						>
-						<label for="fee_<?php echo esc_attr( $selectable_fee->id ); ?>">
-							<?php echo esc_html( $selectable_fee->display_name ); ?>
-						</label>
-					</div>
-				<?php endforeach; ?>
+				<div class="selectable-fees">
+					<select
+						class="tribe-dropdown"
+						name="ticket_order_modifier_fees[]"
+						id="ticket_order_modifier_fees"
+						multiple
+						data-placeholder="<?php esc_attr_e( 'Select fees...', 'event-tickets' ); ?>"
+						data-search-placeholder="<?php esc_attr_e( 'Search fees...', 'event-tickets' ); ?>"
+						data-allow-clear="true"
+						data-width="resolve"
+					>
+						<option value=""><?php esc_html_e( 'Select fees', 'event-tickets' ); ?></option>
+
+						<?php foreach ( $selectable_fees as $fee ) : ?>
+							<option
+								value="<?php echo esc_attr( $fee->id ); ?>" <?php selected( in_array( $fee->id, $related_fee_ids ) ); ?>>
+								<?php echo esc_html( $fee->display_name ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</div>
 			<?php endif; ?>
 
 		<?php else : ?>
@@ -62,3 +67,5 @@ if ( empty( $automatic_fees ) && empty( $selectable_fees ) ) {
 
 	</div>
 </div>
+
+

--- a/src/admin-views/order_modifiers/classic-fee-edit.php
+++ b/src/admin-views/order_modifiers/classic-fee-edit.php
@@ -14,8 +14,9 @@
 ?>
 
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left"
-		   for="ticket_fees"><?php esc_html_e( 'Ticket Fees:', 'event-tickets' ); ?></label>
+	<label class="ticket_form_label ticket_form_left" for="ticket_fees">
+		<?php esc_html_e( 'Ticket Fees:', 'event-tickets' ); ?>
+	</label>
 	<div class="ticket_form_right">
 
 		<?php if ( ! empty( $automatic_fees ) || ! empty( $selectable_fees ) ) : ?>

--- a/src/admin-views/order_modifiers/classic-fee-edit.php
+++ b/src/admin-views/order_modifiers/classic-fee-edit.php
@@ -1,0 +1,25 @@
+<div class="input_block">
+	<label class="ticket_form_label ticket_form_left" for="ticket_fees">Ticket Fees:</label>
+	<div class="ticket_form_right">
+		<?php if ( ! empty( $fees ) ) : ?>
+			<?php foreach ( $fees as $fee ) : ?>
+				<div class="fee-checkbox">
+					<input
+						type="checkbox"
+						id="fee_<?php echo esc_attr( $fee->id ); ?>"
+						name="ticket_order_modifier_fees[]"
+						value="<?php echo esc_attr( $fee->id ); ?>"
+						<?php if ( $fee->meta_value === 'all' || $fee->meta_value === null ) : ?>
+							checked="checked"
+						<?php endif; ?>
+					>
+					<label for="fee_<?php echo esc_attr( $fee->id ); ?>">
+						<?php echo esc_html( $fee->display_name ); ?>
+					</label>
+				</div>
+			<?php endforeach; ?>
+		<?php else : ?>
+			<p><?php esc_html_e( 'No fees available.', 'event-tickets' ); ?></p>
+		<?php endif; ?>
+	</div>
+</div>

--- a/src/admin-views/order_modifiers/classic-fee-edit.php
+++ b/src/admin-views/order_modifiers/classic-fee-edit.php
@@ -1,25 +1,60 @@
+<?php
+/**
+ * Template for displaying the ticket fees section in the ticket metabox.
+ *
+ * @since TBD
+ *
+ * @var int   $post_id The event the ticket is associated to.
+ * @var int   $ticket_id The ID of the current ticket (nullable).
+ * @var array $related_fee_ids Array of fee IDs associated with the current ticket.
+ * @var array $automatic_fees Array of fees that are automatically applied (meta_value is 'all' or empty).
+ * @var array $selectable_fees Array of fees that can be manually selected (meta_value is not 'all').
+ */
+
+?>
+
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_fees">Ticket Fees:</label>
+	<label class="ticket_form_label ticket_form_left"
+		   for="ticket_fees"><?php esc_html_e( 'Ticket Fees:', 'event-tickets' ); ?></label>
 	<div class="ticket_form_right">
-		<?php if ( ! empty( $fees ) ) : ?>
-			<?php foreach ( $fees as $fee ) : ?>
-				<div class="fee-checkbox">
-					<input
-						type="checkbox"
-						id="fee_<?php echo esc_attr( $fee->id ); ?>"
-						name="ticket_order_modifier_fees[]"
-						value="<?php echo esc_attr( $fee->id ); ?>"
-						<?php if ( $fee->meta_value === 'all' || $fee->meta_value === null ) : ?>
-							checked="checked"
-						<?php endif; ?>
-					>
-					<label for="fee_<?php echo esc_attr( $fee->id ); ?>">
-						<?php echo esc_html( $fee->display_name ); ?>
-					</label>
+
+		<?php if ( ! empty( $automatic_fees ) || ! empty( $selectable_fees ) ) : ?>
+
+			<!-- Display automatically applied fees if meta_value is 'all' or empty -->
+			<?php if ( ! empty( $automatic_fees ) ) : ?>
+				<div class="automatic-fees">
+					<h4><?php esc_html_e( 'The following fees will be automatically applied:', 'event-tickets' ); ?></h4>
+					<ul>
+						<?php foreach ( $automatic_fees as $automatic_fee ) : ?>
+							<li><?php echo esc_html( $automatic_fee->display_name ); ?></li>
+						<?php endforeach; ?>
+					</ul>
 				</div>
-			<?php endforeach; ?>
+			<?php endif; ?>
+
+			<!-- Display checkboxes for fees that are not 'all' -->
+			<?php if ( ! empty( $selectable_fees ) ) : ?>
+				<?php foreach ( $selectable_fees as $selectable_fee ) : ?>
+					<div class="fee-checkbox">
+						<input
+							type="checkbox"
+							id="fee_<?php echo esc_attr( $selectable_fee->id ); ?>"
+							name="ticket_order_modifier_fees[]"
+							value="<?php echo esc_attr( $selectable_fee->id ); ?>"
+							<?php if ( in_array( $selectable_fee->id, $related_fee_ids ) ) : ?>
+								checked="checked"
+							<?php endif; ?>
+						>
+						<label for="fee_<?php echo esc_attr( $selectable_fee->id ); ?>">
+							<?php echo esc_html( $selectable_fee->display_name ); ?>
+						</label>
+					</div>
+				<?php endforeach; ?>
+			<?php endif; ?>
+
 		<?php else : ?>
 			<p><?php esc_html_e( 'No fees available.', 'event-tickets' ); ?></p>
 		<?php endif; ?>
+
 	</div>
 </div>

--- a/src/admin-views/order_modifiers/classic-fee-edit.php
+++ b/src/admin-views/order_modifiers/classic-fee-edit.php
@@ -11,6 +11,9 @@
  * @var array $selectable_fees Array of fees that can be manually selected (meta_value is not 'all').
  */
 
+if ( empty( $automatic_fees ) && empty( $selectable_fees ) ) {
+	return;
+}
 ?>
 
 <div class="input_block">

--- a/src/resources/js/admin/order-modifiers/fees.js
+++ b/src/resources/js/admin/order-modifiers/fees.js
@@ -1,0 +1,76 @@
+/**
+ * File: fees.js
+ * Description: This script initializes a Select2 dropdown for the "Ticket Order Modifier Fees"
+ * and ensures the dropdown remains functional when dynamically added elements are observed.
+ *
+ * It integrates the `tribe_dropdowns()` function from the dropdown.js file and ensures the
+ * dropdown is initialized when the document is ready or when new elements are added to the DOM.
+ *
+ * Dependencies:
+ * - jQuery
+ * - tribe_dropdowns.js
+ *
+ * @since TBD
+ */
+
+(function ( $, tribe_dropdowns ) {
+	'use strict';
+
+	/**
+	 * Initializes the Select2 dropdown for ticket order modifier fees.
+	 * Ensures the dropdown is initialized only if it exists and hasn't already been initialized.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	const initFeesDropdown = () => {
+		const feesDropdown = document.querySelector( '#ticket_order_modifier_fees' );
+
+		// Check if the dropdown exists and hasn't been initialized by Select2.
+		if ( feesDropdown && ! feesDropdown.classList.contains( 'select2-hidden-accessible' ) ) {
+			$( feesDropdown ).tribe_dropdowns();
+		}
+	};
+
+	/**
+	 * Initializes the dropdown when the document is fully loaded and ready.
+	 *
+	 * @since TBD
+	 */
+	document.addEventListener( 'DOMContentLoaded',
+		() => {
+			initFeesDropdown();
+		}
+	);
+
+	/**
+	 * MutationObserver to detect when elements (such as the dropdown) are dynamically added to the DOM.
+	 * If new nodes are added that include the fee dropdown, initialize Select2 on them.
+	 *
+	 * @since TBD
+	 */
+	const observer = new MutationObserver(
+		( mutationsList ) => {
+			for ( const mutation of mutationsList ) {
+				// Check if any added nodes contain the dropdown we're looking for.
+				if ( mutation.addedNodes.length > 0 ) {
+					initFeesDropdown(); // Initialize the dropdown when added to the DOM.
+				}
+			}
+		}
+	);
+
+	/**
+	 * Observe the document body for added child nodes and run the observer on the entire subtree.
+	 * This ensures dynamically added elements are captured and initialized.
+	 *
+	 * @since TBD
+	 */
+	observer.observe( document.body, {
+		childList: true,
+		subtree: true
+		}
+	);
+
+})( jQuery, window.tribe_dropdowns );

--- a/src/resources/postcss/tickets-admin.pcss
+++ b/src/resources/postcss/tickets-admin.pcss
@@ -825,6 +825,34 @@ p.description {
 	}
 }
 
+#ticket_order_modifier_ticket_fees {
+	width: 70%;
+
+	.automatic-fees {
+		ul {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 5px;
+			list-style-type: none;
+			padding: 0;
+		}
+
+		li {
+			flex: 1 0 30%;
+			margin: 0;
+		}
+	}
+
+	.selectable-fees {
+		width: 100%;
+
+		.select2-selection {
+			/* @todo redscar - We shouldnt hardcode this at all. Something is wrong with the element styling. */
+			width:300px;
+		}
+	}
+}
+
 .tec-tickets-price {
 	ins {
 		text-decoration: none;


### PR DESCRIPTION
This PR introduces several improvements and refinements related to the ticket fee functionality in both the `class-fee-edit.php` template and the `Order_Modifier_Fee_Metabox.php` class.

#### Changes:
- **`class-fee-edit.php`**:
  - Updated the template to distinguish between automatically applied fees (those with `meta_value = 'all'` or empty) and selectable fees.
  - Automatically applied fees are now listed separately above the checkboxes, while selectable fees are rendered as checkboxes for manual selection.
  
- **`Order_Modifier_Fee_Metabox.php`**:
  - Refactored the logic for retrieving and displaying fees in the ticket metabox. Fees are now grouped into automatically applied and selectable categories.
  - Implemented methods to fetch associated fees for a given ticket and properly handle relationships between tickets and modifiers.
  - Improved variable naming for better code clarity and maintainability.

#### Additional Updates:
- Ensured proper handling of fee relationships when saving and deleting tickets.
- Improved readability by refactoring repetitive logic and optimizing variable names.
- Various minor adjustments to ensure smooth integration and user-friendly functionality within the ticket editing metabox.

[Fees_Ticket_Metabox.webm](https://github.com/user-attachments/assets/b9a89509-c3c3-457f-9a3f-6ca37a8357dd)
