### PR TITLE
SLR - fix issue 242

### DIFF
--- a/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
+++ b/src/Tickets/Seating/app/blockEditor/hook-callbacks.js
@@ -297,13 +297,6 @@ export const filterButtonIsDisabled = (isDisabled, state, ownProps) => {
 	return false;
 };
 
-export function captureCapacityTableMappedProps(mappedProps) {
-	const store = select(storeName);
-	store.setTicketsSharedCapacity(mappedProps.sharedCapacity || 0);
-
-	return mappedProps;
-}
-
 /**
  * Filters the shared capacity input component to return an uneditable number if the seating feature is enabled
  * for the current post.

--- a/src/Tickets/Seating/app/blockEditor/store/common-store-bridge.js
+++ b/src/Tickets/Seating/app/blockEditor/store/common-store-bridge.js
@@ -10,6 +10,7 @@ import {
 import {
 	getTicketId,
 	getTicketsSharedCapacityInt,
+	getTicketsProvider,
 } from '@moderntribe/tickets/data/blocks/ticket/selectors';
 import { CAPPED } from '@moderntribe/tickets/data/blocks/ticket/constants';
 
@@ -102,4 +103,20 @@ export function getTicketIdFromCommonStore(clientId) {
  */
 export function getTicketsSharedCapacityFromCommonStore() {
 	return selectFromCommonStore(getTicketsSharedCapacityInt);
+}
+
+/**
+ * Returns the current Ticket provider fetched from the Common store.
+ *
+ * @since TBD
+ *
+ * @return {string} The current ticket Provider fetched from the Common store,
+ *                  or an empty string if the Ticket block client ID is not set.
+ */
+export function getTicketProviderFromCommonStore() {
+	try {
+		return selectFromCommonStore(getTicketsProvider);
+	} catch (e) {
+		return '';
+	}
 }

--- a/src/Tickets/Seating/app/blockEditor/store/compatibility.js
+++ b/src/Tickets/Seating/app/blockEditor/store/compatibility.js
@@ -1,0 +1,18 @@
+import { getTicketProviderFromCommonStore } from './common-store-bridge';
+
+/**
+ * Returns whether the current ticket provider supports Seating or not.
+ *
+ * This value cannot be read from data localized by the backend since the user
+ * will be able to change the ticket provider live, while the post, or Ticket,
+ * editing is happening.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the current ticket provider supports seating or not.
+ */
+export function currentProviderSupportsSeating() {
+	const provider = getTicketProviderFromCommonStore();
+
+	return 'TEC\\Tickets\\Commerce\\Module' === provider;
+}

--- a/src/Tickets/Seating/app/blockEditor/store/selectors.js
+++ b/src/Tickets/Seating/app/blockEditor/store/selectors.js
@@ -1,8 +1,9 @@
 import { getTicketIdFromCommonStore } from './common-store-bridge';
+import { currentProviderSupportsSeating } from './compatibility';
 
 export const selectors = {
 	isUsingAssignedSeating(state) {
-		return state.isUsingAssignedSeating;
+		return state.isUsingAssignedSeating && currentProviderSupportsSeating();
 	},
 	getLayouts(state) {
 		return state.layouts;

--- a/tests/slr_jest/blockEditor/store/compatibility.spec.js
+++ b/tests/slr_jest/blockEditor/store/compatibility.spec.js
@@ -1,0 +1,42 @@
+import { currentProviderSupportsSeating } from '@tec/tickets/seating/blockEditor/store/compatibility';
+import commonStoreBridge from '@tec/tickets/seating/blockEditor/store/common-store-bridge';
+jest.mock('@tec/tickets/seating/blockEditor/store/common-store-bridge', () => ({
+	getTicketProviderFromCommonStore: jest.fn(),
+}));
+
+describe('compatibility.js', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.resetAllMocks();
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe('currentProviderSupportsSeating', () => {
+		test('returns false if current provider is empty string', () => {
+			commonStoreBridge.getTicketProviderFromCommonStore.mockReturnValue(
+				''
+			);
+
+			expect(currentProviderSupportsSeating()).toBe(false);
+		});
+
+		test('returns true if current provider is Tickets Commerce', ()=>{
+			commonStoreBridge.getTicketProviderFromCommonStore.mockReturnValue(
+				'TEC\\Tickets\\Commerce\\Module'
+			);
+
+			expect(currentProviderSupportsSeating()).toBe(true);
+		});
+
+		test('returns true if current provider is not Tickets Commerce', () => {
+			commonStoreBridge.getTicketProviderFromCommonStore.mockReturnValue(
+				'Some__Other__Provider'
+			);
+
+			expect(currentProviderSupportsSeating()).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Fixes issue 242 from the issue sheet where creation and edit of a ticket using WooCommerce as provider would not be possible.

All the filtering applied by the Seating feature to the Block Editor relies on the `isUsingAssignedSeating` selector return value.
This fix ensures the return value will be consistently false if the current ticket provider is not Tickets Commerce.
