### PR TITLE
Lock layout when GAC tickets present

### DIFF
--- a/src/Tickets/Seating/Editor.php
+++ b/src/Tickets/Seating/Editor.php
@@ -65,11 +65,17 @@ class Editor extends \TEC\Common\Contracts\Provider\Controller {
 			$post_id                   = get_the_ID();
 			$is_using_assigned_seating = tribe_is_truthy( get_post_meta( $post_id, Meta::META_KEY_ENABLED, true ) );
 			$layout_id                 = get_post_meta( $post_id, Meta::META_KEY_LAYOUT_ID, true );
-			$is_layout_locked          = ! empty( $layout_id );
 			$seat_types_by_post_id     = [];
+			$is_layout_locked          = ! empty( $layout_id );
 			foreach ( tribe_tickets()->where( 'event', $post_id )->get_ids( true ) as $ticket_id ) {
+				if ( ! $ticket_id ) {
+					continue;
+				}
+
+				$is_layout_locked                    = true; // If there are tickets already, layout is definitely locked!
 				$seat_types_by_post_id[ $ticket_id ] = get_post_meta( $ticket_id, Meta::META_KEY_SEAT_TYPE, true );
 			}
+
 			$event_capacity = tribe_get_event_capacity( $post_id );
 		}
 

--- a/src/Tickets/Seating/app/blockEditor/capacity-form/index.js
+++ b/src/Tickets/Seating/app/blockEditor/capacity-form/index.js
@@ -147,9 +147,13 @@ export default function CapacityForm({ renderDefaultForm, clientId }) {
 
 	return (
 		<div className="tec-tickets-seating__capacity-form">
-			{isUsingAssignedSeating && isLayoutLocked ? (
+			{isLayoutLocked ? (
 				<div className="tec-tickets-seating__capacity-locked-info">
-					{getString('seat-option-label')}
+					{getString(
+						isUsingAssignedSeating
+							? 'seat-option-label'
+							: 'general-admission-label'
+					)}
 				</div>
 			) : (
 				<RadioControl

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -63,8 +63,10 @@ export const filterHeaderDetails = (items, clientId) => {
  * @return {Object} The body of the request with the seating details.
  */
 export const filterSetBodyDetails = (body, clientId) => {
-	// On first save of a ticket, lock the Layout.
-	// Doesn't matter if ASC or GAC, they layout should be locked.
+	/**
+	 * On first save of a ticket, lock the Layout.
+	 * Doesn't matter if ASC or GAC, they layout should be locked.
+	 */
 	dispatch(storeName).setIsLayoutLocked(true);
 
 	const layoutId = select(storeName).getCurrentLayoutId();

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -63,6 +63,10 @@ export const filterHeaderDetails = (items, clientId) => {
  * @return {Object} The body of the request with the seating details.
  */
 export const filterSetBodyDetails = (body, clientId) => {
+	// On first save of a ticket, lock the Layout.
+	// Doesn't matter if ASC or GAC, they layout should be locked.
+	dispatch(storeName).setIsLayoutLocked(true);
+
 	const layoutId = select(storeName).getCurrentLayoutId();
 	if (!layoutId) {
 		return body;
@@ -74,9 +78,6 @@ export const filterSetBodyDetails = (body, clientId) => {
 	body.append('ticket[seating][seatType]', seatType ? seatType : '');
 	body.append('ticket[seating][layoutId]', layoutId);
 	body.append('ticket[event_capacity]', eventCapacity);
-
-	// On first save of a ticket, lock the Layout.
-	dispatch(storeName).setIsLayoutLocked(true);
 
 	return body;
 };

--- a/tests/slr_integration/Admin/Events/Controller_Test.php
+++ b/tests/slr_integration/Admin/Events/Controller_Test.php
@@ -13,9 +13,9 @@ use Tribe\Tests\Traits\With_Uopz;
 class Controller_Test extends Controller_Test_Case {
 	use SnapshotAssertions;
 	use With_Uopz;
-	
+
 	protected string $controller_class = Controller::class;
-	
+
 	/**
 	 * @before
 	 */
@@ -23,10 +23,10 @@ class Controller_Test extends Controller_Test_Case {
 		$this->set_fn_return( 'wp_create_nonce', 'xxxxxx' );
 		$this->set_fn_return( 'is_admin', true );
 		$this->set_fn_return( 'get_column_headers', [] );
-		
+
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
-		
+
 		Layouts_Service::insert_rows_from_service(
 			[
 				[
@@ -56,13 +56,13 @@ class Controller_Test extends Controller_Test_Case {
 			]
 		);
 	}
-	
+
 	public function tearDown() {
 		parent::tearDown();
 		Layouts_Service::invalidate_cache();
 		unset( $_GET['layout'] );
 	}
-	
+
 	public function events_list_data_provider(): Generator {
 		yield 'No Layout or invalid ID given' => [
 			function (): array {
@@ -72,7 +72,7 @@ class Controller_Test extends Controller_Test_Case {
 				];
 			},
 		];
-		
+
 		yield 'Layout ID without attached event' => [
 			function (): array {
 				return [
@@ -81,7 +81,7 @@ class Controller_Test extends Controller_Test_Case {
 				];
 			},
 		];
-		
+
 		yield 'Events with attached layout: some-layout-1' => [
 			function (): array {
 				$event_id = tribe_events()->set_args(
@@ -94,11 +94,11 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-01 00:00:00',
 					]
 				)->create()->ID;
-				
+
 				$post_id = self::factory()->post->create(
 					[ 'post_title' => 'Post with layout' ]
 				);
-				
+
 				wp_update_post(
 					[
 						'ID'            => $post_id,
@@ -106,24 +106,24 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-02 00:00:00',
 					]
 				);
-				
+
 				update_post_meta( $event_id, Meta::META_KEY_ENABLED, true );
 				update_post_meta( $event_id, Meta::META_KEY_LAYOUT_ID, 'some-layout-1' );
 				update_post_meta( $post_id, Meta::META_KEY_ENABLED, true );
 				update_post_meta( $post_id, Meta::META_KEY_LAYOUT_ID, 'some-layout-1' );
-				
+
 				return [
 					[ 'layout' => 'some-layout-1' ],
 					[ $event_id, $post_id ],
 				];
 			},
 		];
-		
+
 		yield 'Events with varying status with pagination' => [
 			function (): array {
 				$event_id = tribe_events()->set_args(
 					[
-						'title'         => 'Event with layout',
+						'title'         => 'Event with layout and draft status',
 						'status'        => 'draft',
 						'start_date'    => '2020-01-01 00:00:00',
 						'duration'      => 2 * HOUR_IN_SECONDS,
@@ -131,14 +131,14 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-01 00:00:00',
 					]
 				)->create()->ID;
-				
+
 				$post_id = self::factory()->post->create(
 					[
-						'post_title'  => 'Post with layout',
+						'post_title'  => 'Post with layout and pending status',
 						'post_status' => 'pending',
 					]
 				);
-				
+
 				wp_update_post(
 					[
 						'ID'            => $post_id,
@@ -146,7 +146,7 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-02 00:00:00',
 					]
 				);
-				
+
 				$event_id_2 = tribe_events()->set_args(
 					[
 						'title'         => 'Event with draft status',
@@ -157,13 +157,13 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-01 00:00:00',
 					]
 				)->create()->ID;
-				
+
 				$post_id_2 = self::factory()->post->create(
 					[
-						'post_title' => 'Post with pending status',
+						'post_title' => 'Post with published status',
 					]
 				);
-				
+
 				wp_update_post(
 					[
 						'ID'            => $post_id_2,
@@ -171,14 +171,14 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-02 00:00:00',
 					]
 				);
-				
+
 				foreach ( [ $event_id, $event_id_2, $post_id, $post_id_2 ] as $id ) {
 					update_post_meta( $id, Meta::META_KEY_ENABLED, true );
 					update_post_meta( $id, Meta::META_KEY_LAYOUT_ID, 'some-layout-2' );
 				}
-				
+
 				update_user_meta( get_current_user_id(), Associated_Events::OPTION_PER_PAGE, 1 );
-				
+
 				return [
 					[
 						'layout' => 'some-layout-2',
@@ -188,7 +188,7 @@ class Controller_Test extends Controller_Test_Case {
 				];
 			},
 		];
-		
+
 		yield 'Events with search result for - future' => [
 			function (): array {
 				$event_id = tribe_events()->set_args(
@@ -201,11 +201,11 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-01 00:00:00',
 					]
 				)->create()->ID;
-				
+
 				$post_id = self::factory()->post->create(
 					[ 'post_title' => 'Post with layout' ]
 				);
-				
+
 				wp_update_post(
 					[
 						'ID'            => $post_id,
@@ -213,7 +213,7 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-02 00:00:00',
 					]
 				);
-				
+
 				$event_id_2 = tribe_events()->set_args(
 					[
 						'title'         => 'Event with private status',
@@ -224,13 +224,13 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-01 00:00:00',
 					]
 				)->create()->ID;
-				
+
 				$post_id_2 = self::factory()->post->create(
 					[
 						'post_title' => 'Post with future in title',
 					]
 				);
-				
+
 				wp_update_post(
 					[
 						'ID'            => $post_id_2,
@@ -238,12 +238,12 @@ class Controller_Test extends Controller_Test_Case {
 						'post_date_gmt' => '2020-01-02 00:00:00',
 					]
 				);
-				
+
 				foreach ( [ $event_id, $event_id_2, $post_id, $post_id_2 ] as $id ) {
 					update_post_meta( $id, Meta::META_KEY_ENABLED, true );
 					update_post_meta( $id, Meta::META_KEY_LAYOUT_ID, 'some-layout-3' );
 				}
-				
+
 				return [
 					[
 						'layout' => 'some-layout-3',
@@ -254,30 +254,30 @@ class Controller_Test extends Controller_Test_Case {
 			},
 		];
 	}
-	
+
 	/**
 	 * @dataProvider events_list_data_provider
 	 */
 	public function test_associated_events_list( Closure $fixture ): void {
 		[ $vars, $ids ] = $fixture();
-		
+
 		if ( ! empty( $vars ) ) {
 			foreach ( $vars as $key => $value ) {
 				$_GET[ $key ] = $value;
 			}
 		}
-		
+
 		$this->make_controller()->register();
-		
+
 		ob_start();
 		$this->make_controller()->render();
 		$html = ob_get_clean();
-		
+
 		if ( ! empty( $ids ) ) {
 			// Remove the ids from the html.
 			$html = str_replace( $ids, array_fill( 0, count( $ids ), '{{ID}}' ), $html );
 		}
-		
+
 		$this->assertMatchesHtmlSnapshot( $html );
 	}
 }

--- a/tests/slr_integration/Admin/Events/__snapshots__/Controller_Test__test_associated_events_list__Events with varying status with pagination__0.snapshot.html
+++ b/tests/slr_integration/Admin/Events/__snapshots__/Controller_Test__test_associated_events_list__Events with varying status with pagination__0.snapshot.html
@@ -36,7 +36,7 @@
 	<tbody id="the-list"
 				>
 				<tr id="post-{{ID}}" class="iedit author-self level-0 post-{{ID}} type-tribe_events status-draft hentry">
-			<td class="title column-title has-row-actions column-primary page-title" data-colname="Title"><strong><span>Event with layout</span> &mdash; <span class='post-state'>Draft</span></strong>
+			<td class="title column-title has-row-actions column-primary page-title" data-colname="Title"><strong><span>Event with layout and draft status</span> &mdash; <span class='post-state'>Draft</span></strong>
 </td><td class='tags column-tags' data-colname="Tags"></td><td class='tickets column-tickets' data-colname="Attendees">&mdash;</td><td class='date column-date' data-colname="Date">Last Modified<br />2020/01/01 at 12:00 am</td>		</tr>
 			</tbody>
 

--- a/tests/slr_integration/Editor_Test.php
+++ b/tests/slr_integration/Editor_Test.php
@@ -122,6 +122,22 @@ class Editor_Test extends Controller_Test_Case {
 			}
 		];
 
+		yield 'existing post, not using meta set or layout set, with tickets' => [
+			function (): array {
+				$id = self::factory()->post->create();
+				global $pagenow, $post;
+				$pagenow = 'edit.php';
+				$post    = get_post( $id );
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$ticket_1 = $this->create_tc_ticket( $id, 10.10 );
+				$ticket_2 = $this->create_tc_ticket( $id, 20.30 );
+				$ticket_3 = $this->create_tc_ticket( $id, 30.40 );
+
+				return [$ticket_1, $ticket_2, $ticket_3];
+			}
+		];
+
 		yield 'new event' => [
 			function (): array {
 				$post_type = TEC::POSTTYPE;
@@ -210,6 +226,26 @@ class Editor_Test extends Controller_Test_Case {
 				update_post_meta( $ticket_2, Meta::META_KEY_SEAT_TYPE, 'uuid-forward-block' );
 				$ticket_3 = $this->create_tc_ticket( $id, 30.40 );
 				update_post_meta( $ticket_3, Meta::META_KEY_SEAT_TYPE, 'uuid-vip' );
+
+				return [ $ticket_1, $ticket_2, $ticket_3 ];
+			}
+		];
+
+		yield 'existing event, not using meta set or layout set, with tickets' => [
+			function (): array {
+				$id = tribe_events()->set_args( [
+					'title'      => 'Test Event',
+					'start_date' => '+1 week',
+					'duration'   => 3 * HOUR_IN_SECONDS,
+				] )->create()->ID;
+				global $pagenow, $post;
+				$pagenow = 'edit.php';
+				$post    = get_post( $id );
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$ticket_1 = $this->create_tc_ticket( $id, 10.10 );
+				$ticket_2 = $this->create_tc_ticket( $id, 20.30 );
+				$ticket_3 = $this->create_tc_ticket( $id, 30.40 );
 
 				return [ $ticket_1, $ticket_2, $ticket_3 ];
 			}

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__existing event, not using meta set or layout set, with tickets__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__existing event, not using meta set or layout set, with tickets__0.snapshot.json
@@ -1,0 +1,29 @@
+{
+    "isUsingAssignedSeating": false,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": "",
+    "seatTypesByPostId": {
+        "{{ticket_id}}": "",
+        "{{ticket_id}}": "",
+        "{{ticket_id}}": ""
+    },
+    "isLayoutLocked": true,
+    "eventCapacity": 300
+}

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__existing post, not using meta set or layout set, with tickets__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__existing post, not using meta set or layout set, with tickets__0.snapshot.json
@@ -1,0 +1,29 @@
+{
+    "isUsingAssignedSeating": false,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": "",
+    "seatTypesByPostId": {
+        "{{ticket_id}}": "",
+        "{{ticket_id}}": "",
+        "{{ticket_id}}": ""
+    },
+    "isLayoutLocked": true,
+    "eventCapacity": 300
+}


### PR DESCRIPTION
### 🎫 Ticket

Issue 127 from gsheet
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Lock the layout when a GAC ticket is saved or when at least a ticket is present already.

Layout should not be able to change:

when a ticket is already present
when an ASC ticket has ever been part of the post/event and as a result a layout id is stored in the post's/event's meta.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/268bfe4af73c4ad8aa97632bbdc5f7d1

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
