### PR TITLE
Update uninstall script to remove schema version options

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -38,6 +38,9 @@ if ( ! $option_value && ! $constant_value ) {
 /** @global wpdb $wpdb */
 global $wpdb;
 
+// Remove the option for this uninstall process, so it must manually be set again.
+delete_option( 'event_tickets_uninstall' );
+
 // Remove the options that indicate what version of the DB tables are installed.
 delete_option( 'stellar_schema_version_tec-order-modifiers' );
 delete_option( 'stellar_schema_version_tec-order-modifiers-meta' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,9 +35,26 @@ if ( ! $option_value && ! $constant_value ) {
  * phpcs:disable WordPress.DB.DirectDatabaseQuery
  */
 
+/** @global wpdb $wpdb */
 global $wpdb;
+
+// Remove the options that indicate what version of the DB tables are installed.
+delete_option( 'stellar_schema_version_tec-order-modifiers' );
+delete_option( 'stellar_schema_version_tec-order-modifiers-meta' );
+delete_option( 'stellar_schema_version_tec-order-modifiers-relationships' );
+
+// Remove the options that indicate the previous version of the DB tables.
+delete_option( 'stellar_schema_previous_version_tec-order-modifiers' );
+delete_option( 'stellar_schema_previous_version_tec-order-modifiers-meta' );
+delete_option( 'stellar_schema_previous_version_tec-order-modifiers-relationships' );
+
+// Disable foreign key checks.
+$wpdb->query( 'SET FOREIGN_KEY_CHECKS = 0' );
 
 // Drop our custom tables.
 $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}tec_order_modifiers" );
 $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}tec_order_modifiers_meta" );
 $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}tec_order_modifier_relationships" );
+
+// Re-enable foreign key checks.
+$wpdb->query( 'SET FOREIGN_KEY_CHECKS = 1' );


### PR DESCRIPTION
### 🎫 Ticket

[ET-2192]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

While testing the uninstall script, I noticed that schema options weren't removed from the database. This could hinder recreating the tables if the plugin is uninstalled and reinstalled.

I also noticed that there was an error when trying to drop the modifiers table related to foreign key checks, so I added queries before/and after the table deletion to disable/enable foreign key checks.

The different schema option names are obtained by combining `stellar_schema_version_` and the `$schema_slug` class property for the custom table class. For previous version options, it is `stellar_schema_previous_version_` plus the `$schema` class property.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2192]: https://stellarwp.atlassian.net/browse/ET-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ