### PR TITLE
[ET-2242] Fix duplication of global stock level

### DIFF
--- a/changelog/fix-duplication-of-global-stock-level
+++ b/changelog/fix-duplication-of-global-stock-level
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: ECP-1826 entry already included.
+
+

--- a/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
@@ -151,6 +151,16 @@ class Duplicate_Post extends Integration_Abstract {
 				'post_content' => $new_post_content,
 			]
 		);
+
+		if ( ! get_post_meta( $original_post_id, Global_Stock::GLOBAL_STOCK_ENABLED, true ) ) {
+			return;
+		}
+
+		update_post_meta(
+			$new_post_id,
+			Global_Stock::GLOBAL_STOCK_LEVEL,
+			get_post_meta( $original_post_id, tribe( 'tickets.handler' )->key_capacity, true)
+		);
 	}
 
 	/**
@@ -170,7 +180,6 @@ class Duplicate_Post extends Integration_Abstract {
 				tribe( 'tickets.handler' )->key_image_header,
 				tribe( 'tickets.handler' )->key_provider_field,
 				Global_Stock::GLOBAL_STOCK_ENABLED,
-				Global_Stock::GLOBAL_STOCK_LEVEL,
 				Attendees_List::HIDE_META_KEY,
 			],
 		);

--- a/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
@@ -159,7 +159,7 @@ class Duplicate_Post extends Integration_Abstract {
 		update_post_meta(
 			$new_post_id,
 			Global_Stock::GLOBAL_STOCK_LEVEL,
-			get_post_meta( $original_post_id, tribe( 'tickets.handler' )->key_capacity, true)
+			get_post_meta( $original_post_id, tribe( 'tickets.handler' )->key_capacity, true )
 		);
 	}
 

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -143,7 +143,7 @@ export const getIndependentTickets = createSelector(
 export const getSharedTickets = createSelector(
 	[ getTicketsArray ],
 	( tickets ) => (
-		tickets.filter( ( ticket ) => ticket.details.- === TICKET_TYPES[ SHARED ] )
+		tickets.filter( ( ticket ) => ticket.details.capacityType === TICKET_TYPES[ SHARED ] )
 	),
 );
 

--- a/src/modules/data/blocks/ticket/selectors.js
+++ b/src/modules/data/blocks/ticket/selectors.js
@@ -143,7 +143,7 @@ export const getIndependentTickets = createSelector(
 export const getSharedTickets = createSelector(
 	[ getTicketsArray ],
 	( tickets ) => (
-		tickets.filter( ( ticket ) => ticket.details.capacityType === TICKET_TYPES[ SHARED ] )
+		tickets.filter( ( ticket ) => ticket.details.- === TICKET_TYPES[ SHARED ] )
 	),
 );
 

--- a/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
+++ b/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
@@ -37,11 +37,11 @@ class Duplicate_PostTest extends WPTestCase {
 				);
 
 				$meta = [
-					tribe( 'tickets.handler' )->key_capacity       => 10,
+					tribe( 'tickets.handler' )->key_capacity       => 100,
 					tribe( 'tickets.handler' )->key_image_header   => 4,
 					tribe( 'tickets.handler' )->key_provider_field => 'TEC\Tickets\Commerce\Module',
 					Global_Stock::GLOBAL_STOCK_ENABLED             => true,
-					Global_Stock::GLOBAL_STOCK_LEVEL               => 100,
+					Global_Stock::GLOBAL_STOCK_LEVEL               => 9,
 					Attendees_List::HIDE_META_KEY                  => false,
 				];
 
@@ -82,7 +82,8 @@ class Duplicate_PostTest extends WPTestCase {
 
 		foreach( $meta as $k => $v ) {
 			$this->assertEquals( $v, get_post_meta( $event_id, $k, true ), $k );
-			$this->assertEquals( $v, get_post_meta( $duplicated_event->ID, $k, true ), $k );
+			$val_to_check = $k !== Global_Stock::GLOBAL_STOCK_LEVEL ? $v : $meta[ tribe( 'tickets.handler' )->key_capacity ];
+			$this->assertEquals( $val_to_check, get_post_meta( $duplicated_event->ID, $k, true ), $k );
 		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-2242]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We should not copy over the Global stock level. We should replace it with the original global stock level which is stored in key_capacity originally of the tickets handler..


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2242]: https://stellarwp.atlassian.net/browse/ET-2242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ