### PR TITLE
Fix initial using seating state by considering license status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-### [5.16.1] 2024-10-31
+### [5.16.1] 2024-11-04
 
 * Fix - Attendee Registration page will work with FSE Themes. [ET-2261]
+* Fix - Issue preventing ticket creation on an unsaved ticket-able post type, while no Seating license is present. [ET-2264]
 
 ### [5.16.0.1] 2024-10-30
 

--- a/readme.txt
+++ b/readme.txt
@@ -203,9 +203,10 @@ Check out our extensive [knowledgebase](https://evnt.is/18wm) for articles on us
 
 == Changelog ==
 
-= [5.16.1] 2024-10-31 =
+= [5.16.1] 2024-11-04 =
 
 * Fix - Attendee Registration page will work with FSE Themes. [ET-2261]
+* Fix - Issue preventing ticket creation on an unsaved ticket-able post type, while no Seating license is present. [ET-2264]
 
 = [5.16.0.1] 2024-10-30 =
 

--- a/src/Tickets/Seating/Editor.php
+++ b/src/Tickets/Seating/Editor.php
@@ -59,7 +59,7 @@ class Editor extends \TEC\Common\Contracts\Provider\Controller {
 	 */
 	public function get_store_data(): array {
 		if ( tribe_context()->is_new_post() ) {
-			// New posts will always use assigned seating.
+			// New posts will always use assigned seating as long as license exists.
 			$is_using_assigned_seating = true;
 			$layout_id                 = null;
 			$seat_types_by_post_id     = [];
@@ -87,7 +87,7 @@ class Editor extends \TEC\Common\Contracts\Provider\Controller {
 		$service_status = $service->get_status();
 
 		return [
-			'isUsingAssignedSeating' => $is_using_assigned_seating,
+			'isUsingAssignedSeating' => ! $service_status->has_no_license() && $is_using_assigned_seating,
 			'layouts'                => $service->get_layouts_in_option_format(),
 			'seatTypes'              => $layout_id ? $service->get_seat_types_by_layout( $layout_id ) : [],
 			'currentLayoutId'        => $layout_id,

--- a/src/Tickets/Seating/Editor.php
+++ b/src/Tickets/Seating/Editor.php
@@ -87,6 +87,7 @@ class Editor extends \TEC\Common\Contracts\Provider\Controller {
 		$service_status = $service->get_status();
 
 		return [
+			// isUsingAssignedSeating should never be true when there is no license. The ASC controls are hidden when no license is there.
 			'isUsingAssignedSeating' => ! $service_status->has_no_license() && $is_using_assigned_seating,
 			'layouts'                => $service->get_layouts_in_option_format(),
 			'seatTypes'              => $layout_id ? $service->get_seat_types_by_layout( $layout_id ) : [],

--- a/tests/slr_integration/Editor_Test.php
+++ b/tests/slr_integration/Editor_Test.php
@@ -410,6 +410,81 @@ class Editor_Test extends Controller_Test_Case {
 			}
 		];
 
+		yield 'service down - new' => [
+			function (): array {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::SERVICE_DOWN );
+				}, 1000, 2 );
+				global $pagenow, $post;
+				$pagenow = 'post-new.php';
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$post    = get_post( static::factory()->post->create() );
+
+				return [];
+			}
+		];
+
+		yield 'service not connected - new' => [
+			function (): array {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::NOT_CONNECTED );
+				}, 1000, 2 );
+				global $pagenow, $post;
+				$pagenow = 'post-new.php';
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$post    = get_post( static::factory()->post->create() );
+
+				return [];
+			}
+		];
+
+		yield 'no license - new' => [
+			function (): array {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::NO_LICENSE );
+				}, 1000, 2 );
+				global $pagenow, $post;
+				$pagenow = 'post-new.php';
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$post    = get_post( static::factory()->post->create() );
+
+				return [];
+			}
+		];
+
+		yield 'invalid license - new' => [
+			function (): array {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::INVALID_LICENSE );
+				}, 1000, 2 );
+				global $pagenow, $post;
+				$pagenow = 'post-new.php';
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$post    = get_post( static::factory()->post->create() );
+
+				return [];
+			}
+		];
+
+		yield 'expired license - new' => [
+			function (): array {
+				add_filter( 'tec_tickets_seating_service_status', function ( $_status, $backend_base_url ) {
+					return new Service_Status( $backend_base_url, Service_Status::EXPIRED_LICENSE );
+				}, 1000, 2 );
+				global $pagenow, $post;
+				$pagenow = 'post-new.php';
+				$this->given_many_layouts_in_db( 3 );
+				$this->given_layouts_just_updated();
+				$post    = get_post( static::factory()->post->create() );
+
+				return [];
+			}
+		];
+
 		yield 'existing event, not using meta set or layout set, with tickets' => [
 			function (): array {
 				$id = tribe_events()->set_args( [

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__expired license - new__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__expired license - new__0.snapshot.json
@@ -1,0 +1,30 @@
+{
+    "isUsingAssignedSeating": true,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": null,
+    "seatTypesByPostId": [],
+    "isLayoutLocked": false,
+    "eventCapacity": 0,
+    "serviceStatus": {
+        "ok": false,
+        "status": "expired-license",
+        "connectUrl": "http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&tab=licenses"
+    }
+}

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__invalid license - new__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__invalid license - new__0.snapshot.json
@@ -1,0 +1,30 @@
+{
+    "isUsingAssignedSeating": true,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": null,
+    "seatTypesByPostId": [],
+    "isLayoutLocked": false,
+    "eventCapacity": 0,
+    "serviceStatus": {
+        "ok": false,
+        "status": "invalid-license",
+        "connectUrl": "http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&tab=licenses"
+    }
+}

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__no license - new__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__no license - new__0.snapshot.json
@@ -1,0 +1,30 @@
+{
+    "isUsingAssignedSeating": false,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": null,
+    "seatTypesByPostId": [],
+    "isLayoutLocked": false,
+    "eventCapacity": 0,
+    "serviceStatus": {
+        "ok": false,
+        "status": "no-license",
+        "connectUrl": "http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&tab=licenses"
+    }
+}

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__service down - new__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__service down - new__0.snapshot.json
@@ -1,0 +1,30 @@
+{
+    "isUsingAssignedSeating": true,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": null,
+    "seatTypesByPostId": [],
+    "isLayoutLocked": false,
+    "eventCapacity": 0,
+    "serviceStatus": {
+        "ok": false,
+        "status": "down",
+        "connectUrl": "http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&tab=licenses"
+    }
+}

--- a/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__service not connected - new__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Editor_Test__test_get_store_data__service not connected - new__0.snapshot.json
@@ -1,0 +1,30 @@
+{
+    "isUsingAssignedSeating": true,
+    "layouts": [
+        {
+            "id": "layout-1",
+            "name": "Test layout 1",
+            "seats": "1"
+        },
+        {
+            "id": "layout-2",
+            "name": "Test layout 2",
+            "seats": "2"
+        },
+        {
+            "id": "layout-3",
+            "name": "Test layout 3",
+            "seats": "3"
+        }
+    ],
+    "seatTypes": [],
+    "currentLayoutId": null,
+    "seatTypesByPostId": [],
+    "isLayoutLocked": false,
+    "eventCapacity": 0,
+    "serviceStatus": {
+        "ok": false,
+        "status": "not-connected",
+        "connectUrl": "http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&tab=licenses"
+    }
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2264]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The issue becomes apparent on the FE specifically by the method [isUsingAssignedSeating](https://github.com/the-events-calendar/event-tickets/blob/127d60be346fd2c19d4ba167297974faa9b0e733/src/Tickets/Seating/app/blockEditor/store/selectors.js#L5).

When there is no seating license the GAC vs Seating radio controller is not present in the FE. So there is no way to change that property, resulting in wrong evaluations of the `isDisabled` filter for the "Create Ticket" button. It is being evaluated as ASC ticket instead of GAC while the ASC controls are hidden.


For testing use the below's snippet possibilities to test creating a new ticketable post type. Make sure in every case the block gives you the posibility to create a new ticket.

```php
add_filter( 'tec_tickets_seating_service_status', static function ( $_status, $backend_base_url ) {
	return new Service_Status( $backend_base_url, Service_Status::OK );
	// return new Service_Status( $backend_base_url, Service_Status::NO_LICENSE );
	// return new Service_Status( $backend_base_url, Service_Status::EXPIRED_LICENSE );
//	return new Service_Status( $backend_base_url, Service_Status::SERVICE_DOWN );
//	return new Service_Status( $backend_base_url, Service_Status::NOT_CONNECTED );
	// return new Service_Status( $backend_base_url, Service_Status::INVALID_LICENSE );
}, 10, 2 );
```

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2264]: https://stellarwp.atlassian.net/browse/ET-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ