### PR TITLE
Prevent event capacity being updated while service is down

### DIFF
--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -102,14 +102,6 @@ class Controller extends Controller_Contract {
 		add_filter( 'tec_tickets_get_ticket_counts', [ $this, 'set_event_stock_counts' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ $this, 'prevent_capacity_saves_without_service' ], 1, 4 );
 		add_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10, 4 );
-
-		add_action( 'updated_postmeta', function ( $meta_id, $update_object_id, $update_meta_key, $update_meta_value ) {
-			if ( '_tribe_ticket_capacity' !== $update_meta_key ) {
-				return;
-			}
-
-			$who = 'test';
-		}, 10, 4 );
 	}
 
 	/**

--- a/src/Tickets/Seating/Service/Seat_Types.php
+++ b/src/Tickets/Seating/Service/Seat_Types.php
@@ -424,7 +424,7 @@ class Seat_Types {
 			++$total_updated;
 		}
 
-		add_action( 'updated_post_metadata', [ tribe( Commerce_Controller::class ), 'handle_ticket_meta_update' ], 10, 4 );
+		add_action( 'update_post_metadata', [ tribe( Commerce_Controller::class ), 'handle_ticket_meta_update' ], 10, 4 );
 
 		return $total_updated;
 	}


### PR DESCRIPTION
### 🎫 Ticket

Issue 219 from gsheet

On top of the applied fix yesterday:

- Fixing a typo
- Preventing updates while service is down in different callback for both Tickets and Ticketable post types using Seating.