### PR TITLE
SLR - do not clear session for incomplete orders

### DIFF
--- a/src/Tickets/Seating/Frontend/Session.php
+++ b/src/Tickets/Seating/Frontend/Session.php
@@ -322,9 +322,11 @@ class Session {
 	 *
 	 * @since TBD
 	 *
+	 * @param bool $delete_token_session Whether to delete the token session after confirming the reservations.
+	 *
 	 * @return bool Whether the reservations were confirmed or not.
 	 */
-	public function confirm_all_reservations(): bool {
+	public function confirm_all_reservations(bool $delete_token_session = true): bool {
 		$confirmed = true;
 
 		foreach ( $this->get_entries() as $post_id => $token ) {
@@ -334,8 +336,11 @@ class Session {
 				continue;
 			}
 
-			$confirmed &= $this->reservations->confirm( $post_id, $reservation_uuids )
-							&& $this->sessions->delete_token_session( $token );
+			$confirmed = $this->reservations->confirm( $post_id, $reservation_uuids );
+
+			if ( $confirmed && $delete_token_session ) {
+				$confirmed &= $this->sessions->delete_token_session( $token );
+			}
 		}
 
 		return $confirmed;

--- a/src/Tickets/Seating/Orders/Controller.php
+++ b/src/Tickets/Seating/Orders/Controller.php
@@ -14,6 +14,7 @@ use TEC\Common\lucatume\DI52\Container;
 use TEC\Common\StellarWP\Assets\Asset;
 use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Admin\Attendees\Page as Attendee_Page;
+use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Shortcodes\Checkout_Shortcode;
 use TEC\Tickets\Seating\Admin\Ajax;
 use TEC\Tickets\Seating\Ajax_Methods;
@@ -31,6 +32,7 @@ use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use Tribe__Tickets__Tickets as Tickets;
 use WP_Post;
 use WP_Query;
+use TEC\Tickets\Commerce\Status\Status_Interface;
 
 /**
  * Class Controller
@@ -166,7 +168,11 @@ class Controller extends Controller_Contract {
 		// Attendee delete handler.
 		add_filter( 'tec_tickets_commerce_attendee_to_delete', [ $this, 'handle_attendee_delete' ] );
 
-		add_action( 'tec_tickets_commerce_flag_action_generated_attendees', [ $this, 'confirm_all_reservations' ] );
+		add_action( 'tec_tickets_commerce_flag_action_generated_attendees', [ $this, 'confirm_all_reservations' ], 10, 4 );
+		add_action(
+			'tec_tickets_commerce_order_status_flag_complete',
+			[ $this, 'confirm_all_reservations_on_completion' ]
+		);
 		add_action( 'wp_ajax_' . Ajax::ACTION_FETCH_ATTENDEES, [ $this, 'fetch_attendees_by_post' ] );
 		add_action( 'wp_ajax_' . Ajax::ACTION_RESERVATION_CREATED, [ $this, 'update_reservation' ] );
 		add_action( 'wp_ajax_' . Ajax::ACTION_RESERVATION_UPDATED, [ $this, 'update_reservation' ] );
@@ -247,6 +253,10 @@ class Controller extends Controller_Contract {
 		remove_filter( 'post_row_actions', [ $this, 'add_seats_row_action' ] );
 
 		remove_action( 'tec_tickets_commerce_flag_action_generated_attendees', [ $this, 'confirm_all_reservations' ] );
+		remove_action(
+			'tec_tickets_commerce_order_status_flag_complete',
+			[ $this, 'confirm_all_reservations_on_completion' ]
+		);
 		remove_action( 'wp_ajax_' . Ajax::ACTION_FETCH_ATTENDEES, [ $this, 'fetch_attendees_by_post' ] );
 		remove_action( 'wp_ajax_' . Ajax::ACTION_RESERVATION_CREATED, [ $this, 'update_reservation' ] );
 		remove_action( 'wp_ajax_' . Ajax::ACTION_RESERVATION_UPDATED, [ $this, 'update_reservation' ] );
@@ -346,7 +356,7 @@ class Controller extends Controller_Contract {
 		if ( ! $post ) {
 			return;
 		}
-		
+
 		if ( ! tec_tickets_seating_enabled( $post->ID ) ) {
 			return;
 		}
@@ -455,14 +465,22 @@ class Controller extends Controller_Contract {
 	}
 
 	/**
-	 * Confirms all the reservations contained in the Session cookie.
+	 * Confirms all the reservations contained in the Session cookie on generation of an Attendee.
+	 * If the order status is complete, it will also delete the token session.
 	 *
 	 * @since TBD
 	 *
+	 * @param array<Attendee>          $attendees  The generated attendees, unused.
+	 * @param \Tribe__Tickets__Tickets $ticket     The ticket the attendee is generated for, unused.
+	 * @param \WP_Post                 $order      The order the attendee is generated for, unused.
+	 * @param Status_Interface         $new_status New post status.
+	 *
 	 * @return void
 	 */
-	public function confirm_all_reservations(): void {
-		$this->session->confirm_all_reservations();
+	public function confirm_all_reservations($attendees, $ticket, $order, $new_status): void {
+		$incomplete_flags = array_intersect( $new_status->get_flags(), [ 'incomplete', 'count_incomplete' ] );
+		$delete_session   = count( $incomplete_flags ) === 0;
+		$this->session->confirm_all_reservations( $delete_session );
 	}
 
 	/**
@@ -785,5 +803,16 @@ class Controller extends Controller_Contract {
 	 */
 	public function add_seats_row_action( array $actions, $post ): array {
 		return $this->seats_report->add_seats_row_action( $actions, $post );
+	}
+
+	/**
+	 * On completion of a TC Order, confirm all the reservations and clear the session.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function confirm_all_reservations_on_completion(): void {
+		$this->session->confirm_all_reservations();
 	}
 }


### PR DESCRIPTION
This updates the logic used to confirm attendee reservations and clear
the current seat selection session to make sure the session will not be
cleared when the order is not complete (e.g. a pending one).

If the session is incorrectly cleared, then the frontend timer will not
find the session information and will expire sending the user a time-out
message and a redirection dialog. This will happen if the user cannot
complete the payment correctly after a failure (that would generate
attendees and a pending order) in the grace time.

Avoiding the session clear in those instances of failed payment will
allow the user to try and complete the payment beyond the grace period,
provided they still have time to do it.

TODO:
- [ ] Change timer grace time (maybe?)
- [ ] On timeout, along with the session the pending attendees should be removed
- [ ] Automated tests   
