### PR TITLE
Fix/indexes length for modifiers

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifier_Relationships.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifier_Relationships.php
@@ -94,8 +94,8 @@ class Order_Modifier_Relationships extends Abstract_Custom_Table {
 		}
 
 		// Helper method to check and add indexes.
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_indx_modifier_id', 'modifier_id' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_indx_post_id', 'post_id' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_index_modifier_id', 'modifier_id' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_index_post_id', 'post_id' );
 
 		return $results;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifier_Relationships.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifier_Relationships.php
@@ -48,7 +48,7 @@ class Order_Modifier_Relationships extends Abstract_Custom_Table {
 	 *
 	 * @var string The field that uniquely identifies a row in the table.
 	 */
-	protected static $uid_column = 'object_id';
+	protected static $uid_column = 'id';
 
 	/**
 	 * Returns the table creation SQL in the format supported
@@ -66,11 +66,11 @@ class Order_Modifier_Relationships extends Abstract_Custom_Table {
 
 		return "
 			CREATE TABLE `$table_name` (
-				`object_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 				`modifier_id` BIGINT UNSIGNED NOT NULL,
 				`post_id` BIGINT UNSIGNED NOT NULL,
 				`post_type` VARCHAR(20) NOT NULL,
-				PRIMARY KEY (`object_id`)
+				PRIMARY KEY (`id`)
 			) $charset_collate;
 		";
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifier_Relationships.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifier_Relationships.php
@@ -20,7 +20,7 @@ class Order_Modifier_Relationships extends Abstract_Custom_Table {
 	 *
 	 * @var string|null The version number for this schema definition.
 	 */
-	public const SCHEMA_VERSION = '0.1.0-dev';
+	public const SCHEMA_VERSION = '1.0.0';
 
 	/**
 	 * @since TBD
@@ -68,7 +68,7 @@ class Order_Modifier_Relationships extends Abstract_Custom_Table {
 			CREATE TABLE `$table_name` (
 				`object_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 				`modifier_id` BIGINT UNSIGNED NOT NULL,
-				`post_id`  BIGINT UNSIGNED NOT NULL,
+				`post_id` BIGINT UNSIGNED NOT NULL,
 				`post_type` VARCHAR(20) NOT NULL,
 				PRIMARY KEY (`object_id`)
 			) $charset_collate;
@@ -95,8 +95,7 @@ class Order_Modifier_Relationships extends Abstract_Custom_Table {
 
 		// Helper method to check and add indexes.
 		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_indx_modifier_id', 'modifier_id' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_indx_post_type', 'post_id,post_type' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_indx_composite_join', 'modifier_id, post_id, post_type' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_relationship_indx_post_id', 'post_id' );
 
 		return $results;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers.php
@@ -107,6 +107,7 @@ class Order_Modifiers extends Abstract_Custom_Table {
 
 		// Helper method to check and add indexes.
 		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_slug', 'slug' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_modifier_type', 'modifier_type' );
 		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_status_modifier_type', 'status, modifier_type' );
 
 		return $results;

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers.php
@@ -20,7 +20,7 @@ class Order_Modifiers extends Abstract_Custom_Table {
 	 *
 	 * @var string|null The version number for this schema definition.
 	 */
-	public const SCHEMA_VERSION = '0.1.0-dev';
+	public const SCHEMA_VERSION = '1.0.0';
 
 	/**
 	 * @since TBD
@@ -67,10 +67,10 @@ class Order_Modifiers extends Abstract_Custom_Table {
 		return "
 			CREATE TABLE `$table_name` (
 				`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-				`modifier_type` VARCHAR(255) NOT NULL,
+				`modifier_type` VARCHAR(150) NOT NULL,
 				`sub_type` VARCHAR(255) NOT NULL,
 				`raw_amount` DECIMAL(18,6) NOT NULL,
-				`slug` VARCHAR(255) NOT NULL,
+				`slug` VARCHAR(150) NOT NULL,
 				`display_name` VARCHAR(255) NOT NULL,
 				`status` VARCHAR(20) NOT NULL DEFAULT 'draft',
 				`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -107,8 +107,7 @@ class Order_Modifiers extends Abstract_Custom_Table {
 
 		// Helper method to check and add indexes.
 		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_slug', 'slug' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_status_modifier_type_slug', 'status, modifier_type, slug' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_type_display_name', 'modifier_type, display_name' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_status_modifier_type', 'status, modifier_type' );
 
 		return $results;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers.php
@@ -106,9 +106,9 @@ class Order_Modifiers extends Abstract_Custom_Table {
 		}
 
 		// Helper method to check and add indexes.
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_slug', 'slug' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_modifier_type', 'modifier_type' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_indx_status_modifier_type', 'status, modifier_type' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_index_slug', 'slug' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_index_modifier_type', 'modifier_type' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_index_status_modifier_type', 'status, modifier_type' );
 
 		return $results;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers_Meta.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers_Meta.php
@@ -23,7 +23,7 @@ class Order_Modifiers_Meta extends Abstract_Custom_Table {
 	 *
 	 * @var string|null The version number for this schema definition.
 	 */
-	public const SCHEMA_VERSION = '0.1.0-dev';
+	public const SCHEMA_VERSION = '1.0.0';
 
 	/**
 	 * @since TBD
@@ -102,8 +102,6 @@ class Order_Modifiers_Meta extends Abstract_Custom_Table {
 		// Helper method to check and add indexes.
 		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_inx_order_modifier_id', 'order_modifier_id' );
 		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_inx_meta_key', 'meta_key' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_inx_order_modifier_id_meta_key', 'order_modifier_id, meta_key' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_inx_meta_key_meta_value', 'meta_key,meta_value(255)' );
 
 		return $results;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers_Meta.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Custom_Tables/Order_Modifiers_Meta.php
@@ -100,8 +100,8 @@ class Order_Modifiers_Meta extends Abstract_Custom_Table {
 		}
 
 		// Helper method to check and add indexes.
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_inx_order_modifier_id', 'order_modifier_id' );
-		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_inx_meta_key', 'meta_key' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_index_order_modifier_id', 'order_modifier_id' );
+		$results = $this->check_and_add_index( $results, 'tec_order_modifier_meta_index_meta_key', 'meta_key' );
 
 		return $results;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Data_Transfer_Objects/Order_Modifier_Relationships_DTO.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Data_Transfer_Objects/Order_Modifier_Relationships_DTO.php
@@ -28,7 +28,7 @@ class Order_Modifier_Relationships_DTO extends DataTransferObject {
 	 *
 	 * @var int
 	 */
-	protected int $object_id;
+	protected int $id;
 
 	/**
 	 * The modifier ID.
@@ -78,7 +78,7 @@ class Order_Modifier_Relationships_DTO extends DataTransferObject {
 	public static function fromObject( $object ): self {
 		$self = new self();
 
-		$self->object_id   = $object->object_id;
+		$self->id          = $object->id;
 		$self->modifier_id = $object->modifier_id;
 		$self->post_id     = $object->post_id;
 		$self->post_type   = $object->post_type;

--- a/src/Tickets/Commerce/Order_Modifiers/Models/Order_Modifier_Relationships.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Models/Order_Modifier_Relationships.php
@@ -25,7 +25,7 @@ use TEC\Tickets\Commerce\Order_Modifiers\Repositories\Order_Modifier_Relationshi
  *
  * @package TEC\Tickets\Commerce\Order_Modifiers\Models;
  *
- * @property int    $object_id     The primary key of the relationship.
+ * @property int    $id            The primary key of the relationship.
  * @property int    $modifier_id   The Order Modifier ID.
  * @property int    $post_id       The related post ID.
  * @property string $post_type     The post type.
@@ -43,7 +43,7 @@ class Order_Modifier_Relationships extends Model implements ModelCrud, ModelFrom
 	 * @inheritDoc
 	 */
 	protected $properties = [
-		'object_id'   => 'int',
+		'id'          => 'int',
 		'modifier_id' => 'int',
 		'post_id'     => 'int',
 		'post_type'   => 'string',
@@ -88,11 +88,11 @@ class Order_Modifier_Relationships extends Model implements ModelCrud, ModelFrom
 	 * @return static
 	 */
 	public function save(): self {
-		if ( $this->object_id ) {
+		if ( $this->id ) {
 			return tribe( Order_Modifier_Relationships_Repository::class )->update( $this );
 		}
 
-		$this->object_id = tribe( Order_Modifier_Relationships_Repository::class )->insert( $this )->object_id;
+		$this->id = tribe( Order_Modifier_Relationships_Repository::class )->insert( $this )->id;
 
 		return $this;
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifier_Relationship.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifier_Relationship.php
@@ -57,7 +57,7 @@ class Order_Modifier_Relationship extends Repository implements Insertable, Upda
 			]
 		);
 
-		$model->object_id = DB::last_insert_id();
+		$model->id = DB::last_insert_id();
 
 		return $model;
 	}
@@ -79,7 +79,7 @@ class Order_Modifier_Relationship extends Repository implements Insertable, Upda
 				'post_id'     => $model->post_id,
 				'post_type'   => $model->post_type,
 			],
-			[ 'object_id' => $model->object_id ],
+			[ 'id' => $model->id ],
 			[
 				'%d',
 				'%d',
@@ -221,7 +221,7 @@ class Order_Modifier_Relationship extends Repository implements Insertable, Upda
 		$order_modifiers_table = Order_Modifiers::base_table_name();
 
 		return $this->prepareQuery()
-			->select( 'r.object_id,m.id as modifier_id', 'p.ID as post_id', 'p.post_type', 'p.post_title' )
+			->select( 'r.id,m.id as modifier_id', 'p.ID as post_id', 'p.post_type', 'p.post_title' )
 			->innerJoin( "$order_modifiers_table as m", 'r.modifier_id', 'm.id' )
 			->innerJoin( "$posts_table as p", 'r.post_id', 'p.ID' );
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifiers.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifiers.php
@@ -306,6 +306,7 @@ class Order_Modifiers extends Repository implements Insertable, Updatable, Delet
 		$builder               = new ModelQueryBuilder( $this->get_valid_types()[ $modifier_type ] );
 
 		$results = $builder->from( Table::table_name( false ) . ' as m' )
+			->select( 'm.*' )
 			->innerJoin( "{$order_modifiers_table} as r", 'm.id', 'r.modifier_id' )
 			->whereIn( 'r.post_id', $post_ids )
 			->where( 'modifier_type', $modifier_type )

--- a/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifiers.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifiers.php
@@ -309,8 +309,8 @@ class Order_Modifiers extends Repository implements Insertable, Updatable, Delet
 			->select( 'm.*' )
 			->innerJoin( "{$order_modifiers_table} as r", 'm.id', 'r.modifier_id' )
 			->whereIn( 'r.post_id', $post_ids )
-			->where( 'modifier_type', $modifier_type )
-			->where( 'status', $status )
+			->where( 'm.modifier_type', $modifier_type )
+			->where( 'm.status', $status )
 			->getAll();
 
 		return $results ?? [];

--- a/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifiers.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Repositories/Order_Modifiers.php
@@ -176,7 +176,6 @@ class Order_Modifiers extends Repository implements Insertable, Updatable, Delet
 	public function find_by_id( int $id ): Order_Modifier {
 		$result = $this->prepareQuery()
 			->where( 'id', $id )
-			->where( 'modifier_type', $this->modifier_type )
 			->get();
 
 		return $this->normalize_return_result( $result );

--- a/tests/order_modifiers_integration/Checkout/Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Fees_Test.php
@@ -17,7 +17,7 @@ use Tribe\Tests\Traits\With_Uopz;
 use TEC\Tickets\Commerce\Cart as Commerce_Cart;
 use Generator;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal\Fees as PayPalFees;
-use TEC\Tickets\Commerce\Order_Modifiers\API\Fees;
+use TEC\Tickets\Commerce\Order_Modifiers\API\Fees as ApiFees;
 
 class Fees_Test extends Controller_Test_Case {
 	use Ticket_Maker;
@@ -95,11 +95,11 @@ class Fees_Test extends Controller_Test_Case {
 
 		$fee_per_ticket_3 = $this->create_fee_for_ticket( $ticket_id_3, [ 'raw_amount' => 5, 'sub_type' => 'percent' ] );
 
-		$ticket_1_fees = $this->make_controller( Fees::class )->get_fees_for_ticket( $ticket_id_1 );
-		$ticket_2_fees = $this->make_controller( Fees::class )->get_fees_for_ticket( $ticket_id_2 );
-		$ticket_3_fees = $this->make_controller( Fees::class )->get_fees_for_ticket( $ticket_id_3 );
-		$ticket_4_fees = $this->make_controller( Fees::class )->get_fees_for_ticket( $ticket_id_4 );
-		$ticket_5_fees = $this->make_controller( Fees::class )->get_fees_for_ticket( $ticket_id_5 );
+		$ticket_1_fees = $this->make_controller( ApiFees::class )->get_fees_for_ticket( $ticket_id_1 );
+		$ticket_2_fees = $this->make_controller( ApiFees::class )->get_fees_for_ticket( $ticket_id_2 );
+		$ticket_3_fees = $this->make_controller( ApiFees::class )->get_fees_for_ticket( $ticket_id_3 );
+		$ticket_4_fees = $this->make_controller( ApiFees::class )->get_fees_for_ticket( $ticket_id_4 );
+		$ticket_5_fees = $this->make_controller( ApiFees::class )->get_fees_for_ticket( $ticket_id_5 );
 
 		$available_fees = [ $fee_per_ticket_1, $fee_per_ticket_2, $fee_per_ticket_3 ];
 		$automatic_fees = [ $fee_for_all_1, $fee_for_all_2 ];

--- a/tests/order_modifiers_integration/Tables_Test.php
+++ b/tests/order_modifiers_integration/Tables_Test.php
@@ -27,12 +27,12 @@ class Tables_Test extends Controller_Test_Case {
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->exists() );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->exists() );
 
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_slug' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_modifier_type' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_status_modifier_type' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_order_modifier_id' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_meta_key' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_indx_modifier_id' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_indx_post_id' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_index_slug' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_index_modifier_type' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_index_status_modifier_type' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_index_order_modifier_id' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_index_meta_key' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_index_modifier_id' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_index_post_id' ) );
 	}
 }

--- a/tests/order_modifiers_integration/Tables_Test.php
+++ b/tests/order_modifiers_integration/Tables_Test.php
@@ -28,6 +28,7 @@ class Tables_Test extends Controller_Test_Case {
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->exists() );
 
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_slug' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_modifier_type' ) );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_status_modifier_type' ) );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_order_modifier_id' ) );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_meta_key' ) );

--- a/tests/order_modifiers_integration/Tables_Test.php
+++ b/tests/order_modifiers_integration/Tables_Test.php
@@ -28,14 +28,10 @@ class Tables_Test extends Controller_Test_Case {
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->exists() );
 
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_slug' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_status_modifier_type_slug' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_type_display_name' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers::class )->has_index( 'tec_order_modifier_indx_status_modifier_type' ) );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_order_modifier_id' ) );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_meta_key' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_order_modifier_id_meta_key' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifiers_Meta::class )->has_index( 'tec_order_modifier_meta_inx_meta_key_meta_value' ) );
 		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_indx_modifier_id' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_indx_post_type' ) );
-		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_indx_composite_join' ) );
+		$this->assertTrue( tribe( Custom_Tables\Order_Modifier_Relationships::class )->has_index( 'tec_order_modifier_relationship_indx_post_id' ) );
 	}
 }

--- a/tests/order_modifiers_integration/_bootstrap.php
+++ b/tests/order_modifiers_integration/_bootstrap.php
@@ -15,6 +15,12 @@ putenv( 'TEC_TICKETS_COMMERCE=1' );
 putenv( 'TEC_DISABLE_LOGGING=1' );
 // Load Coupons for the tests.
 add_filter( 'tec_tickets_commerce_order_modifiers_coupons_enabled', '__return_true' );
+
+// Drop the custom tables if they exist.
+DB::query( DB::prepare( "DROP TABLE IF EXISTS %i", DB::prefix( 'tec_order_modifiers' ) ) );
+DB::query( DB::prepare( "DROP TABLE IF EXISTS %i", DB::prefix( 'tec_order_modifiers_meta' ) ) );
+DB::query( DB::prepare( "DROP TABLE IF EXISTS %i", DB::prefix( 'tec_order_modifier_relationships' ) ) );
+
 tribe_register_provider( Commerce_Provider::class );
 
 // Ensure `post` is a ticketable post type.
@@ -27,9 +33,9 @@ define( 'JSON_SNAPSHOT_OPTIONS', JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JS
 // Start the posts auto-increment from a high number to make it easier to replace the post IDs in HTML snapshots.
 global $wpdb;
 DB::query( "ALTER TABLE $wpdb->posts AUTO_INCREMENT = 5096" );
-DB::query( DB::prepare( "ALTER TABLE %i AUTO_INCREMENT = 9687", DB::prefix( 'tec_order_modifiers' )) );
-DB::query( DB::prepare( "ALTER TABLE %i AUTO_INCREMENT = 9687", DB::prefix( 'tec_order_modifiers_meta' )) );
-DB::query( DB::prepare( "ALTER TABLE %i AUTO_INCREMENT = 9687", DB::prefix( 'tec_order_modifier_relationships' )) );
+DB::query( DB::prepare( "ALTER TABLE %i AUTO_INCREMENT = 9687", DB::prefix( 'tec_order_modifiers' ) ) );
+DB::query( DB::prepare( "ALTER TABLE %i AUTO_INCREMENT = 9687", DB::prefix( 'tec_order_modifiers_meta' ) ) );
+DB::query( DB::prepare( "ALTER TABLE %i AUTO_INCREMENT = 9687", DB::prefix( 'tec_order_modifier_relationships' ) ) );
 
 // Disconnect Promoter to avoid license-related notices.
 remove_action( 'tribe_tickets_promoter_trigger', [ tribe( Dispatcher::class ), 'trigger' ] );


### PR DESCRIPTION
In this PR i am making sure that:

No index is longer than 191 bytes (when its a text).
Only index what we need to index based on our where statements.
Change column name from object_id from relationships table since there is no object being referenced to id.
Fix queries (especially because of the previous change).

Code is covered by tests already made sure we covered all the changes as well.