### PR TITLE
Ignore ASC events from being canditates of receiving moved tickets or attendees

### DIFF
--- a/src/Tickets/Seating/Admin.php
+++ b/src/Tickets/Seating/Admin.php
@@ -174,8 +174,8 @@ class Admin extends Controller_Contract {
 	 * @return array The modified query arguments.
 	 */
 	public function exclude_asc_events_from_candidates_from_moving_tickets_to( array $query_args ): array {
-		if ( empty( $query_args['meta_query'] ) || ! is_array( $query_args['meta_query'] ) ) { // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			$query_args['meta_query'] = [];
+		if ( empty( $query_args['meta_query'] ) || ! is_array( $query_args['meta_query'] ) ) {
+			$query_args['meta_query'] = []; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		}
 
 		$query_args['meta_query'][] = [

--- a/src/Tickets/Seating/Admin.php
+++ b/src/Tickets/Seating/Admin.php
@@ -76,6 +76,8 @@ class Admin extends Controller_Contract {
 		remove_action( 'admin_menu', [ $this, 'add_embed_submenu_page' ], 1000 );
 
 		remove_action( 'admin_init', [ $this, 'register_woo_incompatibility_notice' ] );
+
+		remove_filter( 'tec_tickets_find_ticket_type_host_posts_query_args', [ $this, 'exclude_asc_events_from_candidates_from_moving_tickets_to' ] );
 	}
 
 	/**
@@ -158,6 +160,42 @@ class Admin extends Controller_Contract {
 		add_action( 'admin_menu', [ $this, 'add_embed_submenu_page' ], 1000 );
 
 		add_action( 'admin_init', [ $this, 'register_woo_incompatibility_notice' ] );
+
+		add_filter( 'tec_tickets_find_ticket_type_host_posts_query_args', [ $this, 'exclude_asc_events_from_candidates_from_moving_tickets_to' ] );
+	}
+
+	/**
+	 * Excludes ASC events from the candidates to move tickets to.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $query_args The query arguments.
+	 *
+	 * @return array The modified query arguments.
+	 */
+	public function exclude_asc_events_from_candidates_from_moving_tickets_to( array $query_args ): array {
+		if ( empty( $query_args['meta_query'] ) || ! is_array( $query_args['meta_query'] ) ) {
+			$query_args['meta_query'] = [];
+		}
+
+		$query_args['meta_query'][] = [
+			'relation' => 'OR',
+			[
+				'key'     => META::META_KEY_ENABLED,
+				'compare' => 'NOT EXISTS',
+			],
+			[
+				'key'     => META::META_KEY_ENABLED,
+				'value'   => '1',
+				'compare' => '!=',
+			]
+		];
+
+		if ( count( $query_args['meta_query'] ) > 1 ) {
+			$query_args['meta_query']['relation'] = 'AND';
+		}
+
+		return $query_args;
 	}
 
 	/**

--- a/src/Tickets/Seating/Admin.php
+++ b/src/Tickets/Seating/Admin.php
@@ -174,7 +174,7 @@ class Admin extends Controller_Contract {
 	 * @return array The modified query arguments.
 	 */
 	public function exclude_asc_events_from_candidates_from_moving_tickets_to( array $query_args ): array {
-		if ( empty( $query_args['meta_query'] ) || ! is_array( $query_args['meta_query'] ) ) {
+		if ( empty( $query_args['meta_query'] ) || ! is_array( $query_args['meta_query'] ) ) { // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$query_args['meta_query'] = [];
 		}
 
@@ -188,7 +188,7 @@ class Admin extends Controller_Contract {
 				'key'     => META::META_KEY_ENABLED,
 				'value'   => '1',
 				'compare' => '!=',
-			]
+			],
 		];
 
 		if ( count( $query_args['meta_query'] ) > 1 ) {


### PR DESCRIPTION
### 🎫 Ticket

Issues 77 and 78 from gsheet
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
Modifies the WP query used to find candidate events for receiving moved tickets or attendees.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
