### PR TITLE
[ET-2273] Fix show screen options filter in ET

### DIFF
--- a/src/Tickets/Admin/Tickets/Screen_Options.php
+++ b/src/Tickets/Admin/Tickets/Screen_Options.php
@@ -46,6 +46,7 @@ class Screen_Options {
 	 * Filters the screen options show screen.
 	 *
 	 * @since 5.14.0
+	 * @since TBD Fixed show screen logic.
 	 *
 	 * @param boolean   $show   Whether to show the screen options.
 	 * @param WP_Screen $screen The current screen.
@@ -53,7 +54,10 @@ class Screen_Options {
 	 * @return boolean
 	 */
 	public function filter_screen_options_show_screen( $show, $screen ) {
-		$show = ! empty( $screen ) && Page::$hook_suffix === $screen->id;
+		// Only show the screen options on the Tickets screen, otherwise bail.
+		if ( empty( $screen )  || Page::$hook_suffix !== $screen->id ) {
+			return $show;
+		}
 
 		/**
 		 * Filter the screen options show screen.
@@ -62,7 +66,7 @@ class Screen_Options {
 		 *
 		 * @param boolean   $show   Whether to show the screen options.
 		 */
-		return apply_filters( 'tec_tickets_admin_tickets_screen_options_show_screen', $show );
+		return apply_filters( 'tec_tickets_admin_tickets_screen_options_show_screen', true );
 	}
 
 	/**

--- a/tests/integration/TEC/Tickets/Admin/Tickets/Screen_OptionsTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Tickets/Screen_OptionsTest.php
@@ -36,15 +36,19 @@ class Screen_OptionsTest extends \Codeception\TestCase\WPTestCase {
 
 	// test
 	public function test_filter_screen_options_show_screen() {
+		// Correct screen should always returb true.
 		$screen = (object) [
 			'id' => Page::$hook_suffix,
 		];
 		$this->assertTrue( $this->screen_options->filter_screen_options_show_screen( true, $screen ) );
+		$this->assertTrue( $this->screen_options->filter_screen_options_show_screen( false, $screen ) );
 
+		// Wrong screen should always return what is passed.
 		$wrong_screen = (object) [
 			'id' => 'not_the_screen_id',
 		];
-		$this->assertFalse( $this->screen_options->filter_screen_options_show_screen( true, $wrong_screen ) );
+		$this->assertFalse( $this->screen_options->filter_screen_options_show_screen( false, $wrong_screen ) );
+		$this->assertTrue( $this->screen_options->filter_screen_options_show_screen( true, $wrong_screen ) );
 	}
 
 	// test


### PR DESCRIPTION
### 🎫 Ticket
[ET-2273]

### 🗒️ Description
The `screen_options_show_screen` filter should always return what is passed into the filter if it doesn't meet the requirements, not change it to false. This was causing Screen Options to not show when not on the Tickets List page, throughout WordPress. Not good.

### 🎥 Artifacts <!-- if applicable-->
Before fix:
![image](https://github.com/user-attachments/assets/91cfcad4-095a-4fe5-a6c7-7444034f2a3a)

After fix:
![image](https://github.com/user-attachments/assets/9a28a32b-3a9a-4e5c-b698-b8c21843e34e)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2273]: https://stellarwp.atlassian.net/browse/ET-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ