### PR TITLE
Fix fetching incorrect order by payment intent

### DIFF
--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -701,6 +701,7 @@ class Order extends Abstract_Order {
 	 * Get the order associated with a given gateway order id.
 	 *
 	 * @since 5.3.0
+	 * @since TBD Update to fetch latest order in the case of multiple orders with the same gateway order id.
 	 *
 	 * @param string $gateway_order_id The gateway order id.
 	 *
@@ -708,6 +709,8 @@ class Order extends Abstract_Order {
 	 */
 	public function get_from_gateway_order_id( string $gateway_order_id ) {
 		return tec_tc_orders()->by_args( [
+			'order_by'         => 'ID',
+			'order'            => 'DESC',
 			'status'           => 'any',
 			'gateway_order_id' => $gateway_order_id,
 		] )->first();

--- a/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Success_Shortcode.php
@@ -35,10 +35,7 @@ class Success_Shortcode extends Shortcode_Abstract {
 	 */
 	public function setup_template_vars() {
 		$order_id = tribe_get_request_var( Success::$order_id_query_arg );
-		$order    = tec_tc_orders()->by_args( [
-			'status'           => 'any',
-			'gateway_order_id' => $order_id,
-		] )->first();
+		$order    = tribe( Order::class )->get_from_gateway_order_id( $order_id );
 
 		$attendees = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
 		// Sort the Attendees by ID.


### PR DESCRIPTION
### 🎫 Ticket
[ET-2225]

### 🗒️ Description
This is a partial fix for the mentioned ticket. There are scenarios where there are more than one orders per payment intent. When fetching, we always want to return the latest one.

### 🎥 Artifacts <!-- if applicable-->
N/A

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2225]: https://stellarwp.atlassian.net/browse/ET-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ