### PR TITLE
[ET-2082] Fix orders not updating on asynchronous/failed payments

### DIFF
--- a/changelog/fix-ET-2082-order-status-not-updating-on-asynchronous-payments
+++ b/changelog/fix-ET-2082-order-status-not-updating-on-asynchronous-payments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Order updates for asynchronous payment methods in Stripe will update correctly. [ET-2082]

--- a/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Webhooks/Payment_Intent_Webhook.php
@@ -6,6 +6,8 @@ use TEC\Tickets\Commerce\Gateways\Contracts\Webhook_Event_Interface;
 use TEC\Tickets\Commerce\Gateways\Stripe\Payment_Intent;
 use TEC\Tickets\Commerce\Gateways\Stripe\Status;
 use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Action_Required;
+use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use Tribe__Utils__Array as Arr;
 
@@ -117,8 +119,9 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 	/**
 	 * Checks if the payment intent contained in the event received has already been processed.
 	 *
-	 * @since      5.3.0
-	 * @since      5.16.0 Remove deprecation notice.
+	 * @since 5.3.0
+	 * @since 5.16.0 Remove deprecation notice.
+	 * @since TBD    Only check matching payment intent ids if they are not pending or action required.
 	 *
 	 * @param array   $payment_intent_received The payment intent data received
 	 * @param array[] $payment_intents_stored  The payment intent data stored from each update, keyed by status.
@@ -132,6 +135,11 @@ class Payment_Intent_Webhook implements Webhook_Event_Interface {
 		}
 
 		foreach ( $payment_intents_stored as $status => $intents ) {
+			// Skip if the status is pending or action required.
+			if ( in_array( $status, [ Pending::SLUG, Action_Required::SLUG ], true ) ) {
+				continue;
+			}
+
 			foreach( $intents as $intent ) {
 				// This payment intent has already been processed and updated.
 				if ( $payment_intent_received['id'] === $intent['id'] ) {

--- a/tests/commerce_integration/TEC/Gateways/Stripe/Webhooks/PaymentIntentWebhookTest.php
+++ b/tests/commerce_integration/TEC/Gateways/Stripe/Webhooks/PaymentIntentWebhookTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace TEC\Gateways\Stripe\Webhooks;
+
+use TEC\Tickets\Commerce\Gateways\Stripe\Webhooks\Payment_Intent_Webhook;
+use TEC\Tickets\Commerce\Gateways\Stripe\Status;
+use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\Commerce\Status\Action_Required;
+use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Tickets\Commerce\Status\Refunded;
+
+class PaymentIntentWebhookTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @dataProvider data_provider_should_payment_intent_be_updated
+	 */
+	public function test_should_payment_intent_be_updated( array $payment_intent_received, array $payment_intents_stored, bool $expected ) {
+		$actual = Payment_Intent_Webhook::should_payment_intent_be_updated( $payment_intent_received, $payment_intents_stored );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function data_provider_should_payment_intent_be_updated() {
+		return [
+			// Scenario 1: Payment intent was reset or processing restarted
+			[
+				['status' => Status::REQUIRES_PAYMENT_METHOD],
+				[
+					Status::REQUIRES_PAYMENT_METHOD => [['id' => 'pi_1']],
+					Status::SUCCEEDED => [['id' => 'pi_2']]
+				],
+				true
+			],
+			// Scenario 2: Payment intent already processed and updated to refunded
+			[
+				['id' => 'pi_2', 'status' => Status::CANCELED],
+				[
+					Refunded::SLUG => [['id' => 'pi_2']]
+				],
+				false
+			],
+			// Scenario 3: Payment intent pending and action required.
+			[
+				['id' => 'pi_3', 'status' => Status::REQUIRES_PAYMENT_METHOD],
+				[
+					Pending::SLUG => [['id' => 'pi_3']],
+					Action_Required::SLUG => [['id' => 'pi_3']]
+				],
+				true
+			],
+			// Scenario 4: Payment intent pending and completed.
+			[
+				['id' => 'pi_3', 'status' => Status::SUCCEEDED],
+				[
+					Pending::SLUG => [['id' => 'pi_3']],
+					Completed::SLUG => [['id' => 'pi_3']]
+				],
+				false
+			]
+		];
+	}
+}
+


### PR DESCRIPTION
### 🎫 Ticket
[ET-2082]
[ET-2258]

### 🗒️ Description
There was an issue reported from users that were using Bancontact and/or iDEAL as payment methods through Stripe. The issue didn't turn out to be specific to those payment methods, but to asynchronous payment methods that were dependent on the Stripe webhook to update the order. This was a similar issue to when failed payments would be retried successfully within the same session. This fix addresses both issues.

### 🎥 Artifacts <!-- if applicable-->
https://share.zight.com/mXuQw6pj

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2082]: https://stellarwp.atlassian.net/browse/ET-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-2258]: https://stellarwp.atlassian.net/browse/ET-2258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ