### PR TITLE
SLR - more fixes to session clear

### DIFF
--- a/changelog/sl-233-pass-2
+++ b/changelog/sl-233-pass-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: No entry required since it's been covered by a previous entry.
+
+

--- a/src/Tickets/Seating/Frontend.php
+++ b/src/Tickets/Seating/Frontend.php
@@ -204,16 +204,16 @@ class Frontend extends Controller_Contract {
 	 *
 	 * @since 5.16.0
 	 *
-	 * @param int $event_id The event ID.
+	 * @param int $post_id The event ID.
 	 *
-	 * @return int
+	 * @return int The number of available ASC tickets for the post.
 	 */
-	public function get_events_ticket_capacity_for_seating( int $event_id ): int {
-		if ( ! tec_tickets_seating_enabled( $event_id ) ) {
+	public function get_events_ticket_capacity_for_seating( int $post_id ): int {
+		if ( ! tec_tickets_seating_enabled( $post_id ) ) {
 			return 0;
 		}
 
-		$provider = Tickets::get_event_ticket_provider_object( $event_id );
+		$provider = Tickets::get_event_ticket_provider_object( $post_id );
 
 		if ( ! $provider ) {
 			return 0;
@@ -221,8 +221,8 @@ class Frontend extends Controller_Contract {
 
 		$available = [];
 
-		foreach ( tribe_tickets()->where( 'event', $event_id )->get_ids( true ) as $ticket_id ) {
-			$ticket = $provider->get_ticket( $event_id, $ticket_id );
+		foreach ( tribe_tickets()->where( 'event', $post_id )->get_ids( true ) as $ticket_id ) {
+			$ticket = $provider->get_ticket( $post_id, $ticket_id );
 
 			if ( ! $ticket ) {
 				continue;

--- a/src/Tickets/Seating/Tables/Sessions.php
+++ b/src/Tickets/Seating/Tables/Sessions.php
@@ -436,7 +436,7 @@ class Sessions extends Table {
 	public function set_token_expiration_timestamp( string $token, int $timestamp ) {
 		try {
 			$query = DB::prepare(
-				"UPDATE %i SET expiration = %d WHERE token = %s",
+				'UPDATE %i SET expiration = %d WHERE token = %s',
 				self::table_name(),
 				$timestamp,
 				$token

--- a/src/Tickets/Seating/Tables/Sessions.php
+++ b/src/Tickets/Seating/Tables/Sessions.php
@@ -9,6 +9,7 @@
 
 namespace TEC\Tickets\Seating\Tables;
 
+use Exception;
 use TEC\Common\StellarWP\DB\DB;
 use TEC\Common\StellarWP\Schema\Tables\Contracts\Table;
 use TEC\Tickets\Seating\Logging;
@@ -85,7 +86,7 @@ class Sessions extends Table {
 			);
 
 			return (int) DB::query( $query );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			( new self() )->log_error(
 				'Failed to remove expired sessions.',
 				[
@@ -149,7 +150,7 @@ class Sessions extends Table {
 			);
 
 			return DB::query( $query ) !== false;
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->log_error(
 				'Failed to upsert the session.',
 				[
@@ -182,7 +183,7 @@ class Sessions extends Table {
 				$token
 			);
 			$expiration = DB::get_var( $query );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->log_error(
 				'Failed to get the seconds left for the token.',
 				[
@@ -225,7 +226,7 @@ class Sessions extends Table {
 				$token
 			);
 			$reservations = DB::get_var( $query );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->log_error(
 				'Failed to get the reservations for the token.',
 				[
@@ -340,7 +341,7 @@ class Sessions extends Table {
 			}
 
 			return $updated !== false;
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->log_error(
 				'Failed to update the reservations for the token.',
 				[
@@ -374,7 +375,7 @@ class Sessions extends Table {
 			);
 
 			return DB::query( $query ) !== false;
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->log_error(
 				'Failed to delete the sessions for the token.',
 				[
@@ -396,9 +397,9 @@ class Sessions extends Table {
 	 *
 	 * @param string $token The token to clear the reservations for.
 	 *
-	 * @return bool Whether the reservations were cleared or not.
+	 * @return bool|false Whether the reservations were cleared or not.
 	 */
-	public function clear_token_reservations( string $token ): bool {
+	public function clear_token_reservations( string $token ) {
 		try {
 			$query = DB::prepare(
 				"UPDATE %i SET reservations = '' WHERE token = %s",
@@ -407,9 +408,44 @@ class Sessions extends Table {
 			);
 
 			return DB::query( $query ) !== false;
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->log_error(
 				'Failed to clear the reservations for the token.',
+				[
+					'source' => __METHOD__,
+					'code'   => $e->getCode(),
+					'token'  => $token,
+					'error'  => $e->getMessage(),
+				]
+			);
+
+			return false;
+		}
+	}
+
+	/**
+	 * Updates a session expiration timestamp by its token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $token The token to update the session for.
+	 * @param int    $timestamp The UNIX timestamp to update the expiration to.
+	 *
+	 * @return bool|false Either the number of rows updated, or `false` on failure.
+	 */
+	public function set_token_expiration_timestamp( string $token, int $timestamp ) {
+		try {
+			$query = DB::prepare(
+				"UPDATE %i SET expiration = %d WHERE token = %s",
+				self::table_name(),
+				$timestamp,
+				$token
+			);
+
+			return DB::query( $query ) !== false;
+		} catch ( Exception $e ) {
+			$this->log_error(
+				'Failed to update the expiration timestamp for the token.',
 				[
 					'source' => __METHOD__,
 					'code'   => $e->getCode(),

--- a/src/Tickets/Seating/app/frontend/session/index.js
+++ b/src/Tickets/Seating/app/frontend/session/index.js
@@ -8,9 +8,11 @@ import { onReady } from '@tec/tickets/seating/utils';
 const {
 	ajaxUrl,
 	ajaxNonce,
+	checkoutGraceTime,
 	ACTION_START,
 	ACTION_SYNC,
 	ACTION_INTERRUPT_GET_DATA,
+	ACTION_PAUSE_TO_CHECKOUT,
 } = localizedData;
 
 /**
@@ -575,7 +577,11 @@ async function requestToBackend(action) {
 		return false;
 	}
 
-	if ([ACTION_START, ACTION_SYNC].indexOf(action) === -1) {
+	if (
+		[ACTION_START, ACTION_SYNC, ACTION_PAUSE_TO_CHECKOUT].indexOf(
+			action
+		) === -1
+	) {
 		return false;
 	}
 
@@ -697,10 +703,16 @@ export function reset() {
  * Postpones the healthcheck that will sync with the backend resetting its timer.
  *
  * @since 5.16.0
+ * @since TBD Added the `resumeInSeconds` parameter.
+ *
+ * @param {number} resumeInSeconds The amount of seconds after which the timer should resume. `0` to not resume.
  *
  * @return {void}
  */
-export function pause() {
+export function pause(resumeInSeconds) {
+	// By default, do not resume.
+	resumeInSeconds = resumeInSeconds || 0;
+
 	setIsInterruptable(false);
 
 	if (healthCheckTimeoutId) {
@@ -715,8 +727,31 @@ export function pause() {
 		countdownTimeoutId = null;
 	}
 
+	if (!resumeInSeconds) {
+		return;
+	}
+
 	// Postpone the healthcheck for 60 seconds.
-	resumeTimeoutId = setTimeout(resume, 60000);
+	resumeTimeoutId = setTimeout(resume, resumeInSeconds * 1000);
+}
+
+/**
+ * Postpones the healthcheck that will sync with the backend resetting its timer for the purpose of
+ * giving the user time to checkout.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} A promise that will resolve when the backend received the signal and the timer paused.
+ */
+export async function pauseToCheckout() {
+	const secondsLeft = await requestToBackend(ACTION_PAUSE_TO_CHECKOUT);
+
+	if (secondsLeft <= 0) {
+		interrupt();
+		return;
+	}
+
+	pause(checkoutGraceTime);
 }
 
 /**
@@ -801,8 +836,8 @@ export function watchCheckoutControls() {
 
 	checkoutControlElements.forEach((checkoutControlElement) => {
 		watchedCheckoutControls.push(checkoutControlElement);
-		checkoutControlElement.addEventListener('click', pause);
-		checkoutControlElement.addEventListener('submit', pause);
+		checkoutControlElement.addEventListener('click', pauseToCheckout);
+		checkoutControlElement.addEventListener('submit', pauseToCheckout);
 	});
 }
 
@@ -815,8 +850,8 @@ export function watchCheckoutControls() {
  */
 function stopWatchingCheckoutControls() {
 	watchedCheckoutControls.forEach((checkoutControlElement) => {
-		checkoutControlElement.removeEventListener('click', pause);
-		checkoutControlElement.removeEventListener('submit', pause);
+		checkoutControlElement.removeEventListener('click', pauseToCheckout);
+		checkoutControlElement.removeEventListener('submit', pauseToCheckout);
 	});
 
 	watchedCheckoutControls = [];

--- a/src/Tickets/Seating/app/frontend/session/localized-data.js
+++ b/src/Tickets/Seating/app/frontend/session/localized-data.js
@@ -2,9 +2,11 @@
  * @typedef {Object} LocalizedTimerData
  * @property {string} ajaxUrl                   The URL to the service iframe.
  * @property {string} ajaxNonce                 The AJAX nonce.
+ * @property {number} checkoutGraceTime         The grace time, in seconds, given to a user to complete the checkout.
  * @property {string} ACTION_START              The action to start the timer.
  * @property {string} ACTION_SYNC               The action to sync the timer with the backend.
  * @property {string} ACTION_INTERRUPT_GET_DATA The action to get the data required to render the redirection modal.
+ * @property {string} ACTION_PAUSE_TO_CHECKOUT  The action to signal the backend we're pausing the timer to checkout.
  * @property {string} TICKETS_BLOCK_DIALOG_NAME The name of the dialog element used to render the seat selection modal.
  */
 

--- a/tests/slr_integration/Frontend/__snapshots__/Timer_Test__test_get_localized_data__0.snapshot.json
+++ b/tests/slr_integration/Frontend/__snapshots__/Timer_Test__test_get_localized_data__0.snapshot.json
@@ -1,7 +1,9 @@
 {
     "ajaxUrl": "http://wordpress.test/wp-admin/admin-ajax.php",
     "ajaxNonce": "22848eb6a0",
+    "checkoutGraceTime": 60,
     "ACTION_START": "tec_tickets_seating_timer_start",
     "ACTION_SYNC": "tec_tickets_seating_timer_sync",
-    "ACTION_INTERRUPT_GET_DATA": "tec_tickets_seating_timer_interrupt_get_data"
+    "ACTION_INTERRUPT_GET_DATA": "tec_tickets_seating_timer_interrupt_get_data",
+    "ACTION_PAUSE_TO_CHECKOUT": "tec_tickets_seating_timer_pause_to_checkout"
 }

--- a/tests/slr_integration/Service/Tables/Sessions_Test.php
+++ b/tests/slr_integration/Service/Tables/Sessions_Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TEC\Tickets\Seating\Tables;
+
+use Exception;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use TEC\Common\StellarWP\DB\DB;
+use TEC\Tickets\Seating\Tests\Integration\Truncates_Custom_Tables;
+use Tribe\Tests\Traits\With_Uopz;
+
+class Sessions_Test extends WPTestCase {
+	use Truncates_Custom_Tables;
+	use With_Uopz;
+
+	public function test_set_token_expiration_timestamp(): void {
+		$sessions = tribe( Sessions::class );
+
+		$initial_expiration = time() + 600;
+
+		$sessions->upsert( 'test-token', 23, $initial_expiration );
+
+		$this->assertEqualsWithDelta( 600, $sessions->get_seconds_left( 'test-token' ), 3 );
+
+		$sessions->set_token_expiration_timestamp( 'test-token', 0 );
+
+		$this->assertEquals( 0, $sessions->get_seconds_left( 'test-token' ) );
+
+		$sessions->set_token_expiration_timestamp( 'test-token', time() + 23 );
+
+		$this->assertEqualsWithDelta( 23, $sessions->get_seconds_left( 'test-token' ), 3 );
+	}
+}

--- a/tests/slr_jest/_bootstrap.js
+++ b/tests/slr_jest/_bootstrap.js
@@ -93,11 +93,14 @@ global.tec.tickets.seating = {
 		session: {
 			ajaxUrl: 'https://wordpress.test/wp-admin/admin-ajax.php',
 			ajaxNonce: '1234567890',
+			checkoutGraceTime: 60,
 			ACTION_START: 'tec_tickets_seating_session_start',
 			ACTION_SYNC: 'tec_tickets_seating_session_sync',
 			ACTION_INTERRUPT_GET_DATA:
 				'tec_tickets_seating_session_interrupt_get_data',
 			ACTION_INTERRUPT: 'tec_tickets_seating_session_interrupt',
+			ACTION_PAUSE_TO_CHECKOUT:
+				'tec_tickets_seating_timer_pause_to_checkout',
 		},
 	},
 	currency: {

--- a/tests/slr_jest/frontend/session.spec.js
+++ b/tests/slr_jest/frontend/session.spec.js
@@ -9,12 +9,13 @@ import {
 	getCountdownTimeoutId,
 	getResumeTimeoutId,
 	pause,
+	pauseToCheckout,
 	resume,
 	getWatchedCheckoutControls,
 	beaconInterrupt,
 } from '@tec/tickets/seating/frontend/session';
 import { watchCheckoutControls } from '../../../src/Tickets/Seating/app/frontend/session';
-import {addFilter} from '@wordpress/hooks';
+import { addFilter } from '@wordpress/hooks';
 
 require('jest-fetch-mock').enableMocks();
 
@@ -66,21 +67,30 @@ describe('Seat Selection Session', () => {
 		expect(isExpired()).toBe(false);
 		expect(getCountdownTimeoutId()).toBe(null);
 		expect(getHealthcheckTimeoutId()).toBe(null);
-		expect(getResumeTimeoutId()).toBe(102);
+		expect(getResumeTimeoutId()).toBe(null);
 
 		await resume();
 
 		expect(isInterruptable()).toBe(true);
 		expect(isStarted()).toBe(true);
 		expect(isExpired()).toBe(false);
-		expect(getCountdownTimeoutId()).toBe(103);
-		expect(getHealthcheckTimeoutId()).toBe(104);
+		expect(getCountdownTimeoutId()).toBe(102);
+		expect(getHealthcheckTimeoutId()).toBe(103);
 		expect(getResumeTimeoutId()).toBe(null);
 	});
 
-	it('should pause the timer on checkout control click', async () => {
+	it('should watch checkout button click', async () => {
+		const actions = [
+			'tec_tickets_seating_session_sync',
+			'tec_tickets_seating_timer_pause_to_checkout',
+		];
+		const urlRegex = RegExp(
+			`https://wordpress.test/wp-admin/admin-ajax\\.php\\?_ajaxNonce=1234567890&action=(${actions.join(
+				'|'
+			)})&token=test-token&postId=23`
+		);
 		fetch.mockIf(
-			'https://wordpress.test/wp-admin/admin-ajax.php?_ajaxNonce=1234567890&action=tec_tickets_seating_session_sync&token=test-token&postId=23',
+			urlRegex,
 			JSON.stringify({
 				success: true,
 				data: { secondsLeft: 30, timestamp: Date.now() / 1000 },
@@ -99,25 +109,35 @@ describe('Seat Selection Session', () => {
 		setTargetDom(dom);
 
 		await syncOnLoad();
+
+		const element = dom.querySelector('#button-1');
+		element.addEventListener = jest.fn();
+
 		await watchCheckoutControls();
 
 		expect(getWatchedCheckoutControls()).toHaveLength(1);
-
-		dom.querySelector('#button-1').click();
-
-		expect(isInterruptable()).toBe(false);
-		expect(isStarted()).toBe(true);
-		expect(isExpired()).toBe(false);
-		expect(getCountdownTimeoutId()).toBe(null);
-		expect(getHealthcheckTimeoutId()).toBe(null);
-		expect(getResumeTimeoutId()).toBe(102);
-		// Let's make sure it will set up to resume in 1 minute.
-		expect(setTimeout).toHaveBeenCalledWith(resume, 60000);
+		expect(element.addEventListener).toHaveBeenCalledWith(
+			'click',
+			pauseToCheckout
+		);
+		expect(element.addEventListener).toHaveBeenCalledWith(
+			'submit',
+			pauseToCheckout
+		);
 	});
 
-	it('should pause the timer on checkout control submit', async () => {
+	it('should watch checkout form submit', async () => {
+		const actions = [
+			'tec_tickets_seating_session_sync',
+			'tec_tickets_seating_timer_pause_to_checkout',
+		];
+		const urlRegex = RegExp(
+			`https://wordpress.test/wp-admin/admin-ajax\\.php\\?_ajaxNonce=1234567890&action=(${actions.join(
+				'|'
+			)})&token=test-token&postId=23`
+		);
 		fetch.mockIf(
-			'https://wordpress.test/wp-admin/admin-ajax.php?_ajaxNonce=1234567890&action=tec_tickets_seating_session_sync&token=test-token&postId=23',
+			urlRegex,
 			JSON.stringify({
 				success: true,
 				data: { secondsLeft: 30, timestamp: Date.now() / 1000 },
@@ -143,11 +163,61 @@ describe('Seat Selection Session', () => {
 		);
 
 		await syncOnLoad();
+
+		const element = dom.querySelector('#my-custom-checkout-form');
+		element.addEventListener = jest.fn();
+
 		await watchCheckoutControls();
 
 		expect(getWatchedCheckoutControls()).toHaveLength(1);
+		expect(element.addEventListener).toHaveBeenCalledWith(
+			'click',
+			pauseToCheckout
+		);
+		expect(element.addEventListener).toHaveBeenCalledWith(
+			'submit',
+			pauseToCheckout
+		);
+	});
 
-		dom.querySelector('#my-custom-checkout-form').submit();
+	it('pauseToCheckout', async () => {
+		const actions = [
+			'tec_tickets_seating_session_sync',
+			'tec_tickets_seating_timer_pause_to_checkout',
+		];
+		const urlRegex = RegExp(
+			`https://wordpress.test/wp-admin/admin-ajax\\.php\\?_ajaxNonce=1234567890&action=(${actions.join(
+				'|'
+			)})&token=test-token&postId=23`
+		);
+		fetch.mockIf(
+			urlRegex,
+			JSON.stringify({
+				success: true,
+				data: { secondsLeft: 30, timestamp: Date.now() / 1000 },
+			})
+		);
+		let timeoutId = 100;
+		global.setTimeout = jest.fn(() => timeoutId++);
+		dom = getTestDocument(
+			'timer',
+			(html) =>
+				html
+					.replaceAll('{{post_id}}', 23)
+					.replaceAll('{{token}}', 'test-token') +
+				'<form id="my-custom-checkout-form">' +
+				'<button>Checkout</button>' +
+				'</form>'
+		);
+		setTargetDom(dom);
+		addFilter(
+			'tec.tickets.seating.frontend.session.checkoutControls',
+			'test',
+			(selector) => selector + ', #my-custom-checkout-form'
+		);
+
+		await syncOnLoad();
+		await pauseToCheckout();
 
 		expect(isInterruptable()).toBe(false);
 		expect(isStarted()).toBe(true);
@@ -174,14 +244,17 @@ describe('Seat Selection Session', () => {
 
 		dom = getTestDocument('timer', (html) =>
 			html
-			.replaceAll('{{post_id}}', 23)
-			.replaceAll('{{token}}', 'test-token')
+				.replaceAll('{{post_id}}', 23)
+				.replaceAll('{{token}}', 'test-token')
 		);
 		setTargetDom(dom);
 
 		await syncOnLoad();
 
-		expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', beaconInterrupt);
+		expect(window.addEventListener).toHaveBeenCalledWith(
+			'beforeunload',
+			beaconInterrupt
+		);
 
 		beaconInterrupt();
 


### PR DESCRIPTION
This updates the logic around session clearing on payment failure to make sure more edge cases are covered.

[SL-233](https://stellarwp.atlassian.net/browse/SL-233)

Artifacts:
* tests
* demo in Jira


[SL-233]: https://stellarwp.atlassian.net/browse/SL-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ