### PR TITLE
SLR - Remove AR page concern

### DIFF
--- a/src/Tickets/Seating/Frontend/Timer.php
+++ b/src/Tickets/Seating/Frontend/Timer.php
@@ -493,19 +493,8 @@ class Timer extends Controller_Contract {
 			return;
 		}
 
-		$is_auto = 1 === (int) tribe_get_request_var( 'auto', 0 );
-
-		if ( $is_auto ) {
-			$is_ar_page = tribe( Attendee_Registration::class )->get_url();
-			$referrer   = wp_get_referer();
-
-			// IMPORTANT: This is an automatic interrupt, originating from the AR page. We want to ignore it!
-			if ( $referrer && $is_ar_page === explode( '?', $referrer )['0'] ) {
-				return;
-			}
-		}
-
 		[ $token, $post_id ] = $token_and_post_id;
+
 
 		$post_type             = get_post_type( $post_id );
 		$post_type_object      = get_post_type_object( $post_type );

--- a/src/Tickets/Seating/app/frontend/session/index.js
+++ b/src/Tickets/Seating/app/frontend/session/index.js
@@ -466,7 +466,6 @@ export function beaconInterrupt() {
 	requestUrl.searchParams.set('action', ACTION_INTERRUPT_GET_DATA);
 	requestUrl.searchParams.set('postId', postId);
 	requestUrl.searchParams.set('token', token);
-	requestUrl.searchParams.set('auto', 1);
 
 	window.navigator.sendBeacon(requestUrl.toString());
 }

--- a/tests/slr_integration/Admin/Maps_Layout_Homepage_Test.php
+++ b/tests/slr_integration/Admin/Maps_Layout_Homepage_Test.php
@@ -207,7 +207,7 @@ class Maps_Layout_Homepage_Test extends WPTestCase {
 				[
 					'id'            => 'layout-uuid-1',
 					'name'          => 'Layout 1',
-					'mapId'         => 'a',
+					'mapId'         => 'map-uuid-1',
 					'seats'         => 100,
 					'screenshotUrl' => 'https://example.com/150',
 					'createdDate'   => '1716901924',
@@ -215,7 +215,7 @@ class Maps_Layout_Homepage_Test extends WPTestCase {
 				[
 					'id'            => 'layout-uuid-2',
 					'name'          => 'Layout 2',
-					'mapId'         => 'b',
+					'mapId'         => 'map-uuid-2',
 					'seats'         => 200,
 					'screenshotUrl' => 'https://example.com/150',
 					'createdDate'   => '1716901924',
@@ -223,7 +223,7 @@ class Maps_Layout_Homepage_Test extends WPTestCase {
 				[
 					'id'            => 'layout-uuid-3',
 					'name'          => 'Layout 3',
-					'mapId'         => 'c',
+					'mapId'         => 'map-uuid-3',
 					'seats'         => 300,
 					'screenshotUrl' => 'https://example.com/150',
 					'createdDate'   => '1716901924',

--- a/tests/slr_integration/Frontend/Timer_Test.php
+++ b/tests/slr_integration/Frontend/Timer_Test.php
@@ -713,63 +713,6 @@ class Timer_Test extends Controller_Test_Case {
 		);
 	}
 
-	/**
-	 * @dataProvider interrupt_data_provider
-	 */
-	public function test_auto_ajax_interrupt( \Closure $fixture ): void {
-		$post_id = $fixture();
-
-		// Create a previous session.
-		$session      = tribe( Session::class );
-		$sessions     = tribe( Sessions::class );
-		$reservations = tribe( Reservations::class );
-		$session->add_entry( $post_id, 'test-token' );
-		update_post_meta( $post_id, Meta::META_KEY_UUID, 'test-post-uuid' );
-		$sessions->upsert( 'test-token', $post_id, time() + 100 );
-		$mock_reservations = $this->create_mock_reservations_data( [ $post_id ], 3 );
-		$sessions->update_reservations( 'test-token', $mock_reservations );
-
-		// Set up the request context.
-		$_REQUEST['_ajax_nonce'] = wp_create_nonce( Session::COOKIE_NAME );
-		$_REQUEST['token']       = 'test-token';
-		$_REQUEST['postId']      = $post_id;
-		$_REQUEST['auto']        = 1;
-		$this->set_class_fn_return( Attendee_Registration::class, 'get_url', 'https://test.url/ar-page/' );
-		$this->set_fn_return( 'wp_get_referer', 'https://test.url/ar-page/' );
-		$this->set_oauth_token( 'auth-token' );
-
-		$timer = $this->make_controller();
-		$timer->register();
-
-		do_action( 'wp_ajax_nopriv_' . Timer::ACTION_INTERRUPT_GET_DATA );
-
-		$this->assertEquals( $mock_reservations, $sessions->get_reservations_for_token( 'test-token' ) );
-		$this->assertEquals( [ $post_id => 'test-token' ], $session->get_entries() );
-
-		$db_object = DB::get_row(
-			DB::prepare(
-				"SELECT * FROM %i WHERE token = %s",
-				Sessions::table_name(),
-				'test-token'
-			)
-			);
-		$this->assertEquals(
-			'test-token',
-			$db_object->token,
-			'On auto interruption from AR page, the token session should NOT have been removed from the database.'
-		);
-		$this->assertEquals(
-			(string) $post_id,
-			$db_object->object_id,
-			'On auto interruption from AR page, the token session should NOT have been removed from the database.'
-		);
-		$this->assertEquals(
-			wp_json_encode( $mock_reservations ),
-			$db_object->reservations,
-			'On auto interruption from AR page, the token session should NOT have been removed from the database.'
-		);
-	}
-
 	public function test_ajax_interrupt_fails_if_reservation_cancellation_fails(): void {
 		$post_id = static::factory()->post->create();
 		// Create a previous session.

--- a/tests/slr_jest/frontend/session.spec.js
+++ b/tests/slr_jest/frontend/session.spec.js
@@ -182,7 +182,7 @@ describe('Seat Selection Session', () => {
 		beaconInterrupt();
 
 		expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
-			'https://wordpress.test/wp-admin/admin-ajax.php?_ajaxNonce=1234567890&action=tec_tickets_seating_session_interrupt_get_data&postId=23&token=test-token&auto=1'
+			'https://wordpress.test/wp-admin/admin-ajax.php?_ajaxNonce=1234567890&action=tec_tickets_seating_session_interrupt_get_data&postId=23&token=test-token'
 		);
 	});
 });


### PR DESCRIPTION
Remove the knowledge and concern of the AR page to let ET+ logic deal
with that. Update tests to follow.

[Releatet ET+ PR](https://github.com/the-events-calendar/event-tickets-plus/pull/1655)
