### PR TITLE
fix(Seating) block stock updates, sync pre meta update

### DIFF
--- a/src/Tickets/Seating/Admin/Ajax.php
+++ b/src/Tickets/Seating/Admin/Ajax.php
@@ -1137,7 +1137,7 @@ class Ajax extends Controller_Contract {
 		$tickets = tribe_tickets()->where( 'event', $post_id )->get_ids( true );
 
 		// We're handling the update of the ticket meta ourselves.
-		remove_filter('update_post_metadata', [tribe(Controller::class), 'handle_ticket_meta_update'], 10);
+		remove_filter( 'update_post_metadata', [ tribe( Controller::class ), 'handle_ticket_meta_update' ], 10 );
 
 		foreach ( $tickets as $ticket_id ) {
 			$previous_capacity = get_post_meta( $ticket_id, $capacity_meta_key, true );

--- a/src/Tickets/Seating/Commerce/Attendees.php
+++ b/src/Tickets/Seating/Commerce/Attendees.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Provides methods to interact with Attndees' data.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Seating\Commerce;
+ */
+
+namespace TEC\Tickets\Seating\Commerce;
+
+use TEC\Common\StellarWP\DB\DB;
+use TEC\Tickets\Seating\Meta;
+use Tribe__Cache_Listener as Triggers;
+
+/**
+ * Class Attendees.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Seating\Commerce;
+ */
+class Attendees {
+
+	/**
+	 * Returns the number of attendees for a given post and seat type..
+	 *
+	 * @since TBD
+	 *
+	 * @param int    $post_id   The post ID to return the number of attendees for.
+	 * @param string $seat_type The seat type UUID to return the number of attendees for.
+	 *
+	 * @return int The number of attendees for the given post and seat type.
+	 */
+	public function get_count_by_post_seat_type( int $post_id, string $seat_type ): int {
+		$cache_key = sprintf( 'seating_attendees_by_post_seat_type_count_%d_%s', $post_id, $seat_type );
+
+		$cache = tribe_cache();
+
+		// This cached value will be invalidated by the save of any Ticket, Attendee or Order.
+		$count = $cache->get( $cache_key, Triggers::TRIGGER_SAVE_POST, null, DAY_IN_SECONDS );
+
+		if ( is_int( $count ) && $count > 0 ) {
+			return $count;
+		}
+
+		$attendee_types                 = array_values( tribe_attendees()->attendee_types() );
+		$attendee_types_in              = DB::prepare(
+			implode( ',', array_fill( 0, count( $attendee_types ), '%s' ) ),
+			...$attendee_types
+		);
+		$attendee_to_event_meta_keys    = array_values( tribe_attendees()->attendee_to_event_keys() );
+		$attendee_to_event_meta_keys_in = DB::prepare(
+			implode( ',', array_fill( 0, count( $attendee_to_event_meta_keys ), '%s' ) ),
+			...$attendee_to_event_meta_keys
+		);
+		global $wpdb;
+		$ticket_post_types               = array_values( tribe_tickets()->ticket_types() );
+		$ticket_post_types_in            = DB::prepare(
+			implode( ',', array_fill( 0, count( $ticket_post_types ), '%s' ) ),
+			...$ticket_post_types
+		);
+		$ticket_to_event_meta_keys       = array_values( tribe_tickets()->ticket_to_event_keys() );
+		$ticket_to_event_meta_keys_in    = DB::prepare(
+			implode( ',', array_fill( 0, count( $ticket_to_event_meta_keys ), '%s' ) ),
+			...$ticket_to_event_meta_keys
+		);
+		$attendee_to_ticket_meta_keys    = array_values( tribe_attendees()->attendee_to_ticket_keys() );
+		$attendee_to_ticket_meta_keys_in = DB::prepare(
+			implode( ',', array_fill( 0, count( $attendee_to_ticket_meta_keys ), '%s' ) ),
+			...$attendee_to_ticket_meta_keys
+		);
+		$seat_type_attendees_count       = DB::get_var(
+			DB::prepare(
+				"SELECT COUNT(*) FROM %i AS attendee
+				JOIN %i AS attendee_for_event ON attendee.ID = attendee_for_event.post_id
+					AND attendee_for_event.meta_key in ({$attendee_to_event_meta_keys_in})
+				JOIN %i AS attendee_for_ticket ON attendee.ID = attendee_for_ticket.post_id
+					AND attendee_for_ticket.meta_key in ({$attendee_to_ticket_meta_keys_in})
+				WHERE attendee.post_type IN ({$attendee_types_in})
+				AND attendee_for_event.meta_value = %d
+				AND attendee_for_ticket.meta_value IN (
+					SELECT ID FROM %i ticket
+					JOIN %i ticket_for_event ON ticket.ID = ticket_for_event.post_id
+						AND meta_key in ({$ticket_to_event_meta_keys_in})
+					JOIN %i ticket_for_seat_type ON ticket.ID = ticket_for_seat_type.post_id
+						AND ticket_for_seat_type.meta_key = %s
+					WHERE ticket.post_type IN ({$ticket_post_types_in})
+					AND ticket_for_event.meta_value = %d
+					AND ticket_for_seat_type.meta_value = %s
+				)",
+				$wpdb->posts,
+				$wpdb->postmeta,
+				$wpdb->postmeta,
+				$post_id,
+				$wpdb->posts,
+				$wpdb->postmeta,
+				$wpdb->postmeta,
+				Meta::META_KEY_SEAT_TYPE,
+				$post_id,
+				$seat_type
+			)
+		);
+
+		$cache->set( $cache_key, $seat_type_attendees_count, DAY_IN_SECONDS, Triggers::TRIGGER_SAVE_POST );
+
+		return (int) $seat_type_attendees_count;
+	}
+}

--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -70,20 +70,20 @@ class Controller extends Controller_Contract {
 	/**
 	 * Controller constructor.
 	 *
-	 * since TBD
+	 * @since TBD
 	 *
-	 * @param Container $container A reference to the DI container instance.
-	 * @param Service   $service   A reference to the Seating Service facade.
-	 * @param Seat_Types_Table  $seat_types_table A reference to the Seat Types Table handler.
-	 * @param Attendees $attendees A reference to the Attendees data handler.
+	 * @param Container        $container        A reference to the DI container instance.
+	 * @param Service          $service          A reference to the Seating Service facade.
+	 * @param Seat_Types_Table $seat_types_table A reference to the Seat Types Table handler.
+	 * @param Attendees        $attendees        A reference to the Attendees data handler.
 	 */
-	public function __construct( Container $container, Service $service, Seat_Types_Table  $seat_types_table, Attendees $attendees ) {
+	public function __construct( Container $container, Service $service, Seat_Types_Table $seat_types_table, Attendees $attendees ) {
 		parent::__construct( $container );
 		$this->service = $service;
 		/** @var Tickets_Handler $tickets_handler */
-		$this->tickets_handler = tribe( 'tickets.handler' );
+		$this->tickets_handler  = tribe( 'tickets.handler' );
 		$this->seat_types_table = $seat_types_table;
-		$this->attendees = $attendees;
+		$this->attendees        = $attendees;
 	}
 
 	/**
@@ -346,7 +346,8 @@ class Controller extends Controller_Contract {
 
 		/*
 		 * Not memoized as its invalidation could not be handled only in this Controller and would run the risk of
-		 * caching the wrong value. */
+		 * caching the wrong value.
+		 */
 		foreach (
 			tribe_tickets()
 				->where( 'event', $event->ID )
@@ -387,10 +388,14 @@ class Controller extends Controller_Contract {
 			return $check;
 		}
 
-		if ( ! in_array( $meta_key, [
-			Ticket::$stock_meta_key,
-			$this->tickets_handler->key_capacity,
-		], true ) ) {
+		if ( ! in_array(
+			$meta_key,
+			[
+				Ticket::$stock_meta_key,
+				$this->tickets_handler->key_capacity,
+			],
+			true
+		) ) {
 			// Not a ticket meta key we care about.
 			return $check;
 		}
@@ -430,7 +435,7 @@ class Controller extends Controller_Contract {
 
 		add_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10, 4 );
 
-		return  $updated;
+		return $updated;
 	}
 
 }

--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -10,13 +10,18 @@
 namespace TEC\Tickets\Seating\Commerce;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\lucatume\DI52\Container;
 use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Ticket;
 use TEC\Tickets\Seating\Meta;
+use TEC\Tickets\Seating\Service\Service;
+use TEC\Tickets\Seating\Tables\Seat_Types as Seat_Types_Table;
+use Tribe__Cache_Listener as Cache_Listener;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use Tribe__Tickets__Tickets as Tickets;
+use Tribe__Tickets__Tickets_Handler as Tickets_Handler;
 use WP_Post;
 
 /**
@@ -27,6 +32,60 @@ use WP_Post;
  * @package TEC\Tickets\Seating\Commerce;
  */
 class Controller extends Controller_Contract {
+	/**
+	 * A reference to the Seating Service facade.
+	 *
+	 * @since TBD
+	 *
+	 * @var Service
+	 */
+	private Service $service;
+
+	/**
+	 * A reference to the Tickets Handler.
+	 *
+	 * @since TBD
+	 *
+	 * @var Tickets_Handler
+	 */
+	private Tickets_Handler $tickets_handler;
+	/**
+	 * A reference to the Seat Types Table handle.
+	 *
+	 * @since TBD
+	 *
+	 * @var Seat_Types_Table
+	 */
+	private Seat_Types_Table $seat_types_table;
+
+	/**
+	 * A reference to the Attendees handler.
+	 *
+	 * @since TBD
+	 *
+	 * @var Attendees
+	 */
+	private Attendees $attendees;
+
+	/**
+	 * Controller constructor.
+	 *
+	 * since TBD
+	 *
+	 * @param Container $container A reference to the DI container instance.
+	 * @param Service   $service   A reference to the Seating Service facade.
+	 * @param Seat_Types_Table  $seat_types_table A reference to the Seat Types Table handler.
+	 * @param Attendees $attendees A reference to the Attendees data handler.
+	 */
+	public function __construct( Container $container, Service $service, Seat_Types_Table  $seat_types_table, Attendees $attendees ) {
+		parent::__construct( $container );
+		$this->service = $service;
+		/** @var Tickets_Handler $tickets_handler */
+		$this->tickets_handler = tribe( 'tickets.handler' );
+		$this->seat_types_table = $seat_types_table;
+		$this->attendees = $attendees;
+	}
+
 	/**
 	 * Subscribes to the WordPress hooks and actions required by the controller.
 	 *
@@ -41,7 +100,7 @@ class Controller extends Controller_Contract {
 		);
 		add_filter( 'tribe_tickets_ticket_inventory', [ $this, 'get_seated_ticket_inventory' ], 10, 3 );
 		add_filter( 'tec_tickets_get_ticket_counts', [ $this, 'set_event_stock_counts' ], 10, 2 );
-		add_action( 'updated_postmeta', [ $this, 'sync_seated_tickets_stock' ], 10, 4 );
+		add_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10, 4 );
 	}
 
 	/**
@@ -58,7 +117,7 @@ class Controller extends Controller_Contract {
 		);
 		remove_filter( 'tribe_tickets_ticket_inventory', [ $this, 'get_seated_ticket_inventory' ] );
 		remove_filter( 'tec_tickets_get_ticket_counts', [ $this, 'set_event_stock_counts' ] );
-		remove_action( 'updated_postmeta', [ $this, 'sync_seated_tickets_stock' ] );
+		remove_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ] );
 	}
 
 	/**
@@ -192,83 +251,6 @@ class Controller extends Controller_Contract {
 	}
 
 	/**
-	 * Filters the stock update value for a ticket.
-	 *
-	 * @since TBD
-	 *
-	 * @param int    $meta_id    ID of the meta entry.
-	 * @param int    $object_id  ID of the object.
-	 * @param string $meta_key   Meta key.
-	 * @param mixed  $meta_value Meta value.
-	 *
-	 * @return void
-	 */
-	public function sync_seated_tickets_stock( $meta_id, $object_id, $meta_key, $meta_value ): void {
-		if ( Ticket::$stock_meta_key !== $meta_key ) {
-			return;
-		}
-
-		if ( ! is_numeric( $meta_value ) ) {
-			return;
-		}
-
-		$stock = (int) $meta_value;
-
-		if ( 0 > $stock ) {
-			// We are not syncing bugs. Seats can NOT be infinite.
-			return;
-		}
-
-		$seat_type = get_post_meta( $object_id, Meta::META_KEY_SEAT_TYPE, true );
-
-		// Not a seating ticket. We should not modify the stock.
-		if ( ! $seat_type ) {
-			return;
-		}
-
-		$ticket = Tickets::load_ticket_object( $object_id );
-
-		if ( ! $ticket instanceof Ticket_Object ) {
-			return;
-		}
-
-		$event = $ticket->get_event();
-
-		if ( ! $event instanceof WP_Post || ! $event->ID ) {
-			return;
-		}
-
-		// Remove the action to avoid infinite loops.
-		remove_action( 'update_post_metadata', [ $this, 'sync_seated_tickets_stock' ] );
-
-		$updated_stock   = $stock;
-		$prev_meta_value = get_post_meta( $object_id, Ticket::$stock_meta_key, true );
-		if ( $prev_meta_value !== '' ) {
-			$updated_stock = min( $stock, $prev_meta_value );
-		}
-
-		update_post_meta( $object_id, Ticket::$stock_meta_key, $updated_stock );
-
-		$cache_listener = tribe( 'Tribe__Cache_Listener' );
-		// Trigger the cache invalidation for this ticket.
-		$cache_listener->save_post( $object_id, get_post( $object_id ) );
-
-		foreach (
-			tribe_tickets()
-				->where( 'event', $event->ID )
-				->not_in( $ticket->ID )
-				->where( 'meta_equals', Meta::META_KEY_SEAT_TYPE, $seat_type )
-				->get_ids( true ) as $ticket_id
-		) {
-			update_post_meta( $ticket_id, Ticket::$stock_meta_key, $updated_stock );
-			// Trigger the cache invalidation for this ticket.
-			$cache_listener->save_post( $object_id, get_post( $object_id ) );
-		}
-
-		add_action( 'updated_postmeta', [ $this, 'sync_seated_tickets_stock' ], 10, 4 );
-	}
-
-	/**
 	 * Filters the handler used to get the token and object ID from the cookie.
 	 *
 	 * @since TBD
@@ -328,4 +310,127 @@ class Controller extends Controller_Contract {
 			)
 		);
 	}
+
+	/**
+	 * Cross-updates the Ticket stock meta across a set of Tickets sharing the same seat type and post.
+	 *
+	 * @since TBD
+	 *
+	 * @param int    $ticket_id The Ticket ID to start the cross-update from.
+	 * @param string $seat_type The seat type UUID.
+	 *
+	 * @return bool Whether the meta update of the Ticket specified by `$ticket_id` was successful or not.
+	 */
+	private function update_seated_ticket_stock( int $ticket_id, string $seat_type ): bool {
+		$ticket = Tickets::load_ticket_object( $ticket_id );
+
+		if ( ! $ticket instanceof Ticket_Object ) {
+			return false;
+		}
+
+		$event = $ticket->get_event();
+
+		if ( ! $event instanceof WP_Post || ! $event->ID ) {
+			return false;
+		}
+
+		$seat_type_seats           = $this->seat_types_table->get_seats( $seat_type );
+		$seat_type_attendees_count = $this->attendees->get_count_by_post_seat_type( $event->ID, $seat_type );
+		$updated_stock             = $seat_type_seats - $seat_type_attendees_count;
+
+		$updated = update_post_meta( $ticket_id, Ticket::$stock_meta_key, $updated_stock );
+
+		// Trigger the save post cache invalidation for this ticket.
+		$cache_listener    = tribe( Cache_Listener::class );
+		$to_invalidate_ids = [ $ticket_id ];
+
+		/*
+		 * Not memoized as its invalidation could not be handled only in this Controller and would run the risk of
+		 * caching the wrong value. */
+		foreach (
+			tribe_tickets()
+				->where( 'event', $event->ID )
+				->not_in( $ticket->ID )
+				->where( 'meta_equals', Meta::META_KEY_SEAT_TYPE, $seat_type )
+				->get_ids( true ) as $seat_type_ticket_id
+		) {
+			update_post_meta( $seat_type_ticket_id, Ticket::$stock_meta_key, $updated_stock );
+			$to_invalidate_ids[] = $seat_type_ticket_id;
+		}
+
+		// This cross-update might have skipped some methods that would normally invalidate theirs caches: do it now.
+		foreach ( $to_invalidate_ids as $to_invalidate_id ) {
+			// Trigger the save post cache invalidation for this ticket.
+			$cache_listener->save_post( $to_invalidate_id, get_post( $to_invalidate_id ) );
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Handle the update of some ticket meta keys depending on the service status and taking care to update
+	 * related meta in other Tickets that should be affected.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|bool $check      Whether to allow the update (`null`) or whether the update is already being processed.
+	 * @param int       $object_id  The ID of the object being updated.
+	 * @param string    $meta_key   The meta key being updated.
+	 * @param mixed     $meta_value The new value for the meta key.
+	 *
+	 * @return null|bool Whether to allow the update (`null`) or whether the update is already being processed and
+	 *                   what is the update result (`false|true`).
+	 */
+	public function handle_ticket_meta_update( $check, $object_id, $meta_key, $meta_value ) {
+		if ( $check !== null ) {
+			// Some other code is already controlling the update, so we should not.
+			return $check;
+		}
+
+		if ( ! in_array( $meta_key, [
+			Ticket::$stock_meta_key,
+			$this->tickets_handler->key_capacity,
+		], true ) ) {
+			// Not a ticket meta key we care about.
+			return $check;
+		}
+
+		$ticket_post_types = tribe_tickets()->ticket_types();
+
+		if ( ! in_array( get_post_type( $object_id ), $ticket_post_types, true ) ) {
+			// Not a ticket post type.
+			return $check;
+		}
+
+		$seat_type = get_post_meta( $object_id, Meta::META_KEY_SEAT_TYPE, true );
+
+		if ( ! ( $seat_type ) ) {
+			// Not an ASC ticket.
+			return $check;
+		}
+
+		if ( ! $this->service->get_status()->is_ok() ) {
+			// Service status is not OK: prevent the update until the service comes back online.
+			return false;
+		}
+
+		// Remove this filter to avoid infinite loops.
+		remove_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ] );
+
+		if ( $meta_key === Ticket::$stock_meta_key ) {
+			if ( (int) $meta_value < 0 ) {
+				// Not syncing unlimited stock: no such thing as infinite seats.
+				return false;
+			}
+
+			$updated = $this->update_seated_ticket_stock( $object_id, $seat_type );
+		} else {
+			$updated = update_post_meta( $object_id, $meta_key, $meta_value );
+		}
+
+		add_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10, 4 );
+
+		return  $updated;
+	}
+
 }

--- a/src/Tickets/Seating/Service/Seat_Types.php
+++ b/src/Tickets/Seating/Service/Seat_Types.php
@@ -256,7 +256,7 @@ class Seat_Types {
 		 * The Commerce controller will, on update of the `_stock` meta, trigger a cross-update of all Tickets sharing the
 		 * same seat type: we're doing this here so the action should not fire.
 		 */
-		remove_action( 'updated_postmeta', [ tribe( Commerce_Controller::class ), 'sync_seated_tickets_stock' ] );
+		remove_action( 'update_post_metadata', [ tribe( Commerce_Controller::class ), 'handle_ticket_meta_update' ] );
 
 		foreach (
 			tribe_tickets()
@@ -278,7 +278,7 @@ class Seat_Types {
 			++$total_updated;
 		}
 
-		add_action( 'updated_postmeta', [ tribe( Commerce_Controller::class ), 'sync_seated_tickets_stock' ], 10, 4 );
+		add_action( 'update_post_metadata', [ tribe( Commerce_Controller::class ), 'handle_ticket_meta_update' ], 10, 4 );
 
 		return $total_updated;
 	}
@@ -307,7 +307,7 @@ class Seat_Types {
 
 		$events_primary = [];
 
-		remove_action( 'updated_postmeta', [ tribe( Commerce_Controller::class ), 'sync_seated_tickets_stock' ] );
+		remove_action( 'update_post_metadata', [ tribe( Commerce_Controller::class ), 'handle_ticket_meta_update' ] );
 
 		foreach (
 			tribe_tickets()
@@ -424,7 +424,7 @@ class Seat_Types {
 			++$total_updated;
 		}
 
-		add_action( 'updated_postmeta', [ tribe( Commerce_Controller::class ), 'sync_seated_tickets_stock' ], 10, 4 );
+		add_action( 'updated_post_metadata', [ tribe( Commerce_Controller::class ), 'handle_ticket_meta_update' ], 10, 4 );
 
 		return $total_updated;
 	}

--- a/src/Tickets/Seating/Tables/Seat_Types.php
+++ b/src/Tickets/Seating/Tables/Seat_Types.php
@@ -79,7 +79,7 @@ class Seat_Types extends Table {
 	public function get_seats( string $seat_type ): int {
 		return (int) DB::get_var(
 			DB::prepare(
-				"SELECT seats FROM %i WHERE id = %s",
+				'SELECT seats FROM %i WHERE id = %s',
 				self::table_name( true ),
 				$seat_type
 			)

--- a/src/Tickets/Seating/Tables/Seat_Types.php
+++ b/src/Tickets/Seating/Tables/Seat_Types.php
@@ -9,6 +9,7 @@
 
 namespace TEC\Tickets\Seating\Tables;
 
+use TEC\Common\StellarWP\DB\DB;
 use TEC\Common\StellarWP\Schema\Tables\Contracts\Table;
 
 /**
@@ -65,6 +66,25 @@ class Seat_Types extends Table {
 	 * @var string
 	 */
 	protected static $uid_column = 'id';
+
+	/**
+	 * Returns the number of seats for a given seat type.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $seat_type The seat type UUID to return the number of seats for.
+	 *
+	 * @return int The number of seats for the given seat type. If the seat type does not exist, returns `0`.
+	 */
+	public function get_seats( string $seat_type ): int {
+		return (int) DB::get_var(
+			DB::prepare(
+				"SELECT seats FROM %i WHERE id = %s",
+				self::table_name( true ),
+				$seat_type
+			)
+		);
+	}
 
 	/**
 	 * Returns the table creation SQL in the format supported

--- a/tests/slr_integration/Editor_Test.php
+++ b/tests/slr_integration/Editor_Test.php
@@ -8,6 +8,7 @@ use TEC\Tickets\Seating\Service\Service_Status;
 use TEC\Tickets\Seating\Tables\Layouts;
 use TEC\Tickets\Seating\Tables\Seat_Types;
 use TEC\Tickets\Seating\Tests\Integration\Layouts_Factory;
+use TEC\Tickets\Seating\Tests\Integration\Truncates_Custom_Tables;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Tribe__Events__Main as TEC;
@@ -20,6 +21,7 @@ class Editor_Test extends Controller_Test_Case {
 	use SnapshotAssertions;
 	use Ticket_Maker;
 	use Order_Maker;
+	use Truncates_Custom_Tables;
 
 	protected string $controller_class = Editor::class;
 
@@ -41,15 +43,6 @@ class Editor_Test extends Controller_Test_Case {
 	}
 
 	/**
-	 * @before
-	 * @after
-	 */
-	public function truncate_custom_tables(): void {
-		Seat_Types::truncate();
-		Layouts::truncate();
-	}
-
-	/**
 	 * @test
 	 */
 	public function it_should_filter_seating_totals(): void {
@@ -62,6 +55,20 @@ class Editor_Test extends Controller_Test_Case {
 		update_post_meta( $post_id, Global_Stock::GLOBAL_STOCK_ENABLED, '1' );
 		update_post_meta( $post_id, Global_Stock::GLOBAL_STOCK_LEVEL, 40 );
 		update_post_meta( $post_id, $tickets_handler->key_capacity, 40 );
+
+		// Create the Seat Types.
+		Seat_Types::insert_many(
+			[
+				[
+					'id'     => 'some-seat-type-1',
+					'name'   => 'B',
+					'seats'  => 40,
+					'map'    => 'some-map-1',
+					'layout' => 'some-layout-1',
+				],
+			]
+		);
+		set_transient( \TEC\Tickets\Seating\Service\Seat_Types::update_transient_name(), time() );
 
 		$ticket_id_1 = $this->create_tc_ticket(
 			$post_id,

--- a/tests/slr_integration/Service/Layouts_Test.php
+++ b/tests/slr_integration/Service/Layouts_Test.php
@@ -8,24 +8,14 @@ use TEC\Tickets\Seating\Meta;
 use TEC\Tickets\Seating\Tables\Layouts as Layouts_Table;
 use TEC\Tickets\Seating\Tables\Maps as Maps_Table;
 use TEC\Tickets\Seating\Tables\Seat_Types as Seat_Types_Table;
+use TEC\Tickets\Seating\Tests\Integration\Truncates_Custom_Tables;
 use Tribe\Tests\Traits\WP_Remote_Mocks;
 use Tribe__Tickets__Data_API as Data_API;
 use Tribe__Tickets__Global_Stock as Global_Stock;
 
 class Layouts_Test extends \Codeception\TestCase\WPTestCase {
 	use WP_Remote_Mocks;
-
-	/**
-	 * @before
-	 * @after
-	 */
-	public function truncate_custom_tables(): void {
-		Seat_Types_Table::truncate();
-		Layouts_Table::truncate();
-		Maps_Table::truncate();
-		delete_transient( Seat_Types::update_transient_name() );
-		delete_transient( Layouts::update_transient_name() );
-	}
+	use Truncates_Custom_Tables;
 
 	/**
 	 * @before
@@ -48,9 +38,6 @@ class Layouts_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function test_invalidate_cache(): void {
-		$this->assertEmpty( get_transient( Layouts::update_transient_name() ) );
-		$this->assertEmpty( get_transient( Seat_Types::update_transient_name() ) );
-
 		$this->given_some_maps_layouts_in_db();
 		set_transient( Seat_Types::update_transient_name(), time() );
 		set_transient( Layouts::update_transient_name(), time() );

--- a/tests/slr_integration/Service/Seat_Types_Test.php
+++ b/tests/slr_integration/Service/Seat_Types_Test.php
@@ -8,6 +8,7 @@ use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Seating\Meta;
 use TEC\Tickets\Seating\Tables\Seat_Types as Seat_Types_Table;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Tribe__Tickets__Data_API as Data_API;
 use Tribe__Tickets__Global_Stock as Global_Stock;
@@ -15,6 +16,7 @@ use Tribe__Tickets__Global_Stock as Global_Stock;
 class Seat_Types_Test extends WPTestCase {
 	use Ticket_Maker;
 	use SnapshotAssertions;
+	use Order_Maker;
 
 	/**
 	 * @before
@@ -343,10 +345,12 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_3_ticket_1, Meta::META_KEY_SEAT_TYPE, 'seat-type-uuid-1' );
 		update_post_meta( $post_3_ticket_1, $capacity_meta_key, 10 );
 		update_post_meta( $post_3_ticket_1, '_stock', 8 );
+		$this->create_order( [ $post_3_ticket_1 => 2 ] );
 
 		update_post_meta( $post_3_ticket_2, Meta::META_KEY_SEAT_TYPE, 'seat-type-uuid-2' );
 		update_post_meta( $post_3_ticket_2, $capacity_meta_key, 20 );
 		update_post_meta( $post_3_ticket_2, '_stock', 16 );
+		$this->create_order( [ $post_3_ticket_2 => 4 ] );
 
 		// Post 4 set up.
 		$post_4_ticket_1 = $this->create_tc_ticket( $post_id_4, 10 );
@@ -358,6 +362,7 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_4_ticket_1, Meta::META_KEY_SEAT_TYPE, 'seat-type-uuid-2' );
 		update_post_meta( $post_4_ticket_1, $capacity_meta_key, 20 );
 		update_post_meta( $post_4_ticket_1, '_stock', 16 );
+		$this->create_order( [ $post_4_ticket_1 => 4 ] );
 
 		// Start testing!
 		// We need to mock the update of seat type 2 to simulate the deletion of the seat type.
@@ -507,6 +512,12 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_2_ticket_6, $capacity_meta_key, 30 );
 		update_post_meta( $post_2_ticket_6, '_stock', 11 );
 
+		$this->create_order( [
+			$post_2_ticket_1 => 4,
+			$post_2_ticket_5 => 8,
+			$post_2_ticket_6 => 19,
+		] );
+
 		// Post 3 set up.
 		$post_3_ticket_1 = $this->create_tc_ticket( $post_id_3, 10 );
 		$post_3_ticket_2 = $this->create_tc_ticket( $post_id_3, 20 );
@@ -538,6 +549,11 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_4_ticket_2, Meta::META_KEY_SEAT_TYPE, 'seat-type-uuid-2' );
 		update_post_meta( $post_4_ticket_2, $capacity_meta_key, 20 );
 		update_post_meta( $post_4_ticket_2, '_stock', 15 );
+
+		$this->create_order( [
+			$post_4_ticket_1 => 3,
+			$post_4_ticket_2 => 5,
+		] );
 
 		// Post 5 set up.
 		$post_5_ticket_1 = $this->create_tc_ticket( $post_id_5, 10 );
@@ -571,6 +587,11 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_6_ticket_2, $capacity_meta_key, 20 );
 		update_post_meta( $post_6_ticket_2, '_stock', 16 );
 
+		$this->create_order( [
+			$post_6_ticket_1 => 5,
+			$post_6_ticket_2 => 4,
+		] );
+
 		// Post 7 set up.
 		$post_7_ticket_1 = $this->create_tc_ticket( $post_id_7, 10 );
 
@@ -593,6 +614,10 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_8_ticket_1, $capacity_meta_key, 20 );
 		update_post_meta( $post_8_ticket_1, '_stock', 12 );
 
+		$this->create_order( [
+			$post_8_ticket_1 => 8
+		] );
+
 		// Post 9 set up.
 		$post_9_ticket_1 = $this->create_tc_ticket( $post_id_9, 10 );
 
@@ -614,6 +639,10 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_10_ticket_1, Meta::META_KEY_SEAT_TYPE, 'seat-type-uuid-1' );
 		update_post_meta( $post_10_ticket_1, $capacity_meta_key, 10 );
 		update_post_meta( $post_10_ticket_1, '_stock', 8 );
+
+		$this->create_order( [
+			$post_10_ticket_1 => 2
+		] );
 
 		// Start testing!
 		// We need to mock the update of seat type 2 to simulate the deletion of the seat type.
@@ -798,6 +827,10 @@ class Seat_Types_Test extends WPTestCase {
 		update_post_meta( $post_2_ticket_1, $capacity_meta_key, 20 );
 		update_post_meta( $post_2_ticket_1, '_stock', 16 );
 
+		$this->create_order([
+			$post_2_ticket_1 => 4
+		]);
+
 		// Start testing!
 		// We need to mock the update of seat type 2 to simulate the deletion of the seat type.
 		update_post_meta( $post_1_ticket_1, Meta::META_KEY_SEAT_TYPE, 'seat-type-uuid-1' );
@@ -820,7 +853,7 @@ class Seat_Types_Test extends WPTestCase {
 		$this->assertEquals( 26, get_post_meta( $post_2_ticket_1, '_stock', true ) );
 		$this->assertEquals( 'seat-type-uuid-1', get_post_meta( $post_2_ticket_1, Meta::META_KEY_SEAT_TYPE, true ) );
 	}
-	
+
 	public function test_get_in_option_format() {
 		// Create seat types with different name value starting with different letters in random order.
 		Seat_Types::insert_rows_from_service(
@@ -862,11 +895,11 @@ class Seat_Types_Test extends WPTestCase {
 				],
 			]
 		);
-		
+
 		set_transient( Seat_Types::update_transient_name(), time() );
-		
+
 		$seat_types = tribe( Seat_Types::class );
-		
+
 		// Get the seat types in option format and match snapshot.
 		$this->assertMatchesJsonSnapshot( wp_json_encode( $seat_types->get_in_option_format( [ 'layout-uuid-1' ] ), JSON_SNAPSHOT_OPTIONS ) );
 	}

--- a/tests/slr_integration/Truncates_Custom_Tables.php
+++ b/tests/slr_integration/Truncates_Custom_Tables.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TEC\Tickets\Seating\Tests\Integration;
+
+use TEC\Tickets\Seating\Tables\Layouts;
+use TEC\Tickets\Seating\Tables\Maps;
+use TEC\Tickets\Seating\Tables\Seat_Types;
+use TEC\Tickets\Seating\Tables\Sessions;
+
+trait Truncates_Custom_Tables {
+	/**
+	 * @before
+	 * @after
+	 */
+	public function truncate_tables(): void {
+		Maps::truncate();
+		Seat_Types::truncate();
+		Layouts::truncate();
+		Sessions::truncate();
+	}
+
+}


### PR DESCRIPTION
This udpates the logic used to cross-sync the stock meta (`_stock`)
across Tickes with the same seat type to do it **before** the default
meta update logic takes place and handle it using custom logic.

Since Stock = Capacity - Attendees, this update relies on a query that
will count Attendees per-post, per-tickets by seat-type to make sure the
value will be consistent.

Since the default logic will take over other meta update systems, I've
modified other code handling similar updates to remove and add again the
meta handling logic.

Finally, I've updated the `slr_integration` tests to make sure that ASC
tickets will map to a Series Type and Attendees in the database.
