### PR TITLE
Update the frontend display of fees

### DIFF
--- a/src/Tickets/Commerce/Gateways/PayPal/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/WhoDat.php
@@ -72,18 +72,30 @@ class WhoDat extends Abstract_WhoDat {
 	 * Verify if the seller was successfully onboarded.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Added runtime cache.
 	 *
 	 * @param string $saved_merchant_id The ID we are looking at Paypal with.
 	 *
 	 * @return array
 	 */
 	public function get_seller_status( $saved_merchant_id ) {
+		$cache = tribe_cache();
+
+		$cache_key = 'paypal_seller_status_' . md5( $saved_merchant_id );
+
+		// Adding cache changed my checkout page from 12s to 2s. Lets keep it!
+		if ( isset( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) ) {
+			return $cache[ $cache_key ];
+		}
+
 		$query_args = [
 			'mode'        => tribe( Merchant::class )->get_mode(),
 			'merchant_id' => $saved_merchant_id,
 		];
 
-		return $this->post( 'seller/status', $query_args );
+		$cache[ $cache_key ] = $this->post( 'seller/status', $query_args );
+
+		return $cache[ $cache_key ];
 	}
 
 	/**

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -156,6 +156,13 @@ abstract class Abstract_Fees extends Controller_Contract {
 	 * @return array The updated total values, including the fees.
 	 */
 	public function calculate_fees( array $values, array $items, Value $subtotal ): array {
+		$cache_key = 'calculate_fees_' . md5( wp_json_encode( $items ) );
+		$cache = tribe_cache();
+
+		if ( ! empty( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) ) {
+			return $cache[ $cache_key ];
+		}
+
 		// Store the subtotal as a class property for later use, encapsulated as a Value object.
 		$this->subtotal = $subtotal;
 
@@ -176,7 +183,9 @@ abstract class Abstract_Fees extends Controller_Contract {
 		// Add the calculated fees to the total value.
 		$values[] = $sum_of_fees;
 
-		return $values;
+		$cache[ $cache_key ] = $values;
+
+		return $cache[ $cache_key ];
 	}
 
 	/**
@@ -479,6 +488,14 @@ abstract class Abstract_Fees extends Controller_Contract {
 				}
 			}
 		}
+
+		// Sort the array alphabetically by display name.
+		usort(
+			$combined_fees,
+			static function ( $a, $b ) {
+				return strcasecmp( $a['display_name'], $b['display_name'] );
+			}
+		);
 
 		return $combined_fees;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -157,7 +157,7 @@ abstract class Abstract_Fees extends Controller_Contract {
 	 */
 	public function calculate_fees( array $values, array $items, Value $subtotal ): array {
 		$cache_key = 'calculate_fees_' . md5( wp_json_encode( $items ) );
-		$cache = tribe_cache();
+		$cache     = tribe_cache();
 
 		if ( ! empty( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) ) {
 			return $cache[ $cache_key ];

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -381,7 +381,7 @@ abstract class Abstract_Fees extends Controller_Contract {
 
 					// Update the quantity and recalculate the subtotal.
 					$fee_items[ $fee['id'] ]['quantity']  = $total_quantity;
-					$fee_items[ $fee['id'] ]['sub_total'] += $amount->multiply_by_integer(
+					$fee_items[ $fee['id'] ]['sub_total'] = $amount->multiply_by_integer(
 						new Integer_Value( $quantity )
 					)->get();
 					continue;
@@ -420,7 +420,7 @@ abstract class Abstract_Fees extends Controller_Contract {
 	 */
 	protected function prepare_fees_for_frontend_display( array $items ): array {
 		// Get the combined fees for the items in the cart.
-		$fees_by_item  = $this->get_combined_fees_for_items( $items, true );
+		$fees_by_item = $this->get_combined_fees_for_items( $items, true );
 
 		// Combine the fees for display.
 		$combined_fees = [];

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -380,8 +380,10 @@ abstract class Abstract_Fees extends Controller_Contract {
 					$total_quantity = $quantity + $fee_items[ $fee['id'] ]['quantity'];
 
 					// Update the quantity and recalculate the subtotal.
-					$fee_items[ $fee['id'] ]['quantity']  = $total_quantity;
-					$fee_items[ $fee['id'] ]['sub_total'] = $amount->multiply_by_integer(
+					$fee_items[ $fee['id'] ]['quantity'] = $total_quantity;
+
+					// DO NOT REMOVE the `+=` operator here. It is necessary for the calculation.
+					$fee_items[ $fee['id'] ]['sub_total'] += $amount->multiply_by_integer(
 						new Integer_Value( $quantity )
 					)->get();
 					continue;

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -386,6 +386,7 @@ abstract class Abstract_Fees extends Controller_Contract {
 					$fee_items[ $fee['id'] ]['sub_total'] += $amount->multiply_by_integer(
 						new Integer_Value( $quantity )
 					)->get();
+
 					continue;
 				}
 
@@ -459,7 +460,7 @@ abstract class Abstract_Fees extends Controller_Contract {
 				if ( array_key_exists( $index, $combined_fees ) ) {
 					// Merge the important parts of the fee.
 					$existing_fee              = $combined_fees[ $index ];
-					$existing_fee['quantity']  += $quantity;
+					$existing_fee['quantity'] += $quantity;
 					$existing_fee['subtotal']  = $existing_fee['subtotal']->add( $subtotal );
 					$existing_fee['for_items'] = array_unique(
 						array_merge( $existing_fee['for_items'], [ $item_id ] )

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -365,7 +365,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		);
 
 		wp_safe_redirect( $edit_link );
-		exit;
+		tribe_exit();
 	}
 
 	/**
@@ -481,6 +481,6 @@ class Modifier_Admin_Handler extends Controller_Contract {
 
 		// Redirect to the original page to avoid resubmitting the form upon refresh.
 		wp_safe_redirect( $redirect_url );
-		exit;
+		tribe_exit();
 	}
 }

--- a/src/Tickets/Commerce/Order_Modifiers/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Values/Currency_Value.php
@@ -9,7 +9,6 @@ declare( strict_types=1 );
 
 namespace TEC\Tickets\Commerce\Order_Modifiers\Values;
 
-use BadMethodCallException;
 use TEC\Tickets\Commerce\Order_Modifiers\Traits\Stringify;
 
 /**
@@ -180,26 +179,84 @@ class Currency_Value implements Value_Interface {
 	}
 
 	/**
-	 * Wrap the methods of the Precision_Value class.
+	 * Add a value to the current value.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $name The method name.
-	 * @param array  $arguments The method arguments.
+	 * @param Currency_Value $value The value to add.
 	 *
-	 * @return mixed The result of the method.
+	 * @return Currency_Value The new value object.
 	 */
-	public function __call( $name, $arguments ) {
-		if ( ! method_exists( $this->value, $name ) ) {
-			throw new BadMethodCallException( "Method {$name} does not exist." );
+	public function add( Currency_Value $value ): Currency_Value {
+		$result = $this->value->add( $value->get_raw_value() );
+
+		return new self(
+			$result,
+			$this->currency_symbol,
+			$this->thousands_separator,
+			$this->decimal_separator,
+			$this->currency_symbol_position
+		);
+	}
+
+	/**
+	 * Subtract a value from the current value.
+	 *
+	 * @since TBD
+	 *
+	 * @param Currency_Value $value The value to subtract.
+	 *
+	 * @return Currency_Value The new value object.
+	 */
+	public function subtract( Currency_Value $value ): Currency_Value {
+		$result = $this->value->subtract( $value->get_raw_value() );
+
+		return new self(
+			$result,
+			$this->currency_symbol,
+			$this->thousands_separator,
+			$this->decimal_separator,
+			$this->currency_symbol_position
+		);
+	}
+
+	/**
+	 * Add multiple values together.
+	 *
+	 * @since TBD
+	 *
+	 * @param Currency_Value ...$values The values to add.
+	 *
+	 * @return Currency_Value The new value object.
+	 */
+	public static function sum( Currency_Value ...$values ): Currency_Value {
+		$sum = new Precision_Value( 0 );
+
+		foreach ( $values as $value ) {
+			$sum = $sum->add( $value->get_raw_value() );
 		}
 
-		// Some methods may return a new instance of the class.
-		$result = $this->value->{$name}( ...$arguments );
-		if ( $result instanceof Precision_Value ) {
-			$this->value = $result;
-		}
+		return static::create( $sum );
+	}
 
-		return $result;
+	/**
+	 * Multiply the current value by an integer.
+	 *
+	 * @since TBD
+	 *
+	 * @param Integer_Value $value The value to multiply by.
+	 *
+	 * @return Currency_Value The new value object.
+	 */
+	public function multiply_by_integer( Integer_Value $value ): Currency_Value {
+		$new_value = $this->value->multiply_by_integer( $value );
+
+		return new self(
+			$new_value,
+			$this->currency_symbol,
+			$this->thousands_separator,
+			$this->decimal_separator,
+			$this->currency_symbol_position
+		);
 	}
 }

--- a/src/Tickets/Commerce/Order_Modifiers/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Values/Currency_Value.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace TEC\Tickets\Commerce\Order_Modifiers\Values;
 
+use BadMethodCallException;
 use TEC\Tickets\Commerce\Order_Modifiers\Traits\Stringify;
 
 /**
@@ -176,5 +177,29 @@ class Currency_Value implements Value_Interface {
 			'decimal_separator'        => $decimal_separator ?? '.',
 			'currency_symbol_position' => $currency_symbol_position ?? 'before',
 		];
+	}
+
+	/**
+	 * Wrap the methods of the Precision_Value class.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $name The method name.
+	 * @param array  $arguments The method arguments.
+	 *
+	 * @return mixed The result of the method.
+	 */
+	public function __call( $name, $arguments ) {
+		if ( ! method_exists( $this->value, $name ) ) {
+			throw new BadMethodCallException( "Method {$name} does not exist." );
+		}
+
+		// Some methods may return a new instance of the class.
+		$result = $this->value->{$name}( ...$arguments );
+		if ( $result instanceof Precision_Value ) {
+			$this->value = $result;
+		}
+
+		return $result;
 	}
 }

--- a/src/views/v2/commerce/checkout/order-modifiers/fees.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/fees.php
@@ -29,11 +29,13 @@
 					echo esc_html( $fee['display_name'] );
 					if ( $fee['quantity'] > 1 ) {
 						printf(
+							/* translators: %s: Quantity of a fee */
 							' ' . esc_html_x( '(%sx)', 'Quantity of a fee with "x" after it, eg. "2x"', 'event-tickets' ),
 							esc_html( $fee['quantity'] )
 						);
 					}
-					?>:
+					echo ':';
+					?>
 				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
 					<?php echo esc_html( $fee['subtotal'] ); ?>

--- a/src/views/v2/commerce/checkout/order-modifiers/fees.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/fees.php
@@ -25,10 +25,18 @@
 		<?php foreach ( $active_fees as $fee ) : ?>
 			<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<?php echo esc_html( $fee['display_name'] ); ?>:
+					<?php
+					echo esc_html( $fee['display_name'] );
+					if ( $fee['quantity'] > 1 ) {
+						printf(
+							' ' . esc_html_x( '(%sx)', 'Quantity of a fee with "x" after it, eg. "2x"', 'event-tickets' ),
+							esc_html( $fee['quantity'] )
+						);
+					}
+					?>:
 				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					<?php echo esc_html( $fee['fee_amount'] ); ?>
+					<?php echo esc_html( $fee['subtotal'] ); ?>
 				</span>
 			</li>
 		<?php endforeach; ?>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -283,444 +283,69 @@
 	<ul>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
+					test fee 1 (2x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.14				</span>
+					$3.34				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (3x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.67				</span>
+					$9.99				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
+					test fee 1 (4x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
+					$20.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
+					test fee 1 (5x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.14				</span>
+					$33.35				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (6x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.67				</span>
+					$50.04				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
+					test fee 2 (20x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
+					$73.40				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
+					test fee 3 (2x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
+					$0.28				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 3 (4x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.33				</span>
+					$1.68				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
+					test fee 3 (6x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
+					$4.14				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
+					test fee 4 (7x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
+					$16.38				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 5 (4x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.33				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.33				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.42				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.17				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.42				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.17				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.42				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.17				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.42				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.17				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.69				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$8.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.69				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$8.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.69				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$8.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.69				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$8.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.69				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$8.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.69				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$8.34				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.67				</span>
+					$4.68				</span>
 			</li>
 			</ul>
 </div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -292,444 +292,69 @@
 	<ul>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.20				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.20				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (2x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
 					$2.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
+					test fee 1 (3x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
+					$6.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
+					test fee 1 (4x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
+					$12.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (5x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.00				</span>
+					$20.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
+					test fee 1 (6x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
+					$30.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
+					test fee 2 (20x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
+					$60.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 3 (2x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.00				</span>
+					$0.40				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
+					test fee 3 (4x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
+					$2.40				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
+					test fee 3 (6x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.60				</span>
+					$6.00				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
+					test fee 4 (7x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
+					$17.50				</span>
 			</li>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
+					test fee 5 (4x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.60				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.60				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$0.60				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 4:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 5:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.50				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$4.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$4.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$4.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$4.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$4.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 3:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$1.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 2:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
+					$6.00				</span>
 			</li>
 			</ul>
 </div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -1,12 +1,3 @@
-
-
-
-
-
-
-
-
-
 <div class="tribe-common event-tickets">
 	<section
 		class="tribe-tickets__commerce-checkout"
@@ -92,24 +83,9 @@
 	<ul>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (3x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$5.00				</span>
+					$15.00				</span>
 			</li>
 			</ul>
 </div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -83,24 +83,9 @@
 	<ul>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (3x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$2.00				</span>
+					$6.00				</span>
 			</li>
 			</ul>
 </div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -83,17 +83,9 @@
 	<ul>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (2x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$3.00				</span>
+					$6.00				</span>
 			</li>
 			</ul>
 </div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -83,17 +83,9 @@
 	<ul>
 					<li>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
+					test fee 1 (2x):				</span>
 				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$10.00				</span>
-			</li>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1:
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$10.00				</span>
+					$20.00				</span>
 			</li>
 			</ul>
 </div>

--- a/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
+++ b/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
@@ -288,7 +288,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 		);
 
 		// Prevent `exit` from terminating the test.
-		uopz_allow_exit( false );
+		$this->set_fn_return( 'tribe_exit', null );
 
 		// Setup the fixture.
 		$data = $fixture();
@@ -394,7 +394,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 		);
 
 		// Prevent `exit` from terminating the test.
-		uopz_allow_exit( false );
+		$this->set_fn_return( 'tribe_exit', null );
 
 		// Setup the fixture.
 		$data = $fixture();
@@ -728,7 +728,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 		);
 
 		// Prevent exit.
-		uopz_allow_exit( false );
+		$this->set_fn_return( 'tribe_exit', null );
 
 		// Step 1: Use `handle_form_submission` to create a modifier.
 		$_POST                               = [
@@ -811,7 +811,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 		);
 
 		// Prevent exit.
-		uopz_allow_exit( false );
+		$this->set_fn_return( 'tribe_exit', null );
 
 		// Step 1: Create a new modifier.
 		$_POST = [
@@ -919,6 +919,4 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 			);
 		}
 	}
-
-
 }


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->

<img width="669" alt="Screenshot 2024-11-27 at 23 39 45" src="https://github.com/user-attachments/assets/56314a7e-987a-4cfe-9b0f-14ada2a776f7">

In the above screenshot, both tickets have 2 fees applied:

1. "All tickets fee" is $1 per ticket, applied 3 times
2. "A little fee for all tickets" is 0.5% per ticket. It is applied 3 times, but the amount is different based on the ticket amount it applies to. Thus, it is displayed 1 time for the ticket with quantity 1, and 2 times for the ticket with quantity 2.


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
