### PR TITLE
[ET-2263] Remove Ticket Duration tooltips

### DIFF
--- a/changelog/tweak-ET-2263-remove-sale-dates-tooltip
+++ b/changelog/tweak-ET-2263-remove-sale-dates-tooltip
@@ -1,4 +1,4 @@
 Significance: minor
 Type: tweak
 
-Removed irrelevant ticket duration tooltips. [ET-2263]
+Removed outdated ticket duration tooltips. [ET-2263]

--- a/changelog/tweak-ET-2263-remove-sale-dates-tooltip
+++ b/changelog/tweak-ET-2263-remove-sale-dates-tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Removed irrelevant ticket duration tooltips. [ET-2263]

--- a/src/Tickets/Admin/Panels_Data/Ticket_Panel_Data.php
+++ b/src/Tickets/Admin/Panels_Data/Ticket_Panel_Data.php
@@ -48,6 +48,7 @@ class Ticket_Panel_Data {
 	 * Dumps the data to array format.
 	 *
 	 * @since 5.8.0
+	 * @since TBD Removed start and end date help text.
 	 *
 	 * @return array<string,mixed> The data in array format.
 	 */
@@ -117,16 +118,6 @@ class Ticket_Panel_Data {
 			tribe_get_ticket_label_singular( 'input_start_time_aria_label' )
 		);
 
-		$ticket_start_date_help_text = sprintf(
-		// Translators: %s: dynamic 'tickets' text.
-			_x(
-				'If you do not set a start sale date, %s will be available immediately.',
-				'input start time help text title',
-				'event-tickets'
-			),
-			tribe_get_ticket_label_plural_lowercase( 'input_start_time_help_text_title' )
-		);
-
 		$ticket_end_date_aria_label = sprintf(
 		// Translators: %s: dynamic 'Ticket' text.
 			_x(
@@ -136,29 +127,6 @@ class Ticket_Panel_Data {
 			),
 			tribe_get_ticket_label_singular( 'input_end_time_aria_label' )
 		);
-
-		$is_event = class_exists( TEC::class ) && TEC::POSTTYPE === get_post_type( $this->post_id );
-		if ( $is_event ) {
-			$ticket_end_date_help_text = sprintf(
-			// Translators: %s: dynamic 'tickets' text.
-				_x(
-					'If you do not set an end sale date, %s will be available until the event begins.',
-					'input end time help text title',
-					'event-tickets'
-				),
-				tribe_get_ticket_label_plural_lowercase( 'input_end_time_help_text_title' )
-			);
-		} else {
-			$ticket_end_date_help_text = sprintf(
-			// Translators: %s: dynamic 'tickets' text.
-				_x(
-					'If you do not set an end sale date, %s will be available forever.',
-					'input end time help text title',
-					'event-tickets'
-				),
-				tribe_get_ticket_label_plural_lowercase( 'input_end_time_help_text_title' )
-			);
-		}
 
 		$ticket_form_save_text = sprintf(
 		// Translators: %s: dynamic 'tickets' text.
@@ -208,13 +176,11 @@ class Ticket_Panel_Data {
 			'ticket'                           => $ticket,
 			'ticket_description'               => $ticket->description ?? '',
 			'ticket_end_date_aria_label'       => $ticket_end_date_aria_label,
-			'ticket_end_date_help_text'        => $ticket_end_date_help_text,
 			'ticket_end_time'                  => $ticket->end_time ?? '',
 			'ticket_form_save_text'            => $ticket_form_save_text,
 			'ticket_id'                        => $ticket_id,
 			'ticket_name'                      => $ticket->name ?? '',
 			'ticket_start_date_aria_label'     => $ticket_start_date_aria_label,
-			'ticket_start_date_help_text'      => $ticket_start_date_help_text,
 			'ticket_start_time'                => $ticket->start_time ?? '',
 			'timepicker_round'                 => '00:00:00',
 			'timepicker_step'                  => $timepicker_step,

--- a/src/admin-views/editor/panel/fields/dates.php
+++ b/src/admin-views/editor/panel/fields/dates.php
@@ -65,7 +65,6 @@ $default_end_time = '00:00:00';
 			aria-label="<?php echo esc_attr( $ticket_start_date_aria_label ); ?>"
 		/>
 		<span class="helper-text hide-if-js"><?php esc_html_e( 'HH:MM', 'event-tickets' ); ?></span>
-		<span class="dashicons dashicons-editor-help" title="<?php echo esc_attr( $ticket_start_date_help_text ); ?>"></span>
 	</div>
 </div>
 <div class="input_block">
@@ -96,6 +95,5 @@ $default_end_time = '00:00:00';
 			aria-label="<?php echo esc_attr( $ticket_end_date_aria_label ); ?>"
 		/>
 		<span class="helper-text hide-if-js"><?php esc_html_e( 'HH:MM', 'event-tickets' ); ?></span>
-		<span class="dashicons dashicons-editor-help" title="<?php echo esc_attr( $ticket_end_date_help_text ); ?>"></span>
 	</div>
 </div>

--- a/src/admin-views/editor/panel/fields/dates.php
+++ b/src/admin-views/editor/panel/fields/dates.php
@@ -3,8 +3,9 @@
  * The start and end dates field for the ticket editor.
  *
  * @since 5.8.0
+ * @since TBD Removed start and end date tooltips.
  *
- * @version 5.8.0
+ * @version TBD
  *
  * @var string $ticket_start_date The start date of the ticket.
  * @var string $ticket_end_date The end date of the ticket.
@@ -12,8 +13,6 @@
  * @var string $ticket_end_time The end time of the ticket.
  * @var string $ticket_start_date_aria_label The aria label for the start date.
  * @var string $ticket_end_date_aria_label The aria label for the end date.
- * @var string $ticket_start_date_help_text The help text for the start date.
- * @var string $ticket_end_date_help_text The help text for the end date.
  * @var array  $start_date_errors The errors for the start date.
  * @var array  $end_date_errors The errors for the end date.
  * @var string $timepicker_step The timepicker step.

--- a/src/admin-views/editor/panel/ticket.php
+++ b/src/admin-views/editor/panel/ticket.php
@@ -26,7 +26,6 @@
  * @var string                             $ticket_form_save_text            The ticket form save text.
  * @var string                             $ticket_name                      The ticket name.
  * @var string                             $ticket_start_date_aria_label     The ticket start date ARIA attribute.
- * @var string                             $ticket_start_date_help_text      The ticket start date help text.
  * @var string                             $ticket_start_time                The ticket start time.
  * @var string                             $timepicker_round                 The timepicker round.
  * @var string                             $ticket_type                      The type of Ticket the form is for.

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -361,7 +361,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -390,7 +389,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -371,7 +371,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -400,7 +399,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with tickets and RSVPs__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with tickets and RSVPs__0.snapshot.html
@@ -578,7 +578,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -607,7 +606,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -268,7 +268,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -297,7 +296,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of a series with passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of a series with passes__0.snapshot.html
@@ -395,7 +395,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -424,7 +423,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of series with no passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of series with no passes__0.snapshot.html
@@ -268,7 +268,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -297,7 +296,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with no passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with no passes__0.snapshot.html
@@ -226,7 +226,6 @@
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -255,7 +254,6 @@
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with passes__0.snapshot.html
@@ -393,7 +393,6 @@
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -422,7 +421,6 @@
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event by Occurrence provisional ID__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event by Occurrence provisional ID__0.snapshot.html
@@ -389,7 +389,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -418,7 +417,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets and no series passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets and no series passes__0.snapshot.html
@@ -274,7 +274,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -303,7 +302,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets, series has passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets, series has passes__0.snapshot.html
@@ -401,7 +401,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -430,7 +429,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with tickets, RSVPs and passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with tickets, RSVPs and passes__0.snapshot.html
@@ -697,7 +697,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -726,7 +725,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with RSVP__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with RSVP__0.snapshot.html
@@ -361,7 +361,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -390,7 +389,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with ticket__0.snapshot.html
@@ -371,7 +371,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -400,7 +399,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with tickets and RSVPs__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with tickets and RSVPs__0.snapshot.html
@@ -578,7 +578,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -607,7 +606,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event without tickets__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event without tickets__0.snapshot.html
@@ -268,7 +268,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -297,7 +296,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__event__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__event__0.snapshot.html
@@ -266,7 +266,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -295,7 +294,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__post__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__post__0.snapshot.html
@@ -266,7 +266,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -295,7 +294,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
@@ -350,7 +350,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -379,7 +378,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket and sale price__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket and sale price__0.snapshot.html
@@ -371,7 +371,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -400,7 +399,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
@@ -360,7 +360,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -389,7 +388,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
@@ -257,7 +257,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -286,7 +285,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -350,7 +350,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -379,7 +378,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket and sale price__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket and sale price__0.snapshot.html
@@ -371,7 +371,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -400,7 +399,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -360,7 +360,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -389,7 +388,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -257,7 +257,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -286,7 +285,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__event__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__event__0.snapshot.html
@@ -252,7 +252,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -281,7 +280,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available until the event begins."></span>
 	</div>
 </div>
 

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__post__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__post__0.snapshot.html
@@ -252,7 +252,6 @@ New ticket</button><button
 			aria-label="Ticket start date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set a start sale date, tickets will be available immediately."></span>
 	</div>
 </div>
 <div class="input_block">
@@ -281,7 +280,6 @@ New ticket</button><button
 			aria-label="Ticket end date"
 		/>
 		<span class="helper-text hide-if-js">HH:MM</span>
-		<span class="dashicons dashicons-editor-help" title="If you do not set an end sale date, tickets will be available forever."></span>
 	</div>
 </div>
 


### PR DESCRIPTION
### 🎫 Ticket
[ET-2263]

### 🗒️ Description
Due to some recent changes to the ticket duration fields, the tooltips within the classic editor ticket block is no longer relevant, so we are removing them.

### 🎥 Artifacts <!-- if applicable-->
Before:
![image](https://github.com/user-attachments/assets/3ac4d8ab-4a29-4291-992e-6f88b2f75ace)

After:
![image](https://github.com/user-attachments/assets/b84532ac-9997-45cd-8745-e3f0e958a9fd)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2263]: https://stellarwp.atlassian.net/browse/ET-2263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ