### PR TITLE
[SL-124] - Display seating upsell when seating is not active.

### DIFF
--- a/src/Tickets/Seating/Admin.php
+++ b/src/Tickets/Seating/Admin.php
@@ -99,8 +99,8 @@ class Admin extends Controller_Contract {
 	public function add_submenu_page(): void {
 		add_submenu_page(
 			'tec-tickets',
-			__( 'Seat Layouts', 'event-tickets' ),
-			__( 'Seat Layouts', 'event-tickets' ),
+			__( 'Seating', 'event-tickets' ),
+			__( 'Seating', 'event-tickets' ),
 			'manage_options',
 			self::get_menu_slug(),
 			$this->container->callback( Admin\Maps_Layouts_Home_Page::class, 'render' )

--- a/src/Tickets/Seating/Editor.php
+++ b/src/Tickets/Seating/Editor.php
@@ -93,7 +93,7 @@ class Editor extends \TEC\Common\Contracts\Provider\Controller {
 			'serviceStatus'          => [
 				'ok'         => $service_status->is_ok(),
 				'status'     => $service_status->get_status_string(),
-				'connectUrl' => $service_status->get_connnect_url(),
+				'connectUrl' => $service_status->get_connect_url(),
 			],
 		];
 	}

--- a/src/Tickets/Seating/Service/Service_Status.php
+++ b/src/Tickets/Seating/Service/Service_Status.php
@@ -199,7 +199,7 @@ class Service_Status {
 	 *
 	 * @return string The URI to connect to the service.
 	 */
-	public function get_connnect_url(): string {
+	public function get_connect_url(): string {
 		return admin_url( 'admin.php?page=tec-tickets-settings&tab=licenses' );
 	}
 }

--- a/src/Tickets/Seating/Service/Service_Status.php
+++ b/src/Tickets/Seating/Service/Service_Status.php
@@ -181,14 +181,14 @@ class Service_Status {
 		$this->update();
 
 		switch ( $this->status ) {
-			case self::OK:
-				return 'ok';
 			case self::SERVICE_DOWN:
 				return 'down';
 			case self::NOT_CONNECTED:
 				return 'not-connected';
 			case self::INVALID_LICENSE:
 				return 'invalid-license';
+			default:
+				return 'ok';
 		}
 	}
 

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -3,6 +3,7 @@ import { select, dispatch } from '@wordpress/data';
 import SeatType from './header/seat-type';
 import LayoutSelect from './settings/layoutSelect';
 import Upsell from './settings/upsell';
+import Outage from './settings/outage';
 
 export const setSeatTypeForTicket = (clientId) =>
 	dispatch(storeName).setTicketSeatTypeByPostId(clientId);
@@ -154,22 +155,29 @@ export const filterSeatedTicketsAvailabilityMappedProps = (mappedProps) => {
  */
 export const filterSettingsFields = (fields) => {
 	const store = select(storeName);
+	const status = store.getServiceStatus();
 
-	if ( store.isServiceStatusOk() ) {
-		const currentLayout = store.getCurrentLayoutId();
-		const layouts = store.getLayoutsInOptionFormat();
+	switch (status) {
+		case 'not-connected':
+		case 'invalid-license':
+			fields.push(
+				<Upsell />
+			);
+			break;
+		case 'down':
+			fields.push(
+				<Outage />
+			);
+			break;
+		default:
+			const currentLayout = store.getCurrentLayoutId();
+			const layouts = store.getLayoutsInOptionFormat();
 
-		fields.push(
-			<LayoutSelect layouts={layouts} currentLayout={currentLayout} />
-		);
-
-		return fields;
+			fields.push(
+				<LayoutSelect layouts={layouts} currentLayout={currentLayout} />
+			);
+			break;
 	}
-
-	// Show seating upsell.
-	fields.push(
-		<Upsell />
-	)
 
 	return fields;
 };

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -2,6 +2,7 @@ import { storeName } from './store';
 import { select, dispatch } from '@wordpress/data';
 import SeatType from './header/seat-type';
 import LayoutSelect from './settings/layoutSelect';
+import UpSell from './settings/upSell';
 
 export const setSeatTypeForTicket = (clientId) =>
 	dispatch(storeName).setTicketSeatTypeByPostId(clientId);
@@ -153,12 +154,22 @@ export const filterSeatedTicketsAvailabilityMappedProps = (mappedProps) => {
  */
 export const filterSettingsFields = (fields) => {
 	const store = select(storeName);
-	const currentLayout = store.getCurrentLayoutId();
-	const layouts = store.getLayoutsInOptionFormat();
 
+	if ( store.isServiceStatusOk() ) {
+		const currentLayout = store.getCurrentLayoutId();
+		const layouts = store.getLayoutsInOptionFormat();
+
+		fields.push(
+			<LayoutSelect layouts={layouts} currentLayout={currentLayout} />
+		);
+
+		return fields;
+	}
+
+	// Show seating upsell.
 	fields.push(
-		<LayoutSelect layouts={layouts} currentLayout={currentLayout} />
-	);
+		<UpSell />
+	)
 
 	return fields;
 };

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -2,7 +2,7 @@ import { storeName } from './store';
 import { select, dispatch } from '@wordpress/data';
 import SeatType from './header/seat-type';
 import LayoutSelect from './settings/layoutSelect';
-import UpSell from './settings/upSell';
+import Upsell from './settings/upsell';
 
 export const setSeatTypeForTicket = (clientId) =>
 	dispatch(storeName).setTicketSeatTypeByPostId(clientId);
@@ -168,7 +168,7 @@ export const filterSettingsFields = (fields) => {
 
 	// Show seating upsell.
 	fields.push(
-		<UpSell />
+		<Upsell />
 	)
 
 	return fields;

--- a/src/Tickets/Seating/app/blockEditor/settings/outage.js
+++ b/src/Tickets/Seating/app/blockEditor/settings/outage.js
@@ -1,0 +1,40 @@
+import { _x } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+
+const Outage = () => {
+	const iconStyle = {
+		color: '#FCB900',
+		marginRight: '6px',
+	};
+
+	const wrapperStyle = {
+		display: 'flex',
+		flexDirection: 'row',
+		alignItems: 'center',
+	};
+
+	const messageStyle = {
+		color: 'var(--tec-color-icon-primary-alt)',
+		fontWeight: 'var(--tec-font-weight-regular)',
+		fontSize: 'var(--tec-font-size-2)',
+		lineHeight: 'var(--tec-line-height-1)',
+	}
+
+	return (
+		<div className="tec-tickets-seating__settings_layout--wrapper">
+			<div className={"tec-tickets-seating__settings_layout_upsell--header"}>
+				<span className="tec-tickets-seating__settings_layout--title">
+					{_x('Seat Layout', 'Seat layout upsell title', 'event-tickets')}
+				</span>
+			</div>
+			<div style={wrapperStyle}>
+				<Icon icon="warning" size={16} style={iconStyle}/>
+				<span style={messageStyle}>
+				{_x('The Seat Builder service is down. We are working to restore the functionality.', 'Seating service outage message', 'event-tickets')}
+			</span>
+			</div>
+		</div>
+	);
+}
+
+export default Outage;

--- a/src/Tickets/Seating/app/blockEditor/settings/style.pcss
+++ b/src/Tickets/Seating/app/blockEditor/settings/style.pcss
@@ -3,6 +3,17 @@
 	flex-direction: column;
 	gap: 12px;
 	padding-top: 32px;
+
+	.tec-tickets-seating__settings_layout_upsell--header {
+		align-items: center;
+		display: flex;
+		height: 10px;
+		svg {
+			height: 16px;
+			margin-left: 5px;
+			width: 16px;
+		}
+	}
 }
 
 .tec-tickets-seating__settings_layout--title {

--- a/src/Tickets/Seating/app/blockEditor/settings/upSell.js
+++ b/src/Tickets/Seating/app/blockEditor/settings/upSell.js
@@ -1,4 +1,9 @@
+import { ECP as PlusIcon } from '@moderntribe/tickets/icons';
+import { _x } from '@wordpress/i18n';
 const UpSell = () => {
+	const anchorStyle = {
+		color: 'var(--tec-color-link-accent)',
+	};
 
 	return (
 		<div className="tec-tickets-seating__settings_layout--wrapper">
@@ -6,7 +11,32 @@ const UpSell = () => {
 				<span className="tec-tickets-seating__settings_layout--title">
 					{ _x( 'Seat Layout', 'Seat layout upsell title', 'event-tickets' ) }
 				</span>
+				<PlusIcon/>
 			</div>
+
+			<span className={"tec-tickets-seating__settings_layout--description"}>
+				{
+					_x(
+						'Allow purchasers to select seats with',
+						'Seat layout upsell description start',
+						'event-tickets'
+					)
+				}{ ' ' }
+				<a
+					href="https://evnt.is/add-seating"
+					target="_blank"
+					rel="noreferrer noopener"
+				>
+					{ _x( 'Seating', 'Seat layout upsell link label', 'event-tickets' ) }
+				</a>{' '}
+				{
+					_x(
+						'for Event Tickets.',
+						'Seat layout upsell description end',
+						'event-tickets'
+					)
+				}
+			</span>
 		</div>
 	);
 }

--- a/src/Tickets/Seating/app/blockEditor/settings/upSell.js
+++ b/src/Tickets/Seating/app/blockEditor/settings/upSell.js
@@ -1,0 +1,13 @@
+const UpSell = () => {
+
+	return (
+		<div className="tec-tickets-seating__settings_layout--wrapper">
+			<div className={"tec-tickets-seating__settings_layout_upsell--header"}>
+				<span className="tec-tickets-seating__settings_layout--title">
+					{ _x( 'Seat Layout', 'Seat layout upsell title', 'event-tickets' ) }
+				</span>
+			</div>
+		</div>
+	);
+}
+export default UpSell;

--- a/src/Tickets/Seating/app/blockEditor/settings/upSell.js
+++ b/src/Tickets/Seating/app/blockEditor/settings/upSell.js
@@ -21,8 +21,9 @@ const UpSell = () => {
 						'Seat layout upsell description start',
 						'event-tickets'
 					)
-				}{ ' ' }
+				}{' '}
 				<a
+					style={anchorStyle}
 					href="https://evnt.is/add-seating"
 					target="_blank"
 					rel="noreferrer noopener"

--- a/src/Tickets/Seating/app/blockEditor/settings/upsell.js
+++ b/src/Tickets/Seating/app/blockEditor/settings/upsell.js
@@ -1,6 +1,6 @@
 import { ECP as PlusIcon } from '@moderntribe/tickets/icons';
 import { _x } from '@wordpress/i18n';
-const UpSell = () => {
+const Upsell = () => {
 	const anchorStyle = {
 		color: 'var(--tec-color-link-accent)',
 	};
@@ -41,4 +41,4 @@ const UpSell = () => {
 		</div>
 	);
 }
-export default UpSell;
+export default Upsell;

--- a/src/admin-views/seating/maps-layouts-home.php
+++ b/src/admin-views/seating/maps-layouts-home.php
@@ -15,7 +15,7 @@ use TEC\Tickets\Seating\Admin\Tabs\Tab;
 <div class="wrap">
 	<h1>
 		<?php
-		echo esc_html_x( 'Seat Layouts', 'Seat Layouts home page title', 'event-tickets' );
+		echo esc_html_x( 'Seating', 'Seat Layouts home page title', 'event-tickets' );
 		?>
 	</h1>
 

--- a/src/admin-views/seating/service-error-tab.php
+++ b/src/admin-views/seating/service-error-tab.php
@@ -15,7 +15,7 @@
 <div class="wrap">
 	<h1>
 		<?php
-		echo esc_html_x( 'Seat Layouts', 'Seat Layouts home page title', 'event-tickets' );
+		echo esc_html_x( 'Seating', 'Seat Layouts home page title', 'event-tickets' );
 		?>
 	</h1>
 

--- a/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_empty_layouts__0.snapshot.html
+++ b/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_empty_layouts__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 			<h2 id="tribe-settings-tabs" class="nav-tab-wrapper">
 

--- a/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_empty_seating_configurations__0.snapshot.html
+++ b/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_empty_seating_configurations__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 			<h2 id="tribe-settings-tabs" class="nav-tab-wrapper">
 

--- a/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_layout_edit__0.snapshot.html
+++ b/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_layout_edit__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 	
 	

--- a/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_map_edit__0.snapshot.html
+++ b/tests/slr_integration/Admin/__snapshots__/Maps_Layout_Homepage_Test__test_map_edit__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 	
 	

--- a/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__layout edit tab__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__layout edit tab__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 	
 	

--- a/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__layouts tab__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__layouts tab__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 			<h2 id="tribe-settings-tabs" class="nav-tab-wrapper">
 

--- a/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__map edit tab__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__map edit tab__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 	
 	

--- a/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__map new tab__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__map new tab__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 	
 	

--- a/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__maps tab__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__maps tab__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 			<h2 id="tribe-settings-tabs" class="nav-tab-wrapper">
 
@@ -49,7 +49,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 			<h2 id="tribe-settings-tabs" class="nav-tab-wrapper">
 

--- a/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__no tab__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Admin_Test__should_add_the_sub_menu_page__no tab__0.snapshot.html
@@ -1,7 +1,7 @@
 
 <div class="wrap">
 	<h1>
-		Seat Layouts	</h1>
+		Seating	</h1>
 
 			<h2 id="tribe-settings-tabs" class="nav-tab-wrapper">
 

--- a/tests/slr_jest/blockEditor/hook-callbacks.spec.js
+++ b/tests/slr_jest/blockEditor/hook-callbacks.spec.js
@@ -808,11 +808,8 @@ describe('hook-callbacks', () => {
 
 			const fields = filterSettingsFields([]);
 
-			// fields should be an array with one item.
 			expect(fields.length).toEqual(1);
-			// the first item should be an object with a type property.
 			expect(fields[0]).toHaveProperty('type');
-			// expect it to be the LayoutSelect component.
 			expect(fields[0].type.name).toEqual('LayoutSelect');
 		});
 
@@ -823,11 +820,8 @@ describe('hook-callbacks', () => {
 
 			const fields = filterSettingsFields([]);
 
-			// fields should be an array with one item.
 			expect(fields.length).toEqual(1);
-			// the first item should be an object with a type property.
 			expect(fields[0]).toHaveProperty('type');
-			// expect it to be the LayoutSelect component.
 			expect(fields[0].type.name).toEqual('UpSell');
 		});
 

--- a/tests/slr_jest/blockEditor/hook-callbacks.spec.js
+++ b/tests/slr_jest/blockEditor/hook-callbacks.spec.js
@@ -11,6 +11,7 @@ import {
 	removeAllActionsFromTicket,
 	setSeatTypeForTicket,
 	filterButtonIsDisabled,
+	filterSettingsFields,
 } from '@tec/tickets/seating/blockEditor/hook-callbacks';
 
 jest.mock('@wordpress/data', () => ({
@@ -791,4 +792,44 @@ describe('hook-callbacks', () => {
 			);
 		});
 	});
+
+	describe('filterSettingsFields', () => {
+		it('should return layout select component if service is ok', () => {
+			select.mockReturnValue({
+				isServiceStatusOk: () => true,
+				getCurrentLayoutId: () => 'layout-uuid-1',
+				getLayoutsInOptionFormat: () => [
+					{
+						value: 'layout-uuid-1',
+						label: 'Layout Name',
+					},
+				],
+			});
+
+			const fields = filterSettingsFields([]);
+
+			// fields should be an array with one item.
+			expect(fields.length).toEqual(1);
+			// the first item should be an object with a type property.
+			expect(fields[0]).toHaveProperty('type');
+			// expect it to be the LayoutSelect component.
+			expect(fields[0].type.name).toEqual('LayoutSelect');
+		});
+
+		it('should return layout upsell component if service is not ok', () => {
+			select.mockReturnValue({
+				isServiceStatusOk: () => false,
+			});
+
+			const fields = filterSettingsFields([]);
+
+			// fields should be an array with one item.
+			expect(fields.length).toEqual(1);
+			// the first item should be an object with a type property.
+			expect(fields[0]).toHaveProperty('type');
+			// expect it to be the LayoutSelect component.
+			expect(fields[0].type.name).toEqual('UpSell');
+		});
+
+	} );
 });

--- a/tests/slr_jest/blockEditor/hook-callbacks.spec.js
+++ b/tests/slr_jest/blockEditor/hook-callbacks.spec.js
@@ -796,7 +796,7 @@ describe('hook-callbacks', () => {
 	describe('filterSettingsFields', () => {
 		it('should return layout select component if service is ok', () => {
 			select.mockReturnValue({
-				isServiceStatusOk: () => true,
+				getServiceStatus: () => 'ok',
 				getCurrentLayoutId: () => 'layout-uuid-1',
 				getLayoutsInOptionFormat: () => [
 					{
@@ -813,17 +813,40 @@ describe('hook-callbacks', () => {
 			expect(fields[0].type.name).toEqual('LayoutSelect');
 		});
 
-		it('should return layout upsell component if service is not ok', () => {
+		it('should return the upsell component if service is not connected', () => {
 			select.mockReturnValue({
-				isServiceStatusOk: () => false,
+				getServiceStatus: () => 'not-connected',
 			});
 
 			const fields = filterSettingsFields([]);
 
 			expect(fields.length).toEqual(1);
 			expect(fields[0]).toHaveProperty('type');
-			expect(fields[0].type.name).toEqual('UpSell');
+			expect(fields[0].type.name).toEqual('Upsell');
 		});
 
+		it('should return the upsell component if service has invalid license', () => {
+			select.mockReturnValue({
+				getServiceStatus: () => 'invalid-license',
+			});
+
+			const fields = filterSettingsFields([]);
+
+			expect(fields.length).toEqual(1);
+			expect(fields[0]).toHaveProperty('type');
+			expect(fields[0].type.name).toEqual('Upsell');
+		});
+
+		it('should return the outage component if service is down', () => {
+			select.mockReturnValue({
+				getServiceStatus: () => 'down',
+			});
+
+			const fields = filterSettingsFields([]);
+
+			expect(fields.length).toEqual(1);
+			expect(fields[0]).toHaveProperty('type');
+			expect(fields[0].type.name).toEqual('Outage');
+		});
 	} );
 });


### PR DESCRIPTION
### 🎫 Ticket

[SL-124]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Display seating upsell in Block editor settings.
* Rename `Seat Layout` menu to `Seating` - Issue - 143.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
 📷 screenshot(s): 
 
 With no active license: https://share.cleanshot.com/v12H8L3B
 With service down: https://share.cleanshot.com/LHZtLyCc

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[SL-124]: https://stellarwp.atlassian.net/browse/SL-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ