### PR TITLE
SLR - Fix Attendee seat assignment in some flows

### DIFF
--- a/src/Tickets/Seating/Orders/Cart.php
+++ b/src/Tickets/Seating/Orders/Cart.php
@@ -116,8 +116,7 @@ class Cart {
 	 */
 	private function get_session_stack( string $token, int $object_id, int $ticket_id ): Generator {
 		if ( ! isset( $this->session_stacks[ $object_id ][ $ticket_id ] ) ) {
-			$reservations = $this->sessions->get_reservations_for_token( $token );
-			foreach ( $reservations as $reservation_ticket_id => $reservation_data ) {
+			foreach ( $this->get_token_reservations( $token ) as $reservation_ticket_id => $reservation_data ) {
 				$generator = static fn(): Generator => yield from $reservation_data;
 				$this->session_stacks[ $object_id ][ $reservation_ticket_id ] = $generator();
 			}
@@ -214,5 +213,49 @@ class Cart {
 				break;
 			}
 		}
+	}
+
+	/**
+	 * Fetches the token reservations either from the cache or from the database.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $token The token to fetch the reservations for.
+	 *
+	 * @return array<int,array{
+	 *     reservation_id: string,
+	 *     seat_type_id: string,
+	 *     seat_label: string,
+	 * }> The list of reservations for the given token.
+	 */
+	private function get_token_reservations( string $token ): array {
+		$cache        = tribe_cache();
+		$memo_key     = 'tec_tc_session_token_reservations';
+		$reservations = $cache[ $memo_key ] ?? null;
+
+		if ( ! is_array( $reservations ) ) {
+			$reservations       = $this->sessions->get_reservations_for_token( $token );
+			$cache[ $memo_key ] = $reservations;
+		}
+
+		return $reservations;
+	}
+
+	/**
+	 * Warms up the session caches that might be needed later.
+	 *
+	 * @since TBD
+	 *
+	 * @return void The method does not return a valued, the cache is warmed up.
+	 */
+	public function warmup_caches(): void {
+		[ $token ] = $this->get_session_token_object_id();
+
+		if ( empty( $token ) ) {
+			return;
+		}
+
+		/** @noinspection UnusedFunctionResultInspection */
+		$this->get_token_reservations( $token );
 	}
 }

--- a/src/Tickets/Seating/Orders/Controller.php
+++ b/src/Tickets/Seating/Orders/Controller.php
@@ -837,6 +837,9 @@ class Controller extends Controller_Contract {
 	 * @return void
 	 */
 	public function confirm_all_reservations_on_completion(): void {
+		// Attendees needing the session information will likely be generated after, warmup the session cache now.
+		$this->cart->warmup_caches();
+
 		$this->session->confirm_all_reservations();
 	}
 }

--- a/src/Tickets/Seating/Tables/Sessions.php
+++ b/src/Tickets/Seating/Tables/Sessions.php
@@ -215,10 +215,9 @@ class Sessions extends Table {
 	 *     reservation_id: string,
 	 *     seat_type_id: string,
 	 *     seat_label: string,
-	 * }> The list of reservations for the given object ID. A map from ticket ID to a list of reservations for it.
+	 * }> The list of reservations for the given token.
 	 */
 	public function get_reservations_for_token( string $token ) {
-
 		try {
 			$query        = DB::prepare(
 				'SELECT reservations FROM %i WHERE token = %s ',

--- a/tests/slr_integration/Orders/Cart_Test.php
+++ b/tests/slr_integration/Orders/Cart_Test.php
@@ -8,6 +8,7 @@ use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Shortcodes\Checkout_Shortcode;
 use TEC\Tickets\Seating\Frontend\Session;
 use TEC\Tickets\Seating\Meta;
+use TEC\Tickets\Seating\Tables\Sessions;
 use TEC\Tickets\Seating\Tables\Sessions as Sessions_Table;
 use Tribe\Shortcode\Manager;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
@@ -157,7 +158,7 @@ class Cart_Test extends WPTestCase {
 		$this->assertEquals( 'seat-type-id-1', get_post_meta( $attendee_4, Meta::META_KEY_SEAT_TYPE, true ) );
 		$this->assertEquals( 'layout-uuid-1', get_post_meta( $attendee_4, Meta::META_KEY_LAYOUT_ID, true ) );
 	}
-	
+
 	/**
 	 * @test
 	 *
@@ -173,29 +174,29 @@ class Cart_Test extends WPTestCase {
 		$ticket_2 = $this->create_tc_ticket( $post, 20 );
 		update_post_meta( $ticket_2, Meta::META_KEY_LAYOUT_ID, 'layout-uuid-1' );
 		update_post_meta( $ticket_2, Meta::META_KEY_ENABLED, 1 );
-		
+
 		// Create the expired session information.
 		$session = tribe( Session::class );
 		$session->add_entry( $post, 'test-token' );
 		$sessions_table = tribe( Sessions_Table::class );
 		$sessions_table->upsert( 'test-token', $post, time() + 100 );
 		$sessions_table->update_reservations( 'test-token', $this->create_mock_reservations_data( [ $ticket_1, $ticket_2 ], 2 ) );
-		
+
 		$tc_cart = tribe( TicketsCommerce_Cart::class );
-		
+
 		$tc_cart->add_ticket( $ticket_1, 2 );
 		$tc_cart->add_ticket( $ticket_2, 2 );
-		
+
 		$shortcode_manager = new Manager();
 		$shortcode_manager->add_shortcodes();
-		
+
 		$html = do_shortcode( '[tec_tickets_checkout]' );
-		
+
 		// The cart HTML should be showing session timer, items and not be empty.
 		$this->assertContains( 'tribe-tickets__commerce-checkout-cart-items', $html );
 		$this->assertNotContains( 'tribe-tickets__commerce-checkout-cart-empty', $html );
 	}
-	
+
 	/**
 	 * @test
 	 *
@@ -211,28 +212,28 @@ class Cart_Test extends WPTestCase {
 		$ticket_2 = $this->create_tc_ticket( $post, 20 );
 		update_post_meta( $ticket_2, Meta::META_KEY_LAYOUT_ID, 'layout-uuid-1' );
 		update_post_meta( $ticket_2, Meta::META_KEY_ENABLED, 1 );
-		
+
 		// Create the expired session information.
 		$session = tribe( Session::class );
 		$session->add_entry( $post, 'test-token' );
 		$sessions_table = tribe( Sessions_Table::class );
 		$sessions_table->upsert( 'test-token', $post, time() - 100 );
 		$sessions_table->update_reservations( 'test-token', $this->create_mock_reservations_data( [ $ticket_1, $ticket_2 ], 2 ) );
-		
+
 		$tc_cart = tribe( TicketsCommerce_Cart::class );
-		
+
 		$tc_cart->add_ticket( $ticket_1, 2 );
 		$tc_cart->add_ticket( $ticket_2, 2 );
-		
+
 		$shortcode_manager = new Manager();
 		$shortcode_manager->add_shortcodes();
-		
+
 		$html = do_shortcode( '[tec_tickets_checkout]' );
-		
+
 		// As the session info is expired the cart should be empty.
 		$this->assertContains( 'tribe-tickets__commerce-checkout-cart-empty', $html );
 	}
-	
+
 	/**
 	 * @test
 	 *
@@ -248,18 +249,54 @@ class Cart_Test extends WPTestCase {
 		$ticket_2 = $this->create_tc_ticket( $post, 20 );
 		update_post_meta( $ticket_2, Meta::META_KEY_LAYOUT_ID, 'layout-uuid-1' );
 		update_post_meta( $ticket_2, Meta::META_KEY_ENABLED, 1 );
-		
+
 		$tc_cart = tribe( TicketsCommerce_Cart::class );
-		
+
 		$tc_cart->add_ticket( $ticket_1, 2 );
 		$tc_cart->add_ticket( $ticket_2, 2 );
-		
+
 		$shortcode_manager = new Manager();
 		$shortcode_manager->add_shortcodes();
-		
+
 		$html = do_shortcode( '[tec_tickets_checkout]' );
-		
+
 		// As we only have added seated tickets but no session data was added, the cart should be empty.
 		$this->assertContains( 'tribe-tickets__commerce-checkout-cart-empty', $html );
+	}
+
+	public function test_cache_warmup(): void {
+		$post = self::factory()->post->create();
+		update_post_meta( $post, Meta::META_KEY_ENABLED, true );
+		update_post_meta( $post, Meta::META_KEY_LAYOUT_ID, 'layout-uuid-1' );
+		$ticket = $this->create_tc_ticket( $post, 10 );
+		update_post_meta( $ticket, Meta::META_KEY_LAYOUT_ID, 'layout-uuid-1' );
+		// Create the session information.
+		$session = tribe( Session::class );
+		$session->add_entry( $post, 'test-token' );
+		$sessions_table = tribe( Sessions_Table::class );
+		$sessions_table->upsert( 'test-token', $post, time() + 100 );
+		$sessions_table->update_reservations( 'test-token', $this->create_mock_reservations_data( [ $ticket ], 1 ) );
+		$attendee                    = $this->create_attendee_for_ticket( $ticket, $post );
+		$attendee_object             = get_post( $attendee );
+		$attendee_object->event_id   = $post;
+		$attendee_object->product_id = $ticket;
+		$ticket_object               = tribe( Module::class )->get_ticket( $post, $ticket );
+
+		$cart = tribe( Cart::class );
+
+		// Warm-up the caches.
+		$cart->warmup_caches();
+
+		// Now clear the sessions.
+		$sessions = tribe( Sessions::class );
+		$sessions->delete_token_session( 'test-token' );
+		$this->assertEmpty( $sessions->get_reservations_for_token( 'test-token' ) );
+
+		$cart->save_seat_data_for_attendee( $attendee_object, $ticket_object );
+
+		$this->assertEquals( 'reservation-id-1', get_post_meta( $attendee, Meta::META_KEY_RESERVATION_ID, true ) );
+		$this->assertEquals( 'seat-label-0-1', get_post_meta( $attendee, Meta::META_KEY_ATTENDEE_SEAT_LABEL, true ) );
+		$this->assertEquals( 'seat-type-id-0', get_post_meta( $attendee, Meta::META_KEY_SEAT_TYPE, true ) );
+		$this->assertEquals( 'layout-uuid-1', get_post_meta( $attendee, Meta::META_KEY_LAYOUT_ID, true ) );
 	}
 }


### PR DESCRIPTION
[SL-233](https://stellarwp.atlassian.net/browse/SL-233)

Artifacts:
* tests
* [before](https://share.cleanshot.com/TwJRcwDj)
* [after](https://share.cleanshot.com/PjkyDsQQ)

This updates the code around seat assigment to Attendees to take into
account different stock reduction flows, hence Attendee generation
flows.

Depending on when the stock should be reduced and the Attendee
generated, the data required to assign Attendees might still be in the
session or not.

This updates the code to handle both instances and warmup caches used by
the Cart to assign Attendees in either cases.


[SL-233]: https://stellarwp.atlassian.net/browse/SL-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ