### PR TITLE
Tickets Commerce > Stripe Gateway > Webhooks: Use Payment Intent Events rather than Charge Events

### DIFF
--- a/changelog/fix-ET-2225-modify-webhook-handling
+++ b/changelog/fix-ET-2225-modify-webhook-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Tickets Commerce orders will update to the correct status after multiple payment attempts. [ET-2225]

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -2,7 +2,6 @@
 
 namespace TEC\Tickets\Commerce\Gateways\Stripe\Webhooks;
 
-use TEC\Tickets\Commerce\Gateways\Stripe\Status;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\Gateways\Contracts\Webhook_Event_Interface;
@@ -26,44 +25,6 @@ class Charge_Webhook implements Webhook_Event_Interface {
 		$payment_intent_id = $charge_data['payment_intent'];
 
 		$order = tribe( Order::class )->get_from_gateway_order_id( $payment_intent_id );
-
-		$payment_intent = Payment_Intent::get( $payment_intent_id );
-
-		/**
-		 * We were having problems for Payment Intent and Charge happening at the exact same time, so a race condition was happening
-		 * this particular piece of code prevents that problem, by making the Change Webhook look at the Payment Intent status on
-		 * Stripe it forces the Payment Intent to be the source of truth.
-		 *
-		 * See the link below for more information on the problems caused by this bug.
-		 *
-		 * @link https://stellarwp.atlassian.net/browse/ET-1792
-		 *
-		 * Second iteration see below for more information.
-		 *
-		 * @link https://stellarwp.atlassian.net/browse/ET-2142
-		 * @link https://github.com/the-events-calendar/event-tickets/pull/3095
-		 *
-		 * @since 5.7.1
-		 * @since 5.13.0 - Process Refunds requests always.
-		 */
-		if (
-			$payment_intent
-			&& isset( $payment_intent['status'] )
-			&& Status::SUCCEEDED === $payment_intent['status']
-			&& Events::CHARGE_REFUNDED !== Arr::get( $event, 'type' )
-		) {
-				$response->set_status( 200 );
-				$response->set_data(
-					sprintf(
-						// Translators: %1$s is the event id and %2$s is the event type name.
-						__( 'Event %1$s was received and will not be handled because the Payment Intent %2$s was already moved to the Success status.', 'event-tickets' ),
-						esc_html( Arr::get( $event, 'id' ) ),
-						esc_html( $payment_intent_id )
-					)
-				);
-
-				return $response;
-		}
 
 		if ( empty( $order ) ) {
 

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Events.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Events.php
@@ -277,5 +277,4 @@ class Events {
 
 		return tribe( Commerce_Status\Status_Handler::class )->get_by_class( $events[ $event_name ] );
 	}
-
 }

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Events.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Events.php
@@ -142,6 +142,7 @@ class Events {
 	 * Returns the handle to be used for each webhook event.
 	 *
 	 * @since 5.3.0
+	 * @since TBD Removed Charge events that can be replaced by Payment Intent events.
 	 *
 	 * @return array
 	 */
@@ -150,9 +151,7 @@ class Events {
 			static::ACCOUNT_UPDATED                  => [ Account_Webhook::class, 'handle_account_updated' ],
 			static::ACCOUNT_APPLICATION_DEAUTHORIZED => [ Account_Webhook::class, 'handle_account_deauthorized' ],
 			static::CHARGE_EXPIRED                   => [ Charge_Webhook::class, 'handle' ],
-			static::CHARGE_FAILED                    => [ Charge_Webhook::class, 'handle' ],
 			static::CHARGE_REFUNDED                  => [ Charge_Webhook::class, 'handle' ],
-			static::CHARGE_SUCCEEDED                 => [ Charge_Webhook::class, 'handle' ],
 			static::PAYMENT_INTENT_PROCESSING        => [ Payment_Intent_Webhook::class, 'handle' ],
 			static::PAYMENT_INTENT_REQUIRES_ACTION   => [ Payment_Intent_Webhook::class, 'handle' ],
 			static::PAYMENT_INTENT_SUCCEEDED         => [ Payment_Intent_Webhook::class, 'handle' ],
@@ -175,18 +174,17 @@ class Events {
 	 * If it converts directly to a TC status it will be the status Class name, otherwise it will be callable.
 	 *
 	 * @since 5.3.0
+	 * @since TBD Removed Charge events that can be replaced by Payment Intent events.
 	 *
 	 * @return callable[]|Commerce_Status\Status_Interface[]
 	 */
 	public static function get_event_transition_status(): array {
 		$events = [
 			static::CHARGE_EXPIRED                 => Commerce_Status\Not_Completed::class,
-			static::CHARGE_FAILED                  => Commerce_Status\Denied::class,
 			static::CHARGE_REFUNDED                => Commerce_Status\Refunded::class,
-			static::CHARGE_SUCCEEDED               => Commerce_Status\Completed::class,
 			static::PAYMENT_INTENT_CANCELED        => Commerce_Status\Denied::class,
 			static::PAYMENT_INTENT_CREATED         => Commerce_Status\Created::class,
-			static::PAYMENT_INTENT_PAYMENT_FAILED  => Commerce_Status\Not_Completed::class,
+			static::PAYMENT_INTENT_PAYMENT_FAILED  => Commerce_Status\Denied::class,
 			static::PAYMENT_INTENT_PROCESSING      => Commerce_Status\Pending::class,
 			static::PAYMENT_INTENT_REQUIRES_ACTION => Commerce_Status\Action_Required::class,
 			static::PAYMENT_INTENT_SUCCEEDED       => Commerce_Status\Completed::class,

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
@@ -121,11 +121,6 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 
 		foreach ( $payment_intents_stored as $status => $intents ) {
 			foreach( $intents as $intent ) {
-				// Ignore intents that require source.
-				if ( $intent['status'] === Status::REQUIRES_SOURCE && $payment_intent_received['status'] === Status::SUCCEEDED ) {
-					continue;
-				}
-
 				// This payment intent has already been processed and updated.
 				if ( $payment_intent_received['id'] === $intent['id'] ) {
 					return false;


### PR DESCRIPTION
### 🎫 Ticket
[ET-2225]

### 🗒️ Description
I found that the `charge.failed` and `charge.succeeded` events can be replaced with `payment_intent.payment_failed` and `payment_intent.succeeded`. We were trying to handle both at the same time, which was causing issues with duplicate actions.

### 🎥 Artifacts <!-- if applicable-->
Screencast: https://share.zight.com/4guGlj7W

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2225]: https://stellarwp.atlassian.net/browse/ET-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ