### PR TITLE
Keep fees appearance consinsent in block editor

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/app/blockEditor/fees/checkbox-fee.js
+++ b/src/Tickets/Commerce/Order_Modifiers/app/blockEditor/fees/checkbox-fee.js
@@ -57,17 +57,23 @@ const CheckboxFee = ( {
 	const name = getCheckboxName( clientId, fee );
 
 	return (
-		<Checkbox
-			checked={ isChecked }
-			className={ classNames( getContainerClasses() ) }
-			disabled={ isDisabled }
-			id={ name }
-			label={ getFeeLabel( fee ) }
-			onChange={ onChange }
-			name={ name }
-			value={ fee.id }
-			key={ fee.id }
-		/>
+		<div className={ classNames( 'tribe-editor__checkbox', getContainerClasses() ) }>
+			<CheckboxInput
+				checked={ isChecked }
+				className="tribe-editor__checkbox__input"
+				disabled={ isDisabled }
+				id={ name }
+				name={ name }
+				onChange={ onChange }
+				value={ fee.id }
+				key={ fee.id }
+			/>
+			<LabelWithTooltip
+				forId={ name }
+				isLabel={ true }
+				label={ getFeeLabel( fee ) }
+			/>
+		</div>
 	);
 };
 
@@ -114,7 +120,7 @@ const CheckboxFeeWithTooltip = ( {
 				isLabel={ true }
 				label={ getFeeLabel( fee ) }
 				tooltipText={ tooltipText }
-				tooltipLabel={
+				tooltipLabel={ tooltipText &&
 					<Dashicon
 						className="tribe-editor__ticket__tooltip-label"
 						icon="info-outline"

--- a/src/Tickets/Commerce/Order_Modifiers/app/blockEditor/fees/style.pcss
+++ b/src/Tickets/Commerce/Order_Modifiers/app/blockEditor/fees/style.pcss
@@ -19,9 +19,9 @@
 		padding: var(--tec-spacer-2);
 
 		.tribe-editor__ticket__fee-checkbox {
+			align-items: center;
 			display:flex;
 			flex-flow: row nowrap;
-			align-items: center;
 		}
 
 		.tribe-editor__labeled-item {

--- a/src/Tickets/Commerce/Order_Modifiers/app/blockEditor/fees/style.pcss
+++ b/src/Tickets/Commerce/Order_Modifiers/app/blockEditor/fees/style.pcss
@@ -1,23 +1,31 @@
-.tribe-editor__ticket .tribe-editor__ticket__container {
 
-	.tribe-editor__ticket__content-row--fees {
+.tribe-editor__ticket .tribe-editor__ticket__container .tribe-editor__ticket__content-row--fees {
 
-		.tribe-editor__ticket__active-fees-label {
-			flex: none;
-			width: 140px;
-			padding: var(--tec-spacer-2) 0;
+	.tribe-editor__ticket__active-fees-label {
+		flex: none;
+		width: 140px;
+		padding: var(--tec-spacer-2) 0;
+	}
+
+	.components-select-control__input {
+		width: 100%;
+	}
+
+	.tribe-events-block-editor__add-fee {
+		font-size: var(--tec-font-size-3);
+	}
+
+	.tribe-editor__ticket__order_modifier_fees {
+		padding: var(--tec-spacer-2);
+
+		.tribe-editor__ticket__fee-checkbox {
+			display:flex;
+			flex-flow: row nowrap;
+			align-items: center;
 		}
 
-		.components-select-control__input {
-			width: 100%;
-		}
-
-		.tribe-events-block-editor__add-fee {
-			font-size: var(--tec-font-size-3);
-		}
-
-		.tribe-editor__ticket__order_modifier_fees {
-			padding: var(--tec-spacer-2);
+		.tribe-editor__labeled-item {
+			margin-bottom: var(--tec-spacer-0);
 		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

Issue 15 from gsheet
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fixes appearance of fees into blockeditor.

Unfortunately we dont have yet JS tests for order modifiers.

### 🎥 Artifacts <!-- if applicable-->
the problem: https://www.loom.com/share/5f018ff1a441419193582c411ece9835

the solution:
![image](https://github.com/user-attachments/assets/97f7782f-d426-4bc8-9604-64e4b40e7ca3)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
