### PR TITLE
Migrate Upsells appearance logic to use service status interface

### DIFF
--- a/src/Tickets/Seating/Orders/Seats_Report.php
+++ b/src/Tickets/Seating/Orders/Seats_Report.php
@@ -237,7 +237,7 @@ class Seats_Report extends Report_Abstract {
 	 * @return bool Whether the upsell should show or not.
 	 */
 	protected function should_show_upsell(): bool {
-		$service_status = tribe( Service::class )->get_status( true );
+		$service_status = tribe( Service::class )->get_status();
 
 		/**
 		 * Filters whether the upsell should be shown in the Seats report tab.

--- a/src/Tickets/Seating/Orders/Seats_Report.php
+++ b/src/Tickets/Seating/Orders/Seats_Report.php
@@ -11,6 +11,7 @@ use TEC\Tickets\Commerce\Reports\Tabbed_View;
 use TEC\Tickets\Seating\Meta;
 use TEC\Tickets\Seating\Service\Error_Content;
 use TEC\Tickets\Seating\Service\Service;
+use TEC\Tickets\Seating\Service\Service_Status;
 use Tribe__Main;
 use WP_Error;
 use WP_Post;
@@ -244,8 +245,8 @@ class Seats_Report extends Report_Abstract {
 		 *
 		 * @since TBD
 		 *
-		 * @param bool                                       $should_show_upsell Whether the upsell should be shown.
-		 * @param TEC\Tickets\Seating\Service\Service_Status $service_status     The seating service's status.
+		 * @param bool            $should_show_upsell Whether the upsell should be shown.
+		 * @param Service_Status  $service_status     The seating service's status.
 		 */
 		return apply_filters(
 			'tec_tickets_seating_should_show_upsell',

--- a/src/Tickets/Seating/Service/Error_Content.php
+++ b/src/Tickets/Seating/Service/Error_Content.php
@@ -75,6 +75,7 @@ class Error_Content {
 				$cta_label = _x( 'Connect', 'Connect to the Seat Builder button label', 'event-tickets' );
 				$cta_url   = admin_url( 'admin.php?page=tec-tickets-settings&tab=licenses' );
 				break;
+			case Service_Status::EXPIRED_LICENSE:
 			case Service_Status::INVALID_LICENSE:
 				$renew_link = sprintf(
 					// translators: %s is the renew link label.
@@ -140,6 +141,7 @@ class Error_Content {
 					$connect_link
 				);
 				break;
+			case Service_Status::EXPIRED_LICENSE:
 			case Service_Status::INVALID_LICENSE:
 				$renew_link = sprintf(
 					// translators: %s is the renew link label.

--- a/src/Tickets/Seating/app/blockEditor/capacity-form/service-error.js
+++ b/src/Tickets/Seating/app/blockEditor/capacity-form/service-error.js
@@ -44,6 +44,7 @@ const getMessage = (serviceStatus, serviceConnectUrl) => {
 					</a>
 				</span>
 			);
+		case 'expired-license':
 		case 'invalid-license':
 			return (
 				<span style={style}>

--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -159,6 +159,7 @@ export const filterSettingsFields = (fields) => {
 
 	switch (status) {
 		case 'not-connected':
+		case 'expired-license':
 		case 'invalid-license':
 			fields.push(
 				<Upsell />

--- a/src/admin-views/commerce/reports/seats.php
+++ b/src/admin-views/commerce/reports/seats.php
@@ -4,15 +4,10 @@
  *
  * @since TBD
  *
- * @var string $iframe_url         The URL to the service iframe.
- * @var string $token              The ephemeral token used to secure the iframe communication with the service.
- * @var string $error              The error message returned by the service.
- * @var bool   $should_show_upsell Whether it should up-sell instead of showing the iframe.
+ * @var string $iframe_url The URL to the service iframe.
+ * @var string $token      The ephemeral token used to secure the iframe communication with the service.
+ * @var string $error      The error message returned by the service.
  */
-
-if ( $should_show_upsell ) {
-	return $this->template( 'seats-upsell' );
-}
 
 ?>
 <div class="tec-tickets__seating-tab-wrapper wrap">

--- a/tests/slr_integration/Editor_Test.php
+++ b/tests/slr_integration/Editor_Test.php
@@ -271,6 +271,19 @@ class Editor_Test extends Controller_Test_Case {
 			}
 		];
 
+		yield 'expired license' => [
+			function (): array {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::EXPIRED_LICENSE );
+				}, 1000, 2 );
+				global $pagenow, $post;
+				$pagenow = 'edit.php';
+				$post    = get_post( static::factory()->post->create() );
+
+				return [];
+			}
+		];
+
 		yield 'existing event, not using meta set or layout set, with tickets' => [
 			function (): array {
 				$id = tribe_events()->set_args( [

--- a/tests/slr_integration/Frontend_Test.php
+++ b/tests/slr_integration/Frontend_Test.php
@@ -539,6 +539,31 @@ class Frontend_Test extends Controller_Test_Case {
 				return [ $post_id, $ticket ];
 			}
 		];
+
+		yield 'expired license' => [
+			function () {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::EXPIRED_LICENSE );
+				}, 1000, 2 );
+				$post_id = static::factory()->post->create(
+					[
+						'post_type' => 'page',
+					]
+				);
+				update_post_meta( $post_id, Meta::META_KEY_LAYOUT_ID, 'some-layout-uuid' );
+				/**
+				 * @var Tickets_Handler $tickets_handler
+				 */
+				$tickets_handler   = tribe( 'tickets.handler' );
+				$capacity_meta_key = $tickets_handler->key_capacity;
+				update_post_meta( $post_id, $capacity_meta_key, 100 );
+				$ticket = $this->create_tc_ticket( $post_id, 20 );
+
+				update_post_meta( $post_id, Meta::META_KEY_LAYOUT_ID, 'some-layout-uuid' );
+
+				return [ $post_id, $ticket ];
+			}
+		];
 	}
 
 	/**

--- a/tests/slr_integration/Orders/Seats_Report_Test.php
+++ b/tests/slr_integration/Orders/Seats_Report_Test.php
@@ -146,6 +146,7 @@ class Seats_Report_Test extends WPTEstCase {
 
 		$seats_report = tribe( Seats_Report::class );
 
+		test_remove_service_status_ok_callback();
 		$this->set_class_fn_return( License::class, 'is_valid', false );
 		$this->set_class_fn_return( License::class, 'is_expired', false );
 

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__expired license__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__expired license__0.snapshot.json
@@ -1,0 +1,14 @@
+{
+    "isUsingAssignedSeating": false,
+    "layouts": [],
+    "seatTypes": [],
+    "currentLayoutId": "",
+    "seatTypesByPostId": [],
+    "isLayoutLocked": false,
+    "eventCapacity": 0,
+    "serviceStatus": {
+        "ok": false,
+        "status": "expired-license",
+        "connectUrl": "http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&tab=licenses"
+    }
+}

--- a/tests/slr_integration/__snapshots__/Frontend_Test__should_replace_ticket_block_when_seating_is_enabled__expired license__0.snapshot.html
+++ b/tests/slr_integration/__snapshots__/Frontend_Test__should_replace_ticket_block_when_seating_is_enabled__expired license__0.snapshot.html
@@ -1,0 +1,9 @@
+
+<div class="tribe-common event-tickets tribe-tickets__tickets-wrapper">
+	<div class="tribe-tickets__tickets-form tec-tickets-seating__tickets-block">
+		<h2 class="tribe-common-h4 tribe-common-h--alt tribe-tickets__tickets-title">
+			Tickets		</h2>
+		<p>
+			Ticket sales are not available. Please contact the site administrator.		</p>
+	</div>
+</div>

--- a/tests/slr_integration/__snapshots__/Frontend_Test__test_get_ticket_block_data__expired license__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Frontend_Test__test_get_ticket_block_data__expired license__0.snapshot.json
@@ -1,0 +1,15 @@
+{
+    "objectName": "dialog_obj_tec-tickets-seating-seat-selection-modal",
+    "modalId": "tec-tickets-seating-seat-selection-modal",
+    "seatTypeMap": [],
+    "labels": {
+        "oneTicket": "1 Ticket",
+        "multipleTickets": "{count} Tickets"
+    },
+    "providerClass": "TEC\\Tickets\\Commerce\\Module",
+    "postId": {{post_id}},
+    "ajaxUrl": "http://wordpress.test/wp-admin/admin-ajax.php",
+    "ajaxNonce": "1111111111",
+    "ACTION_POST_RESERVATIONS": "tec_tickets_seating_post_reservations",
+    "ACTION_CLEAR_RESERVATIONS": "tec_tickets_seating_clear_reservations"
+}

--- a/tests/slr_integration/_bootstrap.php
+++ b/tests/slr_integration/_bootstrap.php
@@ -49,7 +49,16 @@ if ( ! defined( 'SECURE_AUTH_KEY' ) ) {
 	define( 'SECURE_AUTH_KEY', 'HG&R(f/h#K5{n:,4@swG~1Fc*aQGd@?T,T+zlTR)IsF5ET{SvvwBkI|zq6E}xjxy' );
 }
 
-// In the contest of tests, assume the Service connection is OK.
-add_filter( 'tec_tickets_seating_service_status', static function ( $_status, $backend_base_url ) {
+function test_return_ok_service_status( $_status, $backend_base_url ) {
 	return new Service_Status( $backend_base_url, Service_Status::OK );
-}, 10, 2 );
+};
+
+function test_add_service_status_ok_callback() {
+	add_filter( 'tec_tickets_seating_service_status', 'test_return_ok_service_status', 10, 2 );
+}
+function test_remove_service_status_ok_callback() {
+	remove_filter( 'tec_tickets_seating_service_status', 'test_return_ok_service_status' );
+}
+
+// In the contest of tests, assume the Service connection is OK.
+test_add_service_status_ok_callback();


### PR DESCRIPTION
### 🎫 Ticket

[SL-124][SL-47]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Migrates the upsell features to use the Service Status interface in order to determine if they should render or not.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[SL-124]: https://stellarwp.atlassian.net/browse/SL-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ