### PR TITLE
SLR - smaller frontend bundle, solve errors

### DIFF
--- a/src/Tickets/Seating/Assets.php
+++ b/src/Tickets/Seating/Assets.php
@@ -178,8 +178,8 @@ class Assets extends Controller_Contract {
 			ET::VERSION
 		)
 			->set_dependencies(
+				'tec-tickets-vendor-babel',
 				'wp-i18n',
-				'tribe-tickets-gutenberg-vendor', // Not actually about Block Editor, but transpiling.
 				'tec-tickets-seating-utils',
 				'tec-tickets-seating-ajax'
 			)

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -13,11 +13,19 @@ class Tribe__Tickets__Editor__Assets {
 	public function register() {
 		$plugin = Tribe__Tickets__Main::instance();
 
+		// A minimal set of Babel transpilers for commonly used JavaScript features.
+		tribe_asset(
+			$plugin,
+			'tec-tickets-vendor-babel',
+			'app/vendor-babel.js'
+		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-tickets-gutenberg-vendor',
 			'app/vendor.js',
 			[
+				'tec-tickets-vendor-babel',
 				'react',
 				'react-dom',
 				'thickbox',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,23 @@ const PLUGIN_SCOPE = 'tickets';
 // ──────────────────────────────────────────────────────────────────────────────────────────────
 //
 
+/**
+ * By default, the optimization would break all modules from the `node_modules` directory
+ * in a `src/resources/js/app/vendor.js` file. That file would include React and block-editor
+ * dependencies that are not always required on the frontend. This modification of the default
+ * optimization will create two files: one (`src/resources/js/app/vendor-babel.js`) that contains
+ * only the Babel transpilers and one (`src/resources/js/app/vendor.js`) that contains all the
+ * other dependencies. The second file (`src/resources/js/app/vendor.js`) MUST require the first
+ * (`src/resources/js/app/vendor-babel.js`) file as a dependency.
+ */
+common.optimization.splitChunks.cacheGroups['vendor-babel-runtime'] = {
+	name: 'vendor-babel',
+	chunks: 'all',
+	test: /[\\/]node_modules[\\/]@babel[\\/]/,
+	priority: 20,
+};
+common.optimization.splitChunks.cacheGroups.vendor.priority = 10;
+
 const isProduction = process.env.NODE_ENV === 'production';
 const postfix = isProduction ? 'min.css' : 'css';
 


### PR DESCRIPTION
This solves an issue where Block Editor code would be loaded in the
SLR application frontend as part of the `tribe-tickets-gutenberg-editor`
module.

Originally thought in backend context only, **all** the modules required
to compile the modules (block editor, admin, frontend) from the
`node_modules` directory would be compiled into the
`src/resources/js/app/vendor.js` file.
This file would be registered under the `tribe-tickets-gutenberg-editor`
handle in WordPress and, along with its entire set of requirements
(including React and Block Editor code).

Among those modules required are the Babel transpile utils that are
useful while writing modern JS code not only in backend context, but in
frontend context as well. For this reason the Seating frontend modules
would require the `tribe-tickets-gutenberg-editor`.

The updated WebPack configuration will break the compilation of the
modules in the `node_modules` directory in two files: one that contains
only the Babel transpile facilities
(`src/resources/js/app/vendor-babel.js`) and one that contains all the
others (`src/resources/js/app/vendor.js`).
The registration of the `tribe-tickets-gutenberg-editor` script has been
modified to depend on the new handle: `tec-tickets-vendor-babel`.

Existing Seating frontend code that never really needed **all** the
modules and scripts that come with the `tribe-tickets-gutenberg-editor`
script have been modified to depend, instead, on the
`tec-tickets-vendor-babel` script.
