### PR TITLE
[SL-248] Hide seating settings when license is not valid.

### DIFF
--- a/changelog/fix-sl-248-seating-license-check
+++ b/changelog/fix-sl-248-seating-license-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Hide seating reservation settings when seating license is not valid. [SL-248]

--- a/src/Tickets/Seating/Settings.php
+++ b/src/Tickets/Seating/Settings.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Seating;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\StellarWP\Arrays\Arr;
+use TEC\Tickets\Seating\Service\Service;
 
 /**
  * Class Settings.
@@ -51,12 +52,19 @@ class Settings extends Controller_Contract {
 	 * Add display settings for Event Tickets.
 	 *
 	 * @since 5.17.0
+	 * @since TBD Only add settings if the seating service has a valid license.
 	 *
 	 * @param array $settings List of display settings.
 	 *
 	 * @return array List of display settings.
 	 */
 	public function add_frontend_timer_settings( array $settings ): array {
+		$service_status = tribe( Service::class )->get_status();
+
+		if ( $service_status->has_no_license() || $service_status->is_license_invalid() ) {
+			return $settings;
+		}
+		
 		$timer_settings = [
 			'ticket-seating-options-heading' => [
 				'type' => 'html',

--- a/tests/slr_integration/__snapshots__/Settings_Test__test_seating_reservation_setting_not_included_with_invalid_license__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Settings_Test__test_seating_reservation_setting_not_included_with_invalid_license__0.snapshot.json
@@ -1,0 +1,17 @@
+{
+    "ticket-authentication-requirements": {
+        "type": "checkbox",
+        "label": "Require Login"
+    },
+    "ticket-telemetry-optin-heading": {
+        "type": "html",
+        "html": "<h3 id=\"event-tickets-telemetry-settings\">Telemetry</h3>"
+    },
+    "opt-in-status": {
+        "type": "checkbox_bool",
+        "label": "Opt in to Telemetry",
+        "tooltip": "Enable this option to share usage data with Event Tickets and StellarWP. <a href=\" https://evnt.is/1bcl \">What permissions are being granted?</a> <a href=\" https://evnt.is/1bcm \">Read our Terms of Service</a> <a href=\" https://evnt.is/1bcn \">Read our Privacy Policy</a>",
+        "default": false,
+        "validation_type": "boolean"
+    }
+}

--- a/tests/slr_integration/__snapshots__/Settings_Test__test_seating_reservation_setting_not_included_with_no_license__0.snapshot.json
+++ b/tests/slr_integration/__snapshots__/Settings_Test__test_seating_reservation_setting_not_included_with_no_license__0.snapshot.json
@@ -1,0 +1,17 @@
+{
+    "ticket-authentication-requirements": {
+        "type": "checkbox",
+        "label": "Require Login"
+    },
+    "ticket-telemetry-optin-heading": {
+        "type": "html",
+        "html": "<h3 id=\"event-tickets-telemetry-settings\">Telemetry</h3>"
+    },
+    "opt-in-status": {
+        "type": "checkbox_bool",
+        "label": "Opt in to Telemetry",
+        "tooltip": "Enable this option to share usage data with Event Tickets and StellarWP. <a href=\" https://evnt.is/1bcl \">What permissions are being granted?</a> <a href=\" https://evnt.is/1bcm \">Read our Terms of Service</a> <a href=\" https://evnt.is/1bcn \">Read our Privacy Policy</a>",
+        "default": false,
+        "validation_type": "boolean"
+    }
+}


### PR DESCRIPTION
### 🎫 Ticket

[SL-248]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* Hide seating reservation timer settings if seating license is not available or invalid.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://share.cleanshot.com/fx7py2ZT

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[SL-248]: https://stellarwp.atlassian.net/browse/SL-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ