### PR TITLE
SLR - Fix table update issue

### DIFF
--- a/changelog/slr-fix-blob-db-delta-issue
+++ b/changelog/slr-fix-blob-db-delta-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove default value from sessions table column to avoid database update issues. [n/a]

--- a/src/Tickets/Seating/Tables/Sessions.php
+++ b/src/Tickets/Seating/Tables/Sessions.php
@@ -119,7 +119,7 @@ class Sessions extends Table {
 				`token` varchar(150) NOT NULL,
 				`object_id` bigint(20) NOT NULL,
 				`expiration` int(11) NOT NULL,
-				`reservations` longblob DEFAULT '',
+				`reservations` longblob,
 				`expiration_lock` boolean DEFAULT 0,
 				PRIMARY KEY (`token`)
 			) {$charset_collate};


### PR DESCRIPTION
Ticket: n/a

Remove the default entry from the `reservations` columns of the Sesssions table as it might cause issues in some systems.
