### PR TITLE
Disabled create button when ASC but not seat type selected

### DIFF
--- a/src/Tickets/Blocks/Ticket/app/editor/dashboard/container.js
+++ b/src/Tickets/Blocks/Ticket/app/editor/dashboard/container.js
@@ -8,6 +8,7 @@ import { compose } from 'redux';
  * WordPress dependencies
  */
 import { dispatch as wpDispatch } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -16,12 +17,74 @@ import Template from './template';
 import { actions, selectors } from '@moderntribe/tickets/data/blocks/ticket';
 import { withStore } from '@moderntribe/common/hoc';
 
-const getIsConfirmDisabled = ( state, ownProps ) => (
-	! selectors.isTicketValid( state, ownProps ) ||
-		! selectors.getTicketHasChanges( state, ownProps ) ||
-		selectors.isTicketDisabled( state, ownProps ) ||
-		selectors.getTicketHasDurationError( state, ownProps )
-);
+/**
+ * Filters whether the confirm button should be disabled.
+ *
+ * @since TBD
+ *
+ * @param {Object} state    The state of the store.
+ * @param {Object} ownProps The own props of the component.
+ *
+ * @return {boolean} Whether the confirm button should be disabled.
+ */
+const shouldConfirmBeDisabled = (state, ownProps) => {
+	/**
+	 * Filters whether the ticket is valid.
+	 *
+	 * @since TBD
+	 *
+	 * @param {boolean} isValid  Whether the ticket is valid.
+	 * @param {Object}  state    The state of the store.
+	 * @param {Object}  ownProps The own props of the component.
+	 */
+	const isTicketValid = applyFilters(
+		'tec.tickets.blocks.ticket.isValid',
+		selectors.isTicketValid(state, ownProps),
+		state,
+		ownProps
+	);
+
+	if (!isTicketValid) {
+		return true;
+	}
+
+	if (selectors.isTicketDisabled(state, ownProps)) {
+		return true;
+	}
+
+	if (selectors.getTicketHasDurationError(state, ownProps)) {
+		return true;
+	}
+
+	return !selectors.getTicketHasChanges(state, ownProps);
+};
+
+/**
+ * Whether the confirm button should be disabled.
+ *
+ * @since TBD
+ *
+ * @param {Object} state    The state of the store.
+ * @param {Object} ownProps The own props of the component.
+ *
+ * @return {boolean} Whether the confirm button should be disabled.
+ */
+const getIsConfirmDisabled = (state, ownProps) =>
+	/**
+	 * Filters whether the confirm button should be disabled.
+	 *
+	 * @since TBD
+	 *
+	 * @param {boolean} isDisabled Whether the button is disabled.
+	 * @param {Object}  state      The state of the store.
+	 * @param {Object}  ownProps   The own props of the component.
+	 */
+	applyFilters(
+		'tec.tickets.blocks.confirmButton.isDisabled',
+		shouldConfirmBeDisabled(state, ownProps),
+		state,
+		ownProps
+	);
 
 const onCancelClick = ( state, dispatch, ownProps ) => () => {
 	if ( selectors.getTicketHasBeenCreated( state, ownProps ) ) {

--- a/src/Tickets/Blocks/Ticket/app/editor/dashboard/container.js
+++ b/src/Tickets/Blocks/Ticket/app/editor/dashboard/container.js
@@ -28,6 +28,18 @@ import { withStore } from '@moderntribe/common/hoc';
  * @return {boolean} Whether the confirm button should be disabled.
  */
 const shouldConfirmBeDisabled = (state, ownProps) => {
+	if (selectors.isTicketDisabled(state, ownProps)) {
+		return true;
+	}
+
+	if (selectors.getTicketHasDurationError(state, ownProps)) {
+		return true;
+	}
+
+	if (!selectors.getTicketHasChanges(state, ownProps)) {
+		return true;
+	}
+
 	/**
 	 * Filters whether the ticket is valid.
 	 *
@@ -37,26 +49,12 @@ const shouldConfirmBeDisabled = (state, ownProps) => {
 	 * @param {Object}  state    The state of the store.
 	 * @param {Object}  ownProps The own props of the component.
 	 */
-	const isTicketValid = applyFilters(
+	return !applyFilters(
 		'tec.tickets.blocks.ticket.isValid',
 		selectors.isTicketValid(state, ownProps),
 		state,
 		ownProps
 	);
-
-	if (!isTicketValid) {
-		return true;
-	}
-
-	if (selectors.isTicketDisabled(state, ownProps)) {
-		return true;
-	}
-
-	if (selectors.getTicketHasDurationError(state, ownProps)) {
-		return true;
-	}
-
-	return !selectors.getTicketHasChanges(state, ownProps);
 };
 
 /**

--- a/src/Tickets/Blocks/Ticket/app/editor/dashboard/container.js
+++ b/src/Tickets/Blocks/Ticket/app/editor/dashboard/container.js
@@ -18,46 +18,6 @@ import { actions, selectors } from '@moderntribe/tickets/data/blocks/ticket';
 import { withStore } from '@moderntribe/common/hoc';
 
 /**
- * Filters whether the confirm button should be disabled.
- *
- * @since TBD
- *
- * @param {Object} state    The state of the store.
- * @param {Object} ownProps The own props of the component.
- *
- * @return {boolean} Whether the confirm button should be disabled.
- */
-const shouldConfirmBeDisabled = (state, ownProps) => {
-	if (selectors.isTicketDisabled(state, ownProps)) {
-		return true;
-	}
-
-	if (selectors.getTicketHasDurationError(state, ownProps)) {
-		return true;
-	}
-
-	if (!selectors.getTicketHasChanges(state, ownProps)) {
-		return true;
-	}
-
-	/**
-	 * Filters whether the ticket is valid.
-	 *
-	 * @since TBD
-	 *
-	 * @param {boolean} isValid  Whether the ticket is valid.
-	 * @param {Object}  state    The state of the store.
-	 * @param {Object}  ownProps The own props of the component.
-	 */
-	return !applyFilters(
-		'tec.tickets.blocks.ticket.isValid',
-		selectors.isTicketValid(state, ownProps),
-		state,
-		ownProps
-	);
-};
-
-/**
  * Whether the confirm button should be disabled.
  *
  * @since TBD
@@ -67,7 +27,13 @@ const shouldConfirmBeDisabled = (state, ownProps) => {
  *
  * @return {boolean} Whether the confirm button should be disabled.
  */
-const getIsConfirmDisabled = (state, ownProps) =>
+const getIsConfirmDisabled = (state, ownProps) => {
+	const shouldConfirmBeDisabled =
+		selectors.isTicketDisabled(state, ownProps) ||
+		selectors.getTicketHasDurationError(state, ownProps) ||
+		!selectors.getTicketHasChanges(state, ownProps) ||
+		!selectors.isTicketValid(state, ownProps);
+
 	/**
 	 * Filters whether the confirm button should be disabled.
 	 *
@@ -77,12 +43,13 @@ const getIsConfirmDisabled = (state, ownProps) =>
 	 * @param {Object}  state      The state of the store.
 	 * @param {Object}  ownProps   The own props of the component.
 	 */
-	applyFilters(
+	return applyFilters(
 		'tec.tickets.blocks.confirmButton.isDisabled',
-		shouldConfirmBeDisabled(state, ownProps),
+		shouldConfirmBeDisabled,
 		state,
 		ownProps
 	);
+};
 
 const onCancelClick = ( state, dispatch, ownProps ) => () => {
 	if ( selectors.getTicketHasBeenCreated( state, ownProps ) ) {

--- a/src/Tickets/Seating/app/blockEditor/capacity-form/event-layout-select.js
+++ b/src/Tickets/Seating/app/blockEditor/capacity-form/event-layout-select.js
@@ -26,8 +26,8 @@ function EmptyLayouts( props ) {
 	);
 }
 
-function LockedLayout( props ) {
-	if ( ! props.layoutLocked ) {
+function LockedLayout(props) {
+	if (!(props.layoutLocked && props?.currentLayout)) {
 		return null;
 	}
 

--- a/src/Tickets/Seating/app/blockEditor/capacity-form/index.js
+++ b/src/Tickets/Seating/app/blockEditor/capacity-form/index.js
@@ -128,19 +128,19 @@ export default function CapacityForm({ renderDefaultForm, clientId }) {
 	const onLayoutChange = useCallback(
 		(choice) => {
 			const layoutSeats = getLayoutSeats(choice.value);
-			setTicketsSharedCapacityInCommonStore(layoutSeats);
 			updateEventMeta(choice.value);
 			setLayout(choice.value);
 			setEventCapacity(layoutSeats);
+			setTicketsSharedCapacityInCommonStore(layoutSeats, clientId);
 		},
-		[getLayoutSeats, setEventCapacity, setLayout, updateEventMeta]
+		[getLayoutSeats, setEventCapacity, setLayout, updateEventMeta, clientId]
 	);
 
 	const onSeatTypeChange = useCallback(
 		(choice) => {
 			const seatTypeSeats = getSeatTypeSeats(choice.value);
-			setCappedTicketCapacityInCommonStore(clientId, seatTypeSeats);
 			setTicketSeatType(clientId, choice.value);
+			setCappedTicketCapacityInCommonStore(clientId, seatTypeSeats);
 		},
 		[getSeatTypeSeats, setTicketSeatType, clientId]
 	);

--- a/src/Tickets/Seating/app/blockEditor/filters.js
+++ b/src/Tickets/Seating/app/blockEditor/filters.js
@@ -11,7 +11,7 @@ import {
 	filterTicketIsAsc,
 	setSeatTypeForTicket,
 	filterSettingsFields,
-	filterTicketIsValid,
+	filterButtonIsDisabled,
 } from './hook-callbacks';
 
 const shouldRenderAssignedSeatingForm = true;
@@ -145,7 +145,7 @@ addAction(
 );
 
 addFilter(
-	'tec.tickets.blocks.ticket.isValid',
+	'tec.tickets.blocks.confirmButton.isDisabled',
 	'tec.tickets.seating',
-	filterTicketIsValid
+	filterButtonIsDisabled
 );

--- a/src/Tickets/Seating/app/blockEditor/filters.js
+++ b/src/Tickets/Seating/app/blockEditor/filters.js
@@ -4,7 +4,6 @@ import { storeName } from './store';
 import { select } from '@wordpress/data';
 import Seats from './dashboard-actions/seats';
 import { filterCapacityTableMappedProps } from './capacity-table';
-import LayoutSelect from "./settings/layoutSelect";
 import {
 	filterSeatedTicketsAvailabilityMappedProps,
 	filterSetBodyDetails,
@@ -12,6 +11,7 @@ import {
 	filterTicketIsAsc,
 	setSeatTypeForTicket,
 	filterSettingsFields,
+	filterTicketIsValid,
 } from './hook-callbacks';
 
 const shouldRenderAssignedSeatingForm = true;
@@ -142,4 +142,10 @@ addAction(
 	'tec.tickets.blocks.ticketCreated',
 	'tec.tickets.seating',
 	setSeatTypeForTicket
+);
+
+addFilter(
+	'tec.tickets.blocks.ticket.isValid',
+	'tec.tickets.seating',
+	filterTicketIsValid
 );

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -153,11 +153,46 @@ export const filterSettingsFields = (fields) => {
 	const layouts = store.getLayoutsInOptionFormat();
 
 	fields.push(
-		<LayoutSelect
-			layouts={layouts}
-			currentLayout={currentLayout}
-		/>
+		<LayoutSelect layouts={layouts} currentLayout={currentLayout} />
 	);
 
 	return fields;
-}
+};
+
+/**
+ * Filters whether the ticket is valid.
+ *
+ * @since TBD
+ *
+ * @param {boolean} isValid  Whether the ticket is valid.
+ * @param {Object}  state    The state of the store.
+ * @param {Object}  ownProps The own props of the component.
+ *
+ * @return {boolean} Whether the ticket is valid.
+ */
+export const filterTicketIsValid = (isValid, state, ownProps) => {
+	if (!isValid) {
+		// No need to continue with the check if the ticket is already invalid.
+		return isValid;
+	}
+
+	const store = select(storeName);
+
+	const isUsingAssignedSeating = store.isUsingAssignedSeating();
+	if (!isUsingAssignedSeating) {
+		return isValid;
+	}
+
+	const layoutId = store.getCurrentLayoutId();
+	if (!layoutId) {
+		return false;
+	}
+
+	const seatType = store.getTicketSeatType(ownProps.clientId);
+
+	if (!seatType) {
+		return false;
+	}
+
+	return true;
+};

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -160,35 +160,35 @@ export const filterSettingsFields = (fields) => {
 };
 
 /**
- * Filters whether the ticket is valid.
+ * Filters whether the confirm save button is disabled.
  *
  * @since TBD
  *
- * @param {boolean} isValid  Whether the ticket is valid.
- * @param {Object}  state    The state of the store.
- * @param {Object}  ownProps The own props of the component.
+ * @param {boolean} isDisabled Whether the button is disabled.
+ * @param {Object}  state      The state of the store.
+ * @param {Object}  ownProps   The own props of the component.
  *
- * @return {boolean} Whether the ticket is valid.
+ * @return {boolean} Whether the button is disabled.
  */
-export const filterTicketIsValid = (isValid, state, ownProps) => {
-	if (!isValid) {
-		// No need to continue with the check if the ticket is already invalid.
-		return isValid;
+export const filterButtonIsDisabled = (isDisabled, state, ownProps) => {
+	if (isDisabled) {
+		// If disabled already, we have no reason to enable it.
+		return isDisabled;
 	}
 
 	const store = select(storeName);
 
 	if (!store.isUsingAssignedSeating()) {
-		return isValid;
+		return isDisabled;
 	}
 
 	if (!store.getCurrentLayoutId()) {
-		return false;
+		return true;
 	}
 
 	if (!store.getTicketSeatType(ownProps.clientId)) {
-		return false;
+		return true;
 	}
 
-	return true;
+	return false;
 };

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -178,19 +178,15 @@ export const filterTicketIsValid = (isValid, state, ownProps) => {
 
 	const store = select(storeName);
 
-	const isUsingAssignedSeating = store.isUsingAssignedSeating();
-	if (!isUsingAssignedSeating) {
+	if (!store.isUsingAssignedSeating()) {
 		return isValid;
 	}
 
-	const layoutId = store.getCurrentLayoutId();
-	if (!layoutId) {
+	if (!store.getCurrentLayoutId()) {
 		return false;
 	}
 
-	const seatType = store.getTicketSeatType(ownProps.clientId);
-
-	if (!seatType) {
+	if (!store.getTicketSeatType(ownProps.clientId)) {
 		return false;
 	}
 

--- a/src/Tickets/Seating/app/blockEditor/store/common-store-bridge.js
+++ b/src/Tickets/Seating/app/blockEditor/store/common-store-bridge.js
@@ -6,11 +6,9 @@ import {
 	setTicketTempCapacity,
 	setTicketTempCapacityType,
 	setTicketHasChanges,
-	setTicketTempTitle,
 } from '@moderntribe/tickets/data/blocks/ticket/actions';
 import {
 	getTicketId,
-	getTicketTempTitle,
 } from '@moderntribe/tickets/data/blocks/ticket/selectors';
 import { CAPPED } from '@moderntribe/tickets/data/blocks/ticket/constants';
 
@@ -41,11 +39,5 @@ export function setCappedTicketCapacityInCommonStore(clientId, capacity) {
 }
 
 export function setTicketHasChangesInCommonStore(clientId) {
-	const ticketTempTitle = selectFromCommonStore(getTicketTempTitle, {
-		clientId,
-	});
-
-	// "Changing" the tempTitle will trigger a re-evaluation on the confirm button's disabled status.
-	dispatchToCommonStore(setTicketTempTitle(clientId, ticketTempTitle));
 	dispatchToCommonStore(setTicketHasChanges(clientId, true));
 }

--- a/src/Tickets/Seating/app/blockEditor/store/common-store-bridge.js
+++ b/src/Tickets/Seating/app/blockEditor/store/common-store-bridge.js
@@ -5,8 +5,13 @@ import {
 	setTicketsTempSharedCapacity,
 	setTicketTempCapacity,
 	setTicketTempCapacityType,
+	setTicketHasChanges,
+	setTicketTempTitle,
 } from '@moderntribe/tickets/data/blocks/ticket/actions';
-import { getTicketId } from '@moderntribe/tickets/data/blocks/ticket/selectors';
+import {
+	getTicketId,
+	getTicketTempTitle,
+} from '@moderntribe/tickets/data/blocks/ticket/selectors';
 import { CAPPED } from '@moderntribe/tickets/data/blocks/ticket/constants';
 
 function dispatchToCommonStore(action) {
@@ -17,9 +22,10 @@ function selectFromCommonStore(selector, ...args) {
 	return selector(window.__tribe_common_store__.getState(), ...args);
 }
 
-export function setTicketsSharedCapacityInCommonStore(capacity) {
+export function setTicketsSharedCapacityInCommonStore(capacity, clientId) {
 	dispatchToCommonStore(setTicketsSharedCapacity(capacity));
 	dispatchToCommonStore(setTicketsTempSharedCapacity(capacity));
+	setTicketHasChangesInCommonStore(clientId);
 }
 
 export function getTicketIdFromCommonStore(clientId) {
@@ -31,4 +37,15 @@ export function setCappedTicketCapacityInCommonStore(clientId, capacity) {
 	dispatchToCommonStore(setTicketTempCapacity(clientId, capacity));
 	dispatchToCommonStore(setTicketCapacityType(clientId, CAPPED));
 	dispatchToCommonStore(setTicketTempCapacityType(clientId, CAPPED));
+	setTicketHasChangesInCommonStore(clientId);
+}
+
+export function setTicketHasChangesInCommonStore(clientId) {
+	const ticketTempTitle = selectFromCommonStore(getTicketTempTitle, {
+		clientId,
+	});
+
+	// "Changing" the tempTitle will trigger a re-evaluation on the confirm button's disabled status.
+	dispatchToCommonStore(setTicketTempTitle(clientId, ticketTempTitle));
+	dispatchToCommonStore(setTicketHasChanges(clientId, true));
 }

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -268,7 +268,7 @@ export const getTicketHasBeenCreated = createSelector(
 
 export const getTicketHasChanges = createSelector(
 	[ getTicket ],
-	( ticket ) => ticket.hasChanges || ! ticket.ticketId,
+	( ticket ) => ticket.hasChanges,
 );
 
 export const getTicketHasDurationError = createSelector(

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -268,7 +268,7 @@ export const getTicketHasBeenCreated = createSelector(
 
 export const getTicketHasChanges = createSelector(
 	[ getTicket ],
-	( ticket ) => ticket.hasChanges,
+	( ticket ) => ticket.hasChanges || ! ticket.ticketId,
 );
 
 export const getTicketHasDurationError = createSelector(
@@ -701,7 +701,7 @@ export const isTicketSalePriceValid = createSelector(
 
 export const isTempTitleValid = createSelector(
 	[ getTicketTempTitle ],
-	( title ) => trim( title ) !== '',
+	( title ) => title && trim( title ) !== '',
 );
 
 export const isTempCapacityValid = createSelector(

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -701,7 +701,7 @@ export const isTicketSalePriceValid = createSelector(
 
 export const isTempTitleValid = createSelector(
 	[ getTicketTempTitle ],
-	( title ) => title && trim( title ) !== '',
+	( title ) => trim( title ) !== '',
 );
 
 export const isTempCapacityValid = createSelector(

--- a/tests/slr_jest/blockEditor/hook-callbacks.spec.js
+++ b/tests/slr_jest/blockEditor/hook-callbacks.spec.js
@@ -8,6 +8,7 @@ import {
 	filterSeatedTicketsAvailabilityMappedProps,
 	filterSetBodyDetails,
 	setSeatTypeForTicket,
+	filterTicketIsValid,
 } from '@tec/tickets/seating/blockEditor/hook-callbacks';
 
 jest.mock('@wordpress/data', () => ({
@@ -465,6 +466,123 @@ describe('hook-callbacks', () => {
 
 			const newMappedPropsFromTrue = filterTicketIsAsc(true, 40);
 			expect(newMappedPropsFromTrue).toEqual(true);
+		});
+	});
+
+	describe('filterTicketIsValid', () => {
+		it('if invalid should return invalid', () => {
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+			expect(filterTicketIsValid(false, state, ownProps)).toEqual(false);
+		});
+
+		it('if not ASC it should not interfere', () => {
+			const seatType = null;
+			const layoutId = null;
+			const isUsingAssignedSeating = false;
+
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+
+			select.mockReturnValue({
+				getCurrentLayoutId: () => layoutId,
+				getTicketSeatType: () => seatType,
+				isUsingAssignedSeating: () => isUsingAssignedSeating,
+			});
+
+			expect(filterTicketIsValid(true, state, ownProps)).toEqual(true);
+		});
+
+		it('if ASC and no layout id or seat type it should return invalid', () => {
+			const seatType = null;
+			const layoutId = '';
+			const isUsingAssignedSeating = true;
+
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+
+			select.mockReturnValue({
+				getCurrentLayoutId: () => layoutId,
+				getTicketSeatType: () => seatType,
+				isUsingAssignedSeating: () => isUsingAssignedSeating,
+			});
+
+			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+		});
+
+		it('if ASC and no layout id or seat type it should return invalid', () => {
+			const seatType = '';
+			const layoutId = false;
+			const isUsingAssignedSeating = true;
+
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+
+			select.mockReturnValue({
+				getCurrentLayoutId: () => layoutId,
+				getTicketSeatType: () => seatType,
+				isUsingAssignedSeating: () => isUsingAssignedSeating,
+			});
+
+			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+		});
+
+		it('if ASC and layout id but no seat type it should return invalid', () => {
+			const seatType = '';
+			const layoutId = 'layout-uuid-1';
+			const isUsingAssignedSeating = true;
+
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+
+			select.mockReturnValue({
+				getCurrentLayoutId: () => layoutId,
+				getTicketSeatType: () => seatType,
+				isUsingAssignedSeating: () => isUsingAssignedSeating,
+			});
+
+			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+		});
+
+		it('if ASC and seat type but no layout id it should return invalid', () => {
+			const seatType = 'seat-type-uuid-1';
+			const layoutId = '';
+			const isUsingAssignedSeating = true;
+
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+
+			select.mockReturnValue({
+				getCurrentLayoutId: () => layoutId,
+				getTicketSeatType: () => seatType,
+				isUsingAssignedSeating: () => isUsingAssignedSeating,
+			});
+
+			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+		});
+
+		it('if ASC and seat type and layout id it should return valid', () => {
+			const seatType = 'seat-type-uuid-1';
+			const layoutId = 'layout-uuid-1';
+			const isUsingAssignedSeating = true;
+
+			const ownProps = { clientId: 'client-id-1' };
+
+			const state = {};
+
+			select.mockReturnValue({
+				getCurrentLayoutId: () => layoutId,
+				getTicketSeatType: () => seatType,
+				isUsingAssignedSeating: () => isUsingAssignedSeating,
+			});
+
+			expect(filterTicketIsValid(true, state, ownProps)).toEqual(true);
 		});
 	});
 });

--- a/tests/slr_jest/blockEditor/hook-callbacks.spec.js
+++ b/tests/slr_jest/blockEditor/hook-callbacks.spec.js
@@ -8,7 +8,7 @@ import {
 	filterSeatedTicketsAvailabilityMappedProps,
 	filterSetBodyDetails,
 	setSeatTypeForTicket,
-	filterTicketIsValid,
+	filterButtonIsDisabled,
 } from '@tec/tickets/seating/blockEditor/hook-callbacks';
 
 jest.mock('@wordpress/data', () => ({
@@ -469,12 +469,12 @@ describe('hook-callbacks', () => {
 		});
 	});
 
-	describe('filterTicketIsValid', () => {
-		it('if invalid should return invalid', () => {
+	describe('filterButtonIsDisabled', () => {
+		it('if disabled should return disabled', () => {
 			const ownProps = { clientId: 'client-id-1' };
 
 			const state = {};
-			expect(filterTicketIsValid(false, state, ownProps)).toEqual(false);
+			expect(filterButtonIsDisabled(true, state, ownProps)).toEqual(true);
 		});
 
 		it('if not ASC it should not interfere', () => {
@@ -492,10 +492,10 @@ describe('hook-callbacks', () => {
 				isUsingAssignedSeating: () => isUsingAssignedSeating,
 			});
 
-			expect(filterTicketIsValid(true, state, ownProps)).toEqual(true);
+			expect(filterButtonIsDisabled(true, state, ownProps)).toEqual(true);
 		});
 
-		it('if ASC and no layout id or seat type it should return invalid', () => {
+		it('if ASC and no layout id or seat type it should return disabled', () => {
 			const seatType = null;
 			const layoutId = '';
 			const isUsingAssignedSeating = true;
@@ -510,10 +510,12 @@ describe('hook-callbacks', () => {
 				isUsingAssignedSeating: () => isUsingAssignedSeating,
 			});
 
-			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+			expect(filterButtonIsDisabled(false, state, ownProps)).toEqual(
+				true
+			);
 		});
 
-		it('if ASC and no layout id or seat type it should return invalid', () => {
+		it('if ASC and no layout id or seat type it should return disabled', () => {
 			const seatType = '';
 			const layoutId = false;
 			const isUsingAssignedSeating = true;
@@ -528,10 +530,12 @@ describe('hook-callbacks', () => {
 				isUsingAssignedSeating: () => isUsingAssignedSeating,
 			});
 
-			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+			expect(filterButtonIsDisabled(false, state, ownProps)).toEqual(
+				true
+			);
 		});
 
-		it('if ASC and layout id but no seat type it should return invalid', () => {
+		it('if ASC and layout id but no seat type it should return disabled', () => {
 			const seatType = '';
 			const layoutId = 'layout-uuid-1';
 			const isUsingAssignedSeating = true;
@@ -546,10 +550,12 @@ describe('hook-callbacks', () => {
 				isUsingAssignedSeating: () => isUsingAssignedSeating,
 			});
 
-			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+			expect(filterButtonIsDisabled(false, state, ownProps)).toEqual(
+				true
+			);
 		});
 
-		it('if ASC and seat type but no layout id it should return invalid', () => {
+		it('if ASC and seat type but no layout id it should return disabled', () => {
 			const seatType = 'seat-type-uuid-1';
 			const layoutId = '';
 			const isUsingAssignedSeating = true;
@@ -564,10 +570,12 @@ describe('hook-callbacks', () => {
 				isUsingAssignedSeating: () => isUsingAssignedSeating,
 			});
 
-			expect(filterTicketIsValid(true, state, ownProps)).toEqual(false);
+			expect(filterButtonIsDisabled(false, state, ownProps)).toEqual(
+				true
+			);
 		});
 
-		it('if ASC and seat type and layout id it should return valid', () => {
+		it('if ASC and seat type and layout id it should return enabled', () => {
 			const seatType = 'seat-type-uuid-1';
 			const layoutId = 'layout-uuid-1';
 			const isUsingAssignedSeating = true;
@@ -582,7 +590,9 @@ describe('hook-callbacks', () => {
 				isUsingAssignedSeating: () => isUsingAssignedSeating,
 			});
 
-			expect(filterTicketIsValid(true, state, ownProps)).toEqual(true);
+			expect(filterButtonIsDisabled(false, state, ownProps)).toEqual(
+				false
+			);
 		});
 	});
 });


### PR DESCRIPTION
### 🎫 Ticket

Issue 111 from gsheet.

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

In the PR the create button of a ticket is enabled only when a layout AND a seat type are selected.

Refactors non asc ticket but without introducing any changes. Only makes reading it easier and introduces filters.

Makes sure we access the current layout property if its defined and adds a method in order to enable us to notify the common store that the ticket has changes.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://www.loom.com/share/6c6832c1dd2344efa8f3f5d140a4432d

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
