### PR TITLE
[ET-2269] Tickets Commerce: Add filter for cart hash cookie name

### DIFF
--- a/changelog/tweak-ET-2269-enable-way-to-customize-cart-cookie-name
+++ b/changelog/tweak-ET-2269-enable-way-to-customize-cart-cookie-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add filter to customize the cart hash cookie name for Tickets Commerce. [ET-2269]

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -231,10 +231,10 @@ class Cart {
 		$cart_hash = $this->get_repository()->get_hash();
 
 		if (
-			! empty( $_COOKIE[ static::$cart_hash_cookie_name ] )
-			&& strlen( $_COOKIE[ static::$cart_hash_cookie_name ] ) === $cart_hash_length
+			! empty( $_COOKIE[ static::get_cart_hash_cookie_name() ] )
+			&& strlen( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) === $cart_hash_length
 		) {
-			$cart_hash = $_COOKIE[ static::$cart_hash_cookie_name ];
+			$cart_hash = $_COOKIE[ static::get_cart_hash_cookie_name() ];
 
 			$cart_hash_transient = get_transient( static::get_transient_name( $cart_hash ) );
 
@@ -288,7 +288,7 @@ class Cart {
 		$this->set_cart_hash_cookie( null );
 		$this->get_repository()->clear();
 
-		unset( $_COOKIE[ static::$cart_hash_cookie_name ] );
+		unset( $_COOKIE[ static::get_cart_hash_cookie_name() ] );
 
 		return delete_transient( static::get_current_cart_transient() );
 	}
@@ -321,11 +321,11 @@ class Cart {
 			$expire = 1;
 		}
 
-		$is_cookie_set = setcookie( static::$cart_hash_cookie_name, $value ?? '', $expire, COOKIEPATH ?: '/', COOKIE_DOMAIN, is_ssl(), true );
+		$is_cookie_set = setcookie( static::get_cart_hash_cookie_name(), $value ?? '', $expire, COOKIEPATH ?: '/', COOKIE_DOMAIN, is_ssl(), true );
 
 		if ( $is_cookie_set ) {
 			// Overwrite local variable, so we can use it right away.
-			$_COOKIE[ static::$cart_hash_cookie_name ] = $value;
+			$_COOKIE[ static::get_cart_hash_cookie_name() ] = $value;
 		}
 
 		return $is_cookie_set;
@@ -654,5 +654,25 @@ class Cart {
 	 */
 	public function get_cart_subtotal(): float {
 		return $this->get_repository()->get_cart_subtotal();
+	}
+
+	/**
+	 * Get cart has cookie name.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_cart_hash_cookie_name(): string {
+		/**
+		 * Filters the cart hash cookie name.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $cart_hash_cookie_name The cart hash cookie name.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'tec_tickets_commerce_cart_hash_cookie_name', static::$cart_hash_cookie_name );
 	}
 }

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -231,7 +231,7 @@ class Cart {
 
 		$cart_hash = $this->get_repository()->get_hash();
 
-		$hash_from_cookie = sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] ?? '' );
+		$hash_from_cookie = sanitize_text_field( $_COOKIE[ static::get_cart_hash_cookie_name() ] ?? '' );
 
 		if (
 			strlen( $hash_from_cookie ) === $cart_hash_length

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -231,7 +231,7 @@ class Cart {
 
 		$cart_hash = $this->get_repository()->get_hash();
 
-		$hash_from_cookie = sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) ?? '';
+		$hash_from_cookie = sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] ?? '' );
 
 		if (
 			strlen( $hash_from_cookie ) === $cart_hash_length

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -232,9 +232,9 @@ class Cart {
 
 		if (
 			! empty( $_COOKIE[ static::get_cart_hash_cookie_name() ] )
-			&& strlen( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) === $cart_hash_length
+			&& strlen( esc_html( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) ) === $cart_hash_length
 		) {
-			$cart_hash = $_COOKIE[ static::get_cart_hash_cookie_name() ];
+			$cart_hash = esc_html( $_COOKIE[ static::get_cart_hash_cookie_name() ] );
 
 			$cart_hash_transient = get_transient( static::get_transient_name( $cart_hash ) );
 

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -673,6 +673,8 @@ class Cart {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_tickets_commerce_cart_hash_cookie_name', static::$cart_hash_cookie_name );
+		$filtered_cookie_name = apply_filters( 'tec_tickets_commerce_cart_hash_cookie_name', static::$cart_hash_cookie_name );
+
+		return sanitize_title( $filtered_cookie_name );
 	}
 }

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -231,11 +231,12 @@ class Cart {
 
 		$cart_hash = $this->get_repository()->get_hash();
 
+		$hash_from_cookie = sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) ?? '';
+
 		if (
-			! empty( $_COOKIE[ static::get_cart_hash_cookie_name() ] )
-			&& strlen( sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) ) === $cart_hash_length
+			strlen( $hash_from_cookie ) === $cart_hash_length
 		) {
-			$cart_hash = sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] );
+			$cart_hash = $hash_from_cookie;
 
 			$cart_hash_transient = get_transient( static::get_transient_name( $cart_hash ) );
 
@@ -299,7 +300,7 @@ class Cart {
 	 *
 	 * @since 5.1.9
 	 *
-	 * @parem string $value Value used for the cookie or empty to purge the cookie.
+	 * @param string $value Value used for the cookie or empty to purge the cookie.
 	 *
 	 * @return boolean
 	 */

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 
 namespace TEC\Tickets\Commerce;
 
@@ -232,9 +233,9 @@ class Cart {
 
 		if (
 			! empty( $_COOKIE[ static::get_cart_hash_cookie_name() ] )
-			&& strlen( esc_html( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) ) === $cart_hash_length
+			&& strlen( sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] ) ) === $cart_hash_length
 		) {
-			$cart_hash = esc_html( $_COOKIE[ static::get_cart_hash_cookie_name() ] );
+			$cart_hash = sanitize_key( $_COOKIE[ static::get_cart_hash_cookie_name() ] );
 
 			$cart_hash_transient = get_transient( static::get_transient_name( $cart_hash ) );
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/CartTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/CartTest.php
@@ -173,4 +173,23 @@ class CartTest extends \Codeception\TestCase\WPTestCase {
 		$assertion_msg = 'Cart->get_total() should return 0 when the cart contains only free tickets.';
 		$this->assertEquals( 0, $cart->get_cart_total(), $assertion_msg );
 	}
+
+	/**
+	 * @test
+	 *
+	 * @covers \TEC\Tickets\Commerce\Cart::get_cart_hash_cookie_name
+	 */
+	public function test_cart_hash_cookie_name() {
+		$original_cookie_name = Cart::get_cart_hash_cookie_name();
+		$this->assertEquals( Cart::$cart_hash_cookie_name, $original_cookie_name );
+
+		add_filter( 'tribe_tickets_commerce_cart_hash_cookie_name', function() {
+			return 'different_cookie_name';
+		} );
+
+		$different_cookie_name = Cart::get_cart_hash_cookie_name();
+		$this->assertEquals( 'different_cookie_name', $different_cookie_name );
+
+		$this->assertNotEquals( $original_cookie_name, $different_cookie_name );
+	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/CartTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/CartTest.php
@@ -183,7 +183,7 @@ class CartTest extends \Codeception\TestCase\WPTestCase {
 		$original_cookie_name = Cart::get_cart_hash_cookie_name();
 		$this->assertEquals( Cart::$cart_hash_cookie_name, $original_cookie_name );
 
-		add_filter( 'tribe_tickets_commerce_cart_hash_cookie_name', function() {
+		add_filter( 'tec_tickets_commerce_cart_hash_cookie_name', function() {
 			return 'different_cookie_name';
 		} );
 


### PR DESCRIPTION
### 🎫 Ticket
[ET-2269]

### 🗒️ Description
Adding a filter to change the name of the Tickets Commerce Cart Hash Cookie. This will allow Pantheon users to be able to sell tickets via TC.

### 🎥 Artifacts <!-- if applicable-->
https://share.zight.com/yAugl61k

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2269]: https://stellarwp.atlassian.net/browse/ET-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ