### PR TITLE
Fix/duplicated orders and attendees

### DIFF
--- a/changelog/fix-duplicated-orders-and-attendees
+++ b/changelog/fix-duplicated-orders-and-attendees
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent duplicate orders and as a result duplicated attendees when a payment would initially fail at least once. [ET-2279]

--- a/changelog/fix-duplicated-orders-and-attendees
+++ b/changelog/fix-duplicated-orders-and-attendees
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Prevent duplicate orders and as a result duplicated attendees when a payment would initially fail at least once. [ET-2279]
+Prevent duplicate orders and as a result duplicated attendees when a payment would initially fail at least once. [ET-2280]

--- a/changelog/fix-duplicated-orders-and-attendees-2
+++ b/changelog/fix-duplicated-orders-and-attendees-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Attendee generation during order status transition becomes aware if attendees have been already generated. [ET-2282]

--- a/src/Tickets/Commerce/Abstract_Order.php
+++ b/src/Tickets/Commerce/Abstract_Order.php
@@ -95,7 +95,7 @@ abstract class Abstract_Order {
 		if ( is_user_logged_in() ) {
 			$user                              = wp_get_current_user();
 			$purchaser['purchaser_user_id']    = $user->ID;
-			$purchaser['purchaser_full_name']  = $user->first_name . ' ' . $user->last_name;
+			$purchaser['purchaser_full_name']  = trim( $user->first_name . ' ' . $user->last_name );
 			$purchaser['purchaser_first_name'] = $user->first_name;
 			$purchaser['purchaser_last_name']  = $user->last_name;
 			$purchaser['purchaser_email']      = $user->user_email;

--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -525,7 +525,13 @@ class Attendee {
 		 */
 		do_action( 'tec_tickets_commerce_attendee_before_update', $update_args, $order, $ticket, $args );
 
-		$attendee = tec_tc_attendees()->where( 'id', $existing )->set_args( $update_args )->save();
+		$updated = tec_tc_attendees()->where( 'id', $existing )->set_args( $update_args )->save();
+
+		if ( empty( $updated[ $existing ] ) ) {
+			return $this->create( $order, $ticket, $args );
+		}
+
+		$attendee = tec_tc_attendees()->where( 'id', $existing )->first();
 
 		/**
 		 * Allow the actions after updating the attendee.

--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -501,6 +501,9 @@ class Attendee {
 			$update_args['fields'] = $fields;
 		}
 
+		// No need to update the security code.
+		unset( $update_args['security_code'] );
+
 		/**
 		 * Allow the filtering of the update arguments for attendee.
 		 *

--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -297,7 +297,7 @@ class Attendee {
 		if ( ! $attendee_id ) {
 			return false;
 		}
-		
+
 		$event_id = (int) get_post_meta( $attendee_id, static::$event_relation_meta_key, true );
 
 		/**
@@ -439,6 +439,117 @@ class Attendee {
 		 * @param array         $args     Set of extra arguments used to populate the data for the attendee.
 		 */
 		return apply_filters( 'tec_tickets_commerce_attendee_create', $attendee, $order, $ticket, $args );
+	}
+
+	/**
+	 * Updates or creates an individual attendee given an Order and Ticket.
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Post      $order    Which order generated this attendee.
+	 * @param Ticket_Object $ticket   Which ticket generated this Attendee.
+	 * @param array         $args     Set of extra arguments used to populate the data for the attendee.
+	 * @param ?int          $existing The ID of the existing attendee.
+	 *
+	 * @return \WP_Error|\WP_Post
+	 */
+	public function upsert( \WP_Post $order, $ticket, array $args = [], ?int $existing = null ) {
+		if ( ! $existing ) {
+			return $this->create( $order, $ticket, $args );
+		}
+
+		$update_args = [
+			'order_id'      => $order->ID,
+			'ticket_id'     => $ticket->ID,
+			'event_id'      => $ticket->get_event_id(),
+			'security_code' => Arr::get( $args, 'security_code' ),
+			'opt_out'       => Arr::get( $args, 'opt_out' ),
+			'price_paid'    => Arr::get( $args, 'price_paid' ),
+			'currency'      => Arr::get( $args, 'currency' ),
+		];
+
+		if ( ! empty( $order->purchaser['user_id'] ) ) {
+			$update_args['user_id'] = $order->purchaser['user_id'];
+		}
+
+		if ( ! empty( $args['email'] ) ) {
+			$update_args['email'] = $args['email'];
+		}
+
+		if (
+			empty( $args['email'] )
+			&& ! empty( $order->purchaser['email'] )
+		) {
+			$update_args['email'] = $order->purchaser['email'];
+		}
+
+		if ( ! empty( $args['full_name'] ) ) {
+			$update_args['full_name'] = $args['full_name'];
+			$update_args['title']     = $args['full_name'];
+		}
+
+		if (
+			empty( $args['full_name'] )
+			&& ! empty( $order->purchaser['full_name'] )
+		) {
+			$update_args['full_name'] = $order->purchaser['full_name'];
+			$update_args['title']     = $order->purchaser['full_name'];
+		}
+
+		$fields = Arr::get( $args, 'fields', [] );
+		if ( ! empty( $fields ) ) {
+			$update_args['fields'] = $fields;
+		}
+
+		/**
+		 * Allow the filtering of the update arguments for attendee.
+		 *
+		 * @since TBD
+		 *
+		 * @param array         $update_args Which arguments we are going to use to update the attendee.
+		 * @param \WP_Post      $order       Which order generated this attendee.
+		 * @param Ticket_Object $ticket      Which ticket generated this Attendee.
+		 * @param array         $args        Set of extra arguments used to populate the data for the attendee.
+		 */
+		$update_args = apply_filters( 'tec_tickets_commerce_attendee_update_args', $update_args, $order, $ticket, $args );
+
+		/**
+		 * Allow the actions before updating the attendee.
+		 *
+		 * @since TBD
+		 *
+		 * @param array         $update_args Which arguments we are going to use to update the attendee.
+		 * @param \WP_Post      $order       Which order generated this attendee.
+		 * @param Ticket_Object $ticket      Which ticket generated this Attendee.
+		 * @param array         $args        Set of extra arguments used to populate the data for the attendee.
+		 */
+		do_action( 'tec_tickets_commerce_attendee_before_update', $update_args, $order, $ticket, $args );
+
+		$attendee = tec_tc_attendees()->where( 'id', $existing )->set_args( $update_args )->save();
+
+		/**
+		 * Allow the actions after updating the attendee.
+		 *
+		 * @since TBD
+		 *
+		 * @param \WP_Post      $attendee Post object for the attendee.
+		 * @param \WP_Post      $order    Which order generated this attendee.
+		 * @param Ticket_Object $ticket   Which ticket generated this Attendee.
+		 * @param array         $args     Set of extra arguments used to populate the data for the attendee.
+		 */
+		do_action( 'tec_tickets_commerce_attendee_after_update', $attendee, $order, $ticket, $args );
+
+		/**
+		 * Allow the filtering of the attendee WP_Post after updating attendee.
+		 *
+		 * @since TBD
+		 *
+		 * @param \WP_Post      $attendee Post object for the attendee.
+		 * @param \WP_Post      $order    Which order generated this attendee.
+		 * @param Ticket_Object $ticket   Which ticket generated this Attendee.
+		 * @param array         $args     Set of extra arguments used to populate the data for the attendee.
+		 */
+		return apply_filters( 'tec_tickets_commerce_attendee_update', $attendee, $order, $ticket, $args );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Cart/Unmanaged_Cart.php
+++ b/src/Tickets/Commerce/Cart/Unmanaged_Cart.php
@@ -124,7 +124,7 @@ class Unmanaged_Cart extends Abstract_Cart {
 
 		$this->set_hash( null );
 		delete_transient( Commerce\Cart::get_transient_name( $cart_hash ) );
-		tribe( Commerce\Cart::class )->set_cart_hash_cookie( $cart_hash );
+		tribe( Commerce\Cart::class )->set_cart_hash_cookie( null );
 
 		// clear cart items data.
 		$this->items = [];

--- a/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
+++ b/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
@@ -123,8 +123,12 @@ class Generate_Attendees extends Flag_Action_Abstract {
 						'ticket_id' => $ticket->ID,
 						'event_id'  => $ticket->get_event_id(),
 					]
-				)->fields( 'ids' )->all( true ) as $attendee_id
+				)->get_ids( true ) as $attendee_id
 			) {
+				if ( ! is_int( $attendee_id ) || 0 >= $attendee_id ) {
+					$existing[] = null;
+					continue;
+				}
 				$existing[] = $attendee_id;
 			}
 

--- a/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
+++ b/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
@@ -115,6 +115,8 @@ class Generate_Attendees extends Flag_Action_Abstract {
 
 			$attendees = [];
 
+			$found = [];
+
 			for ( $i = 0; $i < $quantity; $i ++ ) {
 				$args = [
 					'opt_out'       => Arr::get( $extra, 'optout' ),
@@ -143,6 +145,12 @@ class Generate_Attendees extends Flag_Action_Abstract {
 				if ( ! $existing || ! is_int( $existing ) ) {
 					$existing = null;
 				}
+
+				$found[] = $existing;
+
+				$found = array_filter( $found );
+
+				$existing = in_array( $existing, $found, true ) ? null : $existing;
 
 				$attendee = tribe( Attendee::class )->upsert( $order, $ticket, $args, $existing );
 

--- a/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
+++ b/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
@@ -119,9 +119,8 @@ class Generate_Attendees extends Flag_Action_Abstract {
 			foreach (
 				tec_tc_attendees()->by_args(
 					[
-						'order_id'  => $order->ID,
-						'ticket_id' => $ticket->ID,
-						'event_id'  => $ticket->get_event_id(),
+						'post_parent' => $order->ID,
+						'ticket_id'   => $ticket->ID,
 					]
 				)->get_ids( true ) as $attendee_id
 			) {

--- a/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
+++ b/src/Tickets/Commerce/Flag_Actions/Generate_Attendees.php
@@ -138,7 +138,13 @@ class Generate_Attendees extends Flag_Action_Abstract {
 				 */
 				$args = apply_filters( 'tec_tickets_commerce_flag_action_generate_attendee_args', $args, $ticket, $order, $new_status, $old_status, $item, $i );
 
-				$attendee = tribe( Attendee::class )->create( $order, $ticket, $args );
+				$existing = tec_tc_attendees()->by_args( $args )->offset( $i )->first_id();
+
+				if ( ! $existing || ! is_int( $existing ) ) {
+					$existing = null;
+				}
+
+				$attendee = tribe( Attendee::class )->upsert( $order, $ticket, $args, $existing );
 
 				/**
 				 * Fires after an attendee is generated for an order.

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -486,7 +486,7 @@ class Order extends Abstract_Order {
 
 		$order_args['id'] = $existing_order_id;
 
-		$order = $this->upsert( $gateway, $order_args, $existing_order_id );
+		$order = $this->upsert( $gateway, $order_args );
 
 		// We were unable to create the order bail from here.
 		if ( ! $order ) {

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -611,7 +611,7 @@ class Order extends Abstract_Order {
 			/**
 			 * It seems like the $existing_order_id no longer exists or failed to be updated. Let's create a new one instead.
 			 *
-			 * BE AWARE: THe variable $args here is not passed through the update filters since its going to pass through the create filters.
+			 * BE AWARE: The `$args` variable is not passed through the update filters here since it's going to pass through the create filters.
 			 */
 			return $this->create( $gateway, $args );
 		}

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -499,6 +499,8 @@ class Order extends Abstract_Order {
 	 *
 	 * @since 5.2.0
 	 *
+	 * @internal Use `upsert` instead.
+	 *
 	 * @param Gateway_Interface $gateway
 	 * @param array             $args
 	 *

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -605,12 +605,7 @@ class Order extends Abstract_Order {
 		 */
 		$update_args = apply_filters( 'tec_tickets_commerce_order_update_args', $update_args, $gateway );
 
-		$updated = tec_tc_orders()->by_args(
-			[
-				'status' => 'any',
-				'id'     => $existing_order_id,
-			]
-		)->set_args( $update_args )->save();
+		$updated = tec_tc_orders()->where( 'id', $existing_order_id )->set_args( $update_args )->save();
 
 		if ( empty( $updated[ $existing_order_id ] ) ) {
 			/**

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -581,7 +581,7 @@ class Order extends Abstract_Order {
 		 */
 		$existing_order_id = (int) apply_filters( 'tec_tickets_commerce_order_upsert_existing_order_id', $existing_order_id );
 
-		if ( ! $existing_order_id || 0 > $existing_order_id ) {
+		if ( ! $existing_order_id || 0 >= $existing_order_id ) {
 			return $this->create( $gateway, $args );
 		}
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -2,17 +2,14 @@
 
 namespace TEC\Tickets\Commerce;
 
-use TEC\Tickets\Commerce;
 use TEC\Tickets\Commerce\Cart;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Codeception\TestCase\WPTestCase;
-use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
 use WP_Post;
 
 class Order_Test extends WPTestCase {
 	use Ticket_Maker;
-	use Order_Maker;
 
 	public function test_it_does_not_create_multiple_orders_for_single_cart() {
 		$post = self::factory()->post->create();
@@ -49,6 +46,10 @@ class Order_Test extends WPTestCase {
 		$cart->clear_cart();
 		$order_6 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
 		$cart->clear_cart();
+
+		$this->assertInstanceof( WP_Post::class, $order_4 );
+		$this->assertInstanceof( WP_Post::class, $order_5 );
+		$this->assertInstanceof( WP_Post::class, $order_6 );
 
 		// They should NOT be the same order!
 		$this->assertTrue( $order_4->ID !== $order_5->ID );

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -6,10 +6,12 @@ use TEC\Tickets\Commerce\Cart;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Codeception\TestCase\WPTestCase;
 use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
+use Tribe\Tests\Traits\With_Uopz;
 use WP_Post;
 
 class Order_Test extends WPTestCase {
 	use Ticket_Maker;
+	use With_Uopz;
 
 	public function test_it_does_not_create_multiple_orders_for_single_cart() {
 		$post = self::factory()->post->create();
@@ -17,14 +19,18 @@ class Order_Test extends WPTestCase {
 		$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
 
 		$cart = tribe( Cart::class );
-		$hash = $cart->get_cart_hash( true );
 
-		$this->assertTrue( ! empty( $hash ) && is_string( $hash ) );
+		$this->set_fn_return( 'wp_generate_password', 'abcdefghijklmnop' );
+		$hash = $cart->get_cart_hash( true );
+		$this->assertSame( 'abcdefghijklmnop', $hash );
 
 		// Careful!!! Each next order includes previous order's items as well since we are not clearing the cart in between!!
 		$order_1 = $this->create_order_from_cart( [ $ticket_id_1 => 1 ] );
+		$this->assertSame( 'abcdefghijklmnop', $cart->get_cart_hash() );
 		$order_2 = $this->create_order_from_cart( [ $ticket_id_2 => 1 ] );
+		$this->assertSame( 'abcdefghijklmnop', $cart->get_cart_hash() );
 		$order_3 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
+		$this->assertSame( 'abcdefghijklmnop', $cart->get_cart_hash() );
 
 		$this->assertInstanceof( WP_Post::class, $order_1 );
 		$this->assertInstanceof( WP_Post::class, $order_2 );
@@ -35,16 +41,28 @@ class Order_Test extends WPTestCase {
 		$this->assertEquals( $order_1->ID, $order_3->ID );
 
 		// They should not have the same totals!
-		$this->assertEquals( 10, $order_1->total_value->get_decimal() );
-		$this->assertEquals( 30, $order_2->total_value->get_decimal() );
-		$this->assertEquals( 90, $order_3->total_value->get_decimal() );
+		$this->assertSame( 10.0, $order_1->total_value->get_decimal() );
+		$this->assertSame( 30.0, $order_2->total_value->get_decimal() );
+		$this->assertSame( 90.0, $order_3->total_value->get_decimal() );
+
+		$times =0;
+		$this->set_fn_return( 'wp_generate_password', function () use ( &$times ) {
+			$times++;
+			return 'abcdefghijklmnop-' . $times;
+		}, true );
 
 		$cart->clear_cart();
+		$cart->get_cart_hash( true );
 		$order_4 = $this->create_order_from_cart( [ $ticket_id_1 => 1 ] );
+		$this->assertSame( 'abcdefghijklmnop-1', $cart->get_cart_hash() );
 		$cart->clear_cart();
+		$cart->get_cart_hash( true );
 		$order_5 = $this->create_order_from_cart( [ $ticket_id_2 => 1 ] );
+		$this->assertSame( 'abcdefghijklmnop-2', $cart->get_cart_hash() );
 		$cart->clear_cart();
+		$cart->get_cart_hash( true );
 		$order_6 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
+		$this->assertSame( 'abcdefghijklmnop-3', $cart->get_cart_hash() );
 		$cart->clear_cart();
 
 		$this->assertInstanceof( WP_Post::class, $order_4 );
@@ -52,14 +70,13 @@ class Order_Test extends WPTestCase {
 		$this->assertInstanceof( WP_Post::class, $order_6 );
 
 		// They should NOT be the same order!
-		$this->assertTrue( $order_4->ID !== $order_5->ID );
-		$this->assertTrue( $order_4->ID !== $order_6->ID );
-		$this->assertTrue( $order_5->ID !== $order_6->ID );
+		$this->assertNotSame( $order_4->ID, $order_5->ID );
+		$this->assertNotSame( $order_4->ID, $order_6->ID );
+		$this->assertNotSame( $order_5->ID, $order_6->ID );
 
-		// They should have the same totals though.
-		$this->assertEquals( 10, $order_4->total_value->get_decimal() );
-		$this->assertEquals( 20, $order_5->total_value->get_decimal() );
-		$this->assertEquals( 60, $order_6->total_value->get_decimal() );
+		$this->assertSame( 10.0, $order_4->total_value->get_decimal() );
+		$this->assertSame( 20.0, $order_5->total_value->get_decimal() );
+		$this->assertSame( 60.0, $order_6->total_value->get_decimal() );
 	}
 
 	protected function create_order_from_cart( array $items, array $overrides = [] ) {

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace TEC\Tickets\Commerce;
+
+use TEC\Tickets\Commerce;
+use TEC\Tickets\Commerce\Cart;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
+use WP_Post;
+
+class Order_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Order_Maker;
+
+	public function test_it_does_not_create_multiple_orders_for_single_cart() {
+		$post = self::factory()->post->create();
+		$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
+		$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
+
+		$cart = tribe( Cart::class );
+		$hash = $cart->get_cart_hash( true );
+
+		$this->assertTrue( ! empty( $hash ) && is_string( $hash ) );
+
+		// Careful!!! Each next order includes previous order's items as well since we are not clearing the cart in between!!
+		$order_1 = $this->create_order_from_cart( [ $ticket_id_1 => 1 ] );
+		$order_2 = $this->create_order_from_cart( [ $ticket_id_2 => 1 ] );
+		$order_3 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
+
+		$this->assertInstanceof( WP_Post::class, $order_1 );
+		$this->assertInstanceof( WP_Post::class, $order_2 );
+		$this->assertInstanceof( WP_Post::class, $order_3 );
+
+		// They should be the same order!
+		$this->assertEquals( $order_1->ID, $order_2->ID );
+		$this->assertEquals( $order_1->ID, $order_3->ID );
+
+		// They should not have the same totals!
+		$this->assertEquals( 10, $order_1->total_value->get_decimal() );
+		$this->assertEquals( 30, $order_2->total_value->get_decimal() );
+		$this->assertEquals( 90, $order_3->total_value->get_decimal() );
+
+		$cart->clear_cart();
+		$order_4 = $this->create_order_from_cart( [ $ticket_id_1 => 1 ] );
+		$cart->clear_cart();
+		$order_5 = $this->create_order_from_cart( [ $ticket_id_2 => 1 ] );
+		$cart->clear_cart();
+		$order_6 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
+		$cart->clear_cart();
+
+		// They should NOT be the same order!
+		$this->assertTrue( $order_4->ID !== $order_5->ID );
+		$this->assertTrue( $order_4->ID !== $order_6->ID );
+		$this->assertTrue( $order_5->ID !== $order_6->ID );
+
+		// They should have the same totals though.
+		$this->assertEquals( 10, $order_4->total_value->get_decimal() );
+		$this->assertEquals( 20, $order_5->total_value->get_decimal() );
+		$this->assertEquals( 60, $order_6->total_value->get_decimal() );
+	}
+
+	protected function create_order_from_cart( array $items, array $overrides = [] ) {
+		foreach ( $items as $id => $quantity ) {
+			tribe( Cart::class )->get_repository()->add_item( $id, $quantity );
+		}
+
+		$default_purchaser = [
+			'purchaser_user_id'    => 0,
+			'purchaser_full_name'  => 'Test Purchaser',
+			'purchaser_first_name' => 'Test',
+			'purchaser_last_name'  => 'Purchaser',
+			'purchaser_email'      => 'test-' . uniqid() . '@test.com',
+		];
+
+		$purchaser = wp_parse_args( $overrides, $default_purchaser );
+
+		$feed_args_callback = function ( $args ) use ( $overrides ) {
+			$args['post_date']     = $overrides['post_date'] ?? '';
+			$args['post_date_gmt'] = $overrides['post_date_gmt'] ?? $args['post_date'];
+
+			return $args;
+		};
+
+		add_filter( 'tec_tickets_commerce_order_create_args', $feed_args_callback );
+
+		$orders = tribe( Order::class );
+		$order  = $orders->create_from_cart( tribe( Gateway::class ), $purchaser );
+
+		clean_post_cache( $order->ID );
+
+		remove_filter( 'tec_tickets_commerce_order_create_args', $feed_args_callback );
+
+		return $order;
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2280]
[ET-2282]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The issues we have identified regarding attendee duplications are:

Issue 1: Duplicating attendees on status transition without considering if attendees are already created.
Issue 2: Duplicating orders and as a result attendees when at least one failed payment try.
Issue 3: Duplicating attendees because of race condition. Webhook running prior Ajax.

This PR is dealing with Issue 1 and 2.

Description in video: https://www.loom.com/share/43b3d371066c40a2b4c341e63044c8aa

### 🎥 Artifacts <!-- if applicable-->

Solution in video: https://www.loom.com/share/9342174d6cee48efaf7a4d3bec06abff

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2280]: https://stellarwp.atlassian.net/browse/ET-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-2282]: https://stellarwp.atlassian.net/browse/ET-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ