### PR TITLE
Add transient to prevent multiple status changes in a short period

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
-### [5.15.0] 2024-10-17
+### [5.15.0] 2024-10-21
 
+* Fix - Tickets Commerce orders through Stripe no longer will create duplicate attendees. [ET-2256]
 * Fix - Order Completed page will no longer throw a fatal when visiting it directly. [ET-2253]
 * Fix - If users added an index to the `post_meta` table on `meta_value` using `CONCAT()` should speed up queries for them. [GTRIA-1236]
 * Fix - Possible miscounted ticketed or un-ticketed events in the events admin list [ET-2221]

--- a/changelog/fix-ET-2256-duplicate-attendees-created
+++ b/changelog/fix-ET-2256-duplicate-attendees-created
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tickets Commerce orders through Stripe no longer will create duplicate attendees [ET-2256]

--- a/readme.txt
+++ b/readme.txt
@@ -205,6 +205,7 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 = [5.15.0] 2024-10-21 =
 
+* Fix - Tickets Commerce orders through Stripe no longer will create duplicate attendees. [ET-2256]
 * Fix - Order Completed page will no longer throw a fatal when visiting it directly. [ET-2253]
 * Fix - If users added an index to the `post_meta` table on `meta_value` using `CONCAT()` should speed up queries for them. [GTRIA-1236]
 * Fix - Possible miscounted ticketed or un-ticketed events in the events admin list [ET-2221]

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Charge_Webhook.php
@@ -6,6 +6,7 @@ use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\Gateways\Contracts\Webhook_Event_Interface;
 use TEC\Tickets\Commerce\Gateways\Stripe\Payment_Intent;
+use TEC\Tickets\Commerce\Gateways\Stripe\Status;
 use Tribe__Utils__Array as Arr;
 
 /**
@@ -25,6 +26,44 @@ class Charge_Webhook implements Webhook_Event_Interface {
 		$payment_intent_id = $charge_data['payment_intent'];
 
 		$order = tribe( Order::class )->get_from_gateway_order_id( $payment_intent_id );
+
+		$payment_intent = Payment_Intent::get( $payment_intent_id );
+
+		/**
+		 * We were having problems for Payment Intent and Charge happening at the exact same time, so a race condition was happening
+		 * this particular piece of code prevents that problem, by making the Change Webhook look at the Payment Intent status on
+		 * Stripe it forces the Payment Intent to be the source of truth.
+		 *
+		 * See the link below for more information on the problems caused by this bug.
+		 *
+		 * @link https://stellarwp.atlassian.net/browse/ET-1792
+		 *
+		 * Second iteration see below for more information.
+		 *
+		 * @link https://stellarwp.atlassian.net/browse/ET-2142
+		 * @link https://github.com/the-events-calendar/event-tickets/pull/3095
+		 *
+		 * @since 5.7.1
+		 * @since 5.13.0 - Process Refunds requests always.
+		 */
+		if (
+			$payment_intent
+			&& isset( $payment_intent['status'] )
+			&& Status::SUCCEEDED === $payment_intent['status']
+			&& Events::CHARGE_REFUNDED !== Arr::get( $event, 'type' )
+		) {
+				$response->set_status( 200 );
+				$response->set_data(
+					sprintf(
+						// Translators: %1$s is the event id and %2$s is the event type name.
+						__( 'Event %1$s was received and will not be handled because the Payment Intent %2$s was already moved to the Success status.', 'event-tickets' ),
+						esc_html( Arr::get( $event, 'id' ) ),
+						esc_html( $payment_intent_id )
+					)
+				);
+
+				return $response;
+		}
 
 		if ( empty( $order ) ) {
 

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Events.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Events.php
@@ -151,7 +151,9 @@ class Events {
 			static::ACCOUNT_UPDATED                  => [ Account_Webhook::class, 'handle_account_updated' ],
 			static::ACCOUNT_APPLICATION_DEAUTHORIZED => [ Account_Webhook::class, 'handle_account_deauthorized' ],
 			static::CHARGE_EXPIRED                   => [ Charge_Webhook::class, 'handle' ],
+			static::CHARGE_FAILED                    => [ Charge_Webhook::class, 'handle' ],
 			static::CHARGE_REFUNDED                  => [ Charge_Webhook::class, 'handle' ],
+			static::CHARGE_SUCCEEDED                 => [ Charge_Webhook::class, 'handle' ],
 			static::PAYMENT_INTENT_PROCESSING        => [ Payment_Intent_Webhook::class, 'handle' ],
 			static::PAYMENT_INTENT_REQUIRES_ACTION   => [ Payment_Intent_Webhook::class, 'handle' ],
 			static::PAYMENT_INTENT_SUCCEEDED         => [ Payment_Intent_Webhook::class, 'handle' ],
@@ -181,7 +183,9 @@ class Events {
 	public static function get_event_transition_status(): array {
 		$events = [
 			static::CHARGE_EXPIRED                 => Commerce_Status\Not_Completed::class,
+			static::CHARGE_FAILED                  => Commerce_Status\Denied::class,
 			static::CHARGE_REFUNDED                => Commerce_Status\Refunded::class,
+			static::CHARGE_SUCCEEDED               => Commerce_Status\Completed::class,
 			static::PAYMENT_INTENT_CANCELED        => Commerce_Status\Denied::class,
 			static::PAYMENT_INTENT_CREATED         => Commerce_Status\Created::class,
 			static::PAYMENT_INTENT_PAYMENT_FAILED  => Commerce_Status\Denied::class,

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
@@ -68,7 +68,7 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 			$response->set_status( 200 );
 			$response->set_data(
 				sprintf(
-				// Translators: %s is the payment intent id
+					// Translators: %s is the payment intent id.
 					__( 'Payment Intent %s does not require an update or is a duplicate of a past event.', 'event-tickets' ),
 					esc_html( $payment_intent_id )
 				)

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
@@ -64,6 +64,19 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 			) );
 		}
 
+		if ( ! static::should_payment_intent_be_updated( $payment_intent, $order->gateway_payload ) ) {
+			$response->set_status( 200 );
+			$response->set_data(
+				sprintf(
+				// Translators: %s is the payment intent id
+					__( 'Payment Intent %s does not require an update or is a duplicate of a past event.', 'event-tickets' ),
+					esc_html( $payment_intent_id )
+				)
+			);
+
+			return $response;
+		}
+
 		$meta = [
 			'gateway_payload'  => $payment_intent,
 			'gateway_order_id' => $payment_intent_id,
@@ -104,8 +117,8 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 	/**
 	 * Checks if the payment intent contained in the event received has already been processed.
 	 *
-	 * @deprecated 5.14.0
 	 * @since      5.3.0
+	 * @since      TBD Remove deprecation notice.
 	 *
 	 * @param array   $payment_intent_received The payment intent data received
 	 * @param array[] $payment_intents_stored  The payment intent data stored from each update, keyed by status.
@@ -113,7 +126,6 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 	 * @return bool
 	 */
 	public static function should_payment_intent_be_updated( $payment_intent_received, $payment_intents_stored ) {
-		_deprecated_function( __METHOD__, '5.14.0', 'This method will be removed in the future.' );
 		// This payment intent was reset, or processing has re-started without invalidating.
 		if ( 1 < count( $payment_intents_stored ) && $payment_intent_received['status'] === Status::REQUIRES_PAYMENT_METHOD ) {
 			return true;

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -307,6 +307,7 @@ class Order extends Abstract_Order {
 	 * Modify the status of a given order based on Slug.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Added the transient to prevent multiple status changes in a short period.
 	 *
 	 * @throws \Tribe__Repository__Usage_Error
 	 *
@@ -322,6 +323,15 @@ class Order extends Abstract_Order {
 		if ( ! $status ) {
 			return false;
 		}
+
+		// If status change has already been attempted in the last few seconds, bail.
+		$transient_key = 'tec_tickets_tc_order_modify_status_' . $order_id . '_' . $status->get_wp_slug();
+		$transient     = get_transient( $transient_key );
+		if ( $transient ) {
+			return false;
+		}
+
+		set_transient( $transient_key, true, 10 );
 
 		$can_apply = $status->can_apply_to( $order_id, $status );
 		if ( ! $can_apply ) {

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -324,15 +324,6 @@ class Order extends Abstract_Order {
 			return false;
 		}
 
-		// If status change has already been attempted in the last few seconds, bail.
-		$transient_key = 'tec_tickets_tc_order_modify_status_' . $order_id . '_' . $status->get_wp_slug();
-		$transient     = get_transient( $transient_key );
-		if ( $transient ) {
-			return false;
-		}
-
-		set_transient( $transient_key, true, 10 );
-
 		$can_apply = $status->can_apply_to( $order_id, $status );
 		if ( ! $can_apply ) {
 			return $can_apply;

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -307,7 +307,6 @@ class Order extends Abstract_Order {
 	 * Modify the status of a given order based on Slug.
 	 *
 	 * @since 5.1.9
-	 * @since TBD Added the transient to prevent multiple status changes in a short period.
 	 *
 	 * @throws \Tribe__Repository__Usage_Error
 	 *


### PR DESCRIPTION
### 🎫 Ticket
[ET-2256]

### 🗒️ Description
This PR reverts some previous changes we made for a scenario where when a payment fails and is retried and succeeds, the successful order never gets its status changed to Complete.

This PR fixes the issue where multiple attendees are being created on orders.

### 🎥 Artifacts <!-- if applicable-->
N/A

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2256]: https://stellarwp.atlassian.net/browse/ET-2256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ