### PR TITLE
Include status check as part of the transaction

### DIFF
--- a/changelog/fix-include-status-check-as-part-of-the-transaction
+++ b/changelog/fix-include-status-check-as-part-of-the-transaction
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Introduced method `can_transition_to_status` which is preferred over `can_apply_to` along with the order locking system to prevent race conditions. [ET-2281]
+Introduced methods `can_change_to` for Statuses and `can_transition_to` for Orders. [ET-2281]

--- a/changelog/fix-include-status-check-as-part-of-the-transaction
+++ b/changelog/fix-include-status-check-as-part-of-the-transaction
@@ -1,5 +1,4 @@
 Significance: patch
 Type: tweak
-Comment: Changelog entry is already present for this issue - just working on top of it
 
-
+Introduced method `can_transition_to_status` which is preferred over `can_apply_to` along with the order locking system to prevent race conditions. [ET-2281]

--- a/changelog/fix-include-status-check-as-part-of-the-transaction
+++ b/changelog/fix-include-status-check-as-part-of-the-transaction
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Changelog entry is already present for this issue - just working on top of it
+
+

--- a/changelog/fix-include-status-check-as-part-of-the-transaction-2
+++ b/changelog/fix-include-status-check-as-part-of-the-transaction-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Introduced various hooks for the order lock system and order completed checkout actions. [ET-2281]

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -522,12 +522,12 @@ class Order extends Abstract_Order {
 		 * @param Value             $subtotal  The calculated subtotal of the cart items.
 		 * @param Gateway_Interface $gateway   The payment gateway used for the order.
 		 * @param ?array            $purchaser { Purchaser details.
-		 * @type ?int $purchaser_user_id The purchaser user ID.
-		 * @type ?string $purchaser_full_name The purchaser full name.
-		 * @type ?string $purchaser_first_name The purchaser first name.
-		 * @type ?string $purchaser_last_name The purchaser last name.
-		 * @type ?string $purchaser_email The purchaser email.
-		 *                                     }
+		 *     @type ?int $purchaser_user_id The purchaser user ID.
+		 *     @type ?string $purchaser_full_name The purchaser full name.
+		 *     @type ?string $purchaser_first_name The purchaser first name.
+		 *     @type ?string $purchaser_last_name The purchaser last name.
+		 *     @type ?string $purchaser_email The purchaser email.
+		 * }
 		 */
 		$items = apply_filters(
 			'tec_tickets_commerce_create_order_from_cart_items',

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -1065,6 +1065,8 @@ class Order extends Abstract_Order {
 			 */
 			do_action( 'tec_tickets_commerce_order_unlocked', $result, $order_id, $this->get_lock_id() );
 
+			$this->reset_lock_id();
+
 			return $result;
 		} catch ( DatabaseQueryException $e ) {
 			return false;
@@ -1080,6 +1082,17 @@ class Order extends Abstract_Order {
 	 */
 	public function get_lock_id(): string {
 		return self::$lock_id;
+	}
+
+	/**
+	 * Reset the lock ID.
+	 *
+	 * Usually after unlocking an order.
+	 *
+	 * @since TBD
+	 */
+	public function reset_lock_id(): void {
+		self::$lock_id = '';
 	}
 
 	/**

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -522,11 +522,11 @@ class Order extends Abstract_Order {
 		 * @param Value             $subtotal  The calculated subtotal of the cart items.
 		 * @param Gateway_Interface $gateway   The payment gateway used for the order.
 		 * @param ?array            $purchaser { Purchaser details.
-		 *     @type ?int $purchaser_user_id The purchaser user ID.
-		 *     @type ?string $purchaser_full_name The purchaser full name.
-		 *     @type ?string $purchaser_first_name The purchaser first name.
-		 *     @type ?string $purchaser_last_name The purchaser last name.
-		 *     @type ?string $purchaser_email The purchaser email.
+		 *    @type ?int    $purchaser_user_id    The purchaser user ID.
+		 *    @type ?string $purchaser_full_name  The purchaser full name.
+		 *    @type ?string $purchaser_first_name The purchaser first name.
+		 *    @type ?string $purchaser_last_name  The purchaser last name.
+		 *    @type ?string $purchaser_email      The purchaser email.
 		 * }
 		 */
 		$items = apply_filters(

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -800,7 +800,6 @@ class Order extends Abstract_Order {
 	 * @since 5.1.9
 	 *
 	 * @param int  $post_id    A post ID.
-	 *
 	 * @param int  $error_code The current error code.
 	 * @param bool $redirect   Whether to really redirect or not.
 	 *

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -799,9 +799,9 @@ class Order extends Abstract_Order {
 	 *
 	 * @since 5.1.9
 	 *
-	 * @param int  $post_id    A post ID.
 	 * @param int  $error_code The current error code.
 	 * @param bool $redirect   Whether to really redirect or not.
+	 * @param int  $post_id    A post ID.
 	 *
 	 * @todo  Deprecate tpp_error
 	 *

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -291,9 +291,7 @@ class Order extends Abstract_Order {
 				'item_scheduled'           => __( 'Order scheduled.', 'event-tickets' ),
 				'item_updated'             => __( 'Order updated.', 'event-tickets' ),
 				'item_link'                => _x( 'Order Link', 'navigation link block title', 'event-tickets' ),
-				'item_link_description'    => _x( 'A link to an order.',
-					'navigation link block description',
-					'event-tickets' ),
+				'item_link_description'    => _x( 'A link to an order.', 'navigation link block description', 'event-tickets' ),
 			],
 		];
 
@@ -363,8 +361,6 @@ class Order extends Abstract_Order {
 	 * @param array  $extra_args  Extra repository arguments.
 	 *
 	 * @return bool|\WP_Error
-	 * @throws \Tribe__Repository__Usage_Error
-	 *
 	 */
 	public function modify_status( $order_id, $status_slug, array $extra_args = [] ) {
 		$status = tribe( Status\Status_Handler::class )->get_by_slug( $status_slug );
@@ -486,27 +482,29 @@ class Order extends Abstract_Order {
 		$cart = tribe( Cart::class );
 
 		$items = $cart->get_items_in_cart();
-		$items = array_filter( array_map(
-			static function ( $item ) {
-				/** @var Value $ticket_value */
-				$ticket_value         = tribe( Ticket::class )->get_price_value( $item['ticket_id'] );
-				$ticket_regular_value = tribe( Ticket::class )->get_price_value( $item['ticket_id'], true );
+		$items = array_filter(
+			array_map(
+				static function ( $item ) {
+					/** @var Value $ticket_value */
+					$ticket_value         = tribe( Ticket::class )->get_price_value( $item['ticket_id'] );
+					$ticket_regular_value = tribe( Ticket::class )->get_price_value( $item['ticket_id'], true );
 
-				if ( null === $ticket_value ) {
-					return null;
-				}
+					if ( null === $ticket_value ) {
+						return null;
+					}
 
-				$item['price']     = $ticket_value->get_decimal();
-				$item['sub_total'] = $ticket_value->sub_total( $item['quantity'] )->get_decimal();
-				$item['event_id']  = tribe( Ticket::class )->get_related_event_id( $item['ticket_id'] );
+					$item['price']     = $ticket_value->get_decimal();
+					$item['sub_total'] = $ticket_value->sub_total( $item['quantity'] )->get_decimal();
+					$item['event_id']  = tribe( Ticket::class )->get_related_event_id( $item['ticket_id'] );
 
-				$item['regular_price']     = $ticket_regular_value->get_decimal();
-				$item['regular_sub_total'] = $ticket_regular_value->sub_total( $item['quantity'] )->get_decimal();
+					$item['regular_price']     = $ticket_regular_value->get_decimal();
+					$item['regular_sub_total'] = $ticket_regular_value->sub_total( $item['quantity'] )->get_decimal();
 
-				return $item;
-			},
-			$items
-		) );
+					return $item;
+				},
+				$items
+			)
+		);
 
 		$subtotal = $this->get_value_total( $items );
 
@@ -667,8 +665,7 @@ class Order extends Abstract_Order {
 		 *
 		 * @param int $existing_order_id The existing order ID.
 		 */
-		$existing_order_id = (int) apply_filters( 'tec_tickets_commerce_order_upsert_existing_order_id',
-			$existing_order_id );
+		$existing_order_id = (int) apply_filters( 'tec_tickets_commerce_order_upsert_existing_order_id', $existing_order_id );
 
 		if ( ! $existing_order_id || 0 >= $existing_order_id ) {
 			return $this->create( $gateway, $args );

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -1146,7 +1146,7 @@ class Order extends Abstract_Order {
 			/**
 			 * Filters whether the checkout is completed.
 			 *
-			 * Direct query to overcome object cache.
+			 * Does a direct query to overcome object cache.
 			 *
 			 * @since TBD
 			 *

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -789,7 +789,7 @@ class Order extends Abstract_Order {
 	 * @todo  Deprecate tpp_error
 	 *
 	 * @see   \Tribe__Tickets__Commerce__PayPal__Errors for error codes translations.
-	 * @todo  Determine if redirecting should be something relegated to some other method, and here we just actually
+	 * @todo  Determine if redirecting should be something relegated to some other method, and here we only generate
 	 *        generate the order/Attendees.
 	 *
 	 */

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -385,7 +385,7 @@ class Order extends Abstract_Order {
 
 		$can_transition = $this->can_transition_to( $new_status, $order_id );
 
-		if ( ! $can_transition || is_wp_error( $can_transition ) ) {
+		if ( ! $can_transition ) {
 			DB::rollback();
 
 			return $can_transition;

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -407,11 +407,11 @@ class Order extends Abstract_Order {
 
 		$current_status = tribe( Status\Status_Handler::class )->get_by_wp_slug( $current_status_wp_slug );
 
-		$can_apply = $status->status_can_apply_to_status( $current_status, $status, $order_id );
-		if ( ! $can_apply || is_wp_error( $can_apply ) ) {
+		$can_transition = $current_status->can_transition_to_status( $status, $order_id );
+		if ( ! $can_transition || is_wp_error( $can_transition ) ) {
 			DB::rollback();
 
-			return $can_apply;
+			return $can_transition;
 		}
 
 		$args = array_merge( $extra_args, [ 'status' => $status->get_wp_slug() ] );

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -72,7 +72,7 @@ class Pending extends Status_Abstract {
 	 * @param self $new_status     The new status.
 	 * @param ?int $order_id       Which order we are testing against.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool|WP_Error Whether the new status can be applied to the current status.
 	 */
 	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
 		return $this->can_apply_to_pending_status(
@@ -84,8 +84,12 @@ class Pending extends Status_Abstract {
 	/**
 	 * Whether new status can be applied to the current status.
 	 *
+	 * @since TBD
+	 *
 	 * @param bool|WP_Error $status Parent's method result.
 	 * @param int|\WP_Post  $order  Which order we are testing against.
+	 *
+	 * @return bool|WP_Error Whether the new status can be applied to the current status.
 	 */
 	protected function can_apply_to_pending_status( $status, $order ) {
 		// If the parent status is final, don't run.

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -60,8 +60,31 @@ class Pending extends Status_Abstract {
 	 * {@inheritdoc}
 	 */
 	public function can_apply_to( $order, $new_status ) {
-		$status = parent::can_apply_to( $order, $new_status );
+		return $this->can_apply_to_pending_status( parent::can_apply_to( $order, $new_status ), $order );
+	}
 
+	/**
+	 * Whether a Status Interface can be applied on top of another Status Interface.
+	 *
+	 * @since TBD
+	 *
+	 * @param self $current_status The current status.
+	 * @param self $new_status     The new status.
+	 * @param ?int $order_id       Which order we are testing against.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
+		return $this->can_apply_to_pending_status( parent::status_can_apply_to_status( $current_status, $new_status, $order_id ), $order_id );
+	}
+
+	/**
+	 * Whether new status can be applied to the current status.
+	 *
+	 * @param bool|WP_Error $status Parent's method result.
+	 * @param int|\WP_Post  $order  Which order we are testing against.
+	 */
+	protected function can_apply_to_pending_status( $status, $order ) {
 		// If the parent status is final, don't run.
 		if ( ! $status ) {
 			return $status;

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -75,7 +75,10 @@ class Pending extends Status_Abstract {
 	 * @return bool|WP_Error
 	 */
 	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
-		return $this->can_apply_to_pending_status( parent::status_can_apply_to_status( $current_status, $new_status, $order_id ), $order_id );
+		return $this->can_apply_to_pending_status(
+			parent::status_can_apply_to_status( $current_status, $new_status, $order_id ),
+			$order_id
+		);
 	}
 
 	/**

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -62,6 +62,11 @@ class Pending extends Status_Abstract {
 	public function can_apply_to( $order, $new_status ) {
 		$status = parent::can_apply_to( $order, $new_status );
 
+		// If the parent status is final, don't run.
+		if ( ! $status ) {
+			return $status;
+		}
+
 		// If the parent status or abstract has an error already we dont even run.
 		if ( is_wp_error( $status ) ) {
 			return $status;

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -60,41 +60,7 @@ class Pending extends Status_Abstract {
 	 * {@inheritdoc}
 	 */
 	public function can_apply_to( $order, $new_status ) {
-		return $this->can_transition_from_pending_to_status( parent::can_apply_to( $order, $new_status ), $order );
-	}
-
-	/**
-	 * Whether a Status Interface can be applied on top of another Status Interface.
-	 *
-	 * @since TBD
-	 *
-	 * @param self $new_status     The new status.
-	 * @param ?int $order_id       Which order we are testing against.
-	 *
-	 * @return bool|WP_Error Whether the new status can be applied to the current status.
-	 */
-	public function can_transition_to_status( $new_status, $order_id = null ) {
-		return $this->can_transition_from_pending_to_status(
-			parent::can_transition_to_status( $new_status, $order_id ),
-			$order_id
-		);
-	}
-
-	/**
-	 * Whether new status can be applied to the current status.
-	 *
-	 * @since TBD
-	 *
-	 * @param bool|WP_Error $status Parent's method result.
-	 * @param int|\WP_Post  $order  Which order we are testing against.
-	 *
-	 * @return bool|WP_Error Whether the new status can be applied to the current status.
-	 */
-	protected function can_transition_from_pending_to_status( $status, $order ) {
-		// If the parent status is final, don't run.
-		if ( ! $status ) {
-			return $status;
-		}
+		$status = parent::can_apply_to( $order, $new_status );
 
 		// If the parent status or abstract has an error already we dont even run.
 		if ( is_wp_error( $status ) ) {

--- a/src/Tickets/Commerce/Status/Pending.php
+++ b/src/Tickets/Commerce/Status/Pending.php
@@ -60,7 +60,7 @@ class Pending extends Status_Abstract {
 	 * {@inheritdoc}
 	 */
 	public function can_apply_to( $order, $new_status ) {
-		return $this->can_apply_to_pending_status( parent::can_apply_to( $order, $new_status ), $order );
+		return $this->can_transition_from_pending_to_status( parent::can_apply_to( $order, $new_status ), $order );
 	}
 
 	/**
@@ -68,15 +68,14 @@ class Pending extends Status_Abstract {
 	 *
 	 * @since TBD
 	 *
-	 * @param self $current_status The current status.
 	 * @param self $new_status     The new status.
 	 * @param ?int $order_id       Which order we are testing against.
 	 *
 	 * @return bool|WP_Error Whether the new status can be applied to the current status.
 	 */
-	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
-		return $this->can_apply_to_pending_status(
-			parent::status_can_apply_to_status( $current_status, $new_status, $order_id ),
+	public function can_transition_to_status( $new_status, $order_id = null ) {
+		return $this->can_transition_from_pending_to_status(
+			parent::can_transition_to_status( $new_status, $order_id ),
 			$order_id
 		);
 	}
@@ -91,7 +90,7 @@ class Pending extends Status_Abstract {
 	 *
 	 * @return bool|WP_Error Whether the new status can be applied to the current status.
 	 */
-	protected function can_apply_to_pending_status( $status, $order ) {
+	protected function can_transition_from_pending_to_status( $status, $order ) {
 		// If the parent status is final, don't run.
 		if ( ! $status ) {
 			return $status;

--- a/src/Tickets/Commerce/Status/Refunded.php
+++ b/src/Tickets/Commerce/Status/Refunded.php
@@ -62,7 +62,7 @@ class Refunded extends Status_Abstract {
 	 *
 	 * @return bool Whether the new status can be applied to the current status.
 	 */
-	public function can_change_to( $new_status ) {
+	public function can_change_to( $new_status ): bool {
 		if ( $this->get_wp_slug() === $new_status->get_wp_slug() ) {
 			// Refunded can be changed to Refunded to manage multiple refunds.
 			return true;

--- a/src/Tickets/Commerce/Status/Refunded.php
+++ b/src/Tickets/Commerce/Status/Refunded.php
@@ -54,6 +54,28 @@ class Refunded extends Status_Abstract {
 	}
 
 	/**
+	 * Whether a Status Interface can be changed to another Status Interface.
+	 *
+	 * @since TBD
+	 *
+	 * @param self $new_status The new status.
+	 *
+	 * @return bool Whether the new status can be applied to the current status.
+	 */
+	public function can_change_to( $new_status ) {
+		if ( $this->get_wp_slug() === $new_status->get_wp_slug() ) {
+			// Refunded can be changed to Refunded to manage multiple refunds.
+			return true;
+		}
+
+		if ( $this->is_final() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function can_be_updated_to(): array {

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -153,19 +153,18 @@ abstract class Status_Abstract implements Status_Interface {
 	 *
 	 * @since TBD
 	 *
-	 * @param self $current_status The current status.
-	 * @param self $new_status     The new status.
-	 * @param ?int $order_id       Which order we are testing against.
+	 * @param self $new_status The new status.
+	 * @param ?int $order_id   Which order we are testing against.
 	 *
 	 * @return bool Whether the new status can be applied to the current status.
 	 */
-	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
-		if ( $current_status->get_wp_slug() === $new_status->get_wp_slug() ) {
+	public function can_transition_to_status( $new_status, $order_id = null ) {
+		if ( $this->get_wp_slug() === $new_status->get_wp_slug() ) {
 			// Allow from refunded to refunded in order to support multiple refunds.
-			return 'refunded' === $current_status->get_slug();
+			return 'refunded' === $this->get_slug();
 		}
 
-		if ( $current_status->is_final() ) {
+		if ( $this->is_final() ) {
 			return false;
 		}
 

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -149,6 +149,30 @@ abstract class Status_Abstract implements Status_Interface {
 	}
 
 	/**
+	 * Whether a Status Interface can be applied on top of another Status Interface.
+	 *
+	 * @since TBD
+	 *
+	 * @param self $current_status The current status.
+	 * @param self $new_status     The new status.
+	 * @param ?int $order_id       Which order we are testing against.
+	 *
+	 * @return bool
+	 */
+	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
+		if ( $current_status->get_wp_slug() === $new_status->get_wp_slug() ) {
+			// Allow from refunded to refunded in order to support multiple refunds.
+			return 'refunded' === $current_status->get_slug();
+		}
+
+		if ( $current_status->is_final() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public function is_final() {

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -157,7 +157,7 @@ abstract class Status_Abstract implements Status_Interface {
 	 * @param self $new_status     The new status.
 	 * @param ?int $order_id       Which order we are testing against.
 	 *
-	 * @return bool
+	 * @return bool Whether the new status can be applied to the current status.
 	 */
 	public function status_can_apply_to_status( $current_status, $new_status, $order_id = null ) {
 		if ( $current_status->get_wp_slug() === $new_status->get_wp_slug() ) {

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -149,19 +149,17 @@ abstract class Status_Abstract implements Status_Interface {
 	}
 
 	/**
-	 * Whether a Status Interface can be applied on top of another Status Interface.
+	 * Whether a Status Interface can be changed to another Status Interface.
 	 *
 	 * @since TBD
 	 *
 	 * @param self $new_status The new status.
-	 * @param ?int $order_id   Which order we are testing against.
 	 *
 	 * @return bool Whether the new status can be applied to the current status.
 	 */
-	public function can_transition_to_status( $new_status, $order_id = null ) {
+	public function can_change_to( $new_status ) {
 		if ( $this->get_wp_slug() === $new_status->get_wp_slug() ) {
-			// Allow from refunded to refunded in order to support multiple refunds.
-			return 'refunded' === $this->get_slug();
+			return false;
 		}
 
 		if ( $this->is_final() ) {

--- a/src/Tickets/Commerce/Status/Status_Abstract.php
+++ b/src/Tickets/Commerce/Status/Status_Abstract.php
@@ -157,7 +157,7 @@ abstract class Status_Abstract implements Status_Interface {
 	 *
 	 * @return bool Whether the new status can be applied to the current status.
 	 */
-	public function can_change_to( $new_status ) {
+	public function can_change_to( $new_status ): bool {
 		if ( $this->get_wp_slug() === $new_status->get_wp_slug() ) {
 			return false;
 		}

--- a/src/Tickets/Commerce/Status/Trashed.php
+++ b/src/Tickets/Commerce/Status/Trashed.php
@@ -29,6 +29,19 @@ class Trashed extends Status_Abstract {
 	const SLUG = 'trash';
 
 	/**
+	 * Gets the slug of this status in WordPress.
+	 *
+	 * Since this is a core status, we do need to match.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_wp_slug() {
+		return static::SLUG;
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function get_name() {

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -3,6 +3,7 @@
  * @file Global bootstrap for all codeception tests
  */
 use Codeception\Util\Autoload;
+use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Order;
 
 Autoload::addNamespace( 'Tribe__Events__WP_UnitTestCase', __DIR__ . '/_support' );
@@ -43,15 +44,13 @@ putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=1' );
 $_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 1;
 
 function tec_tickets_tests_fake_transactions_enable() {
-	uopz_set_return( Order::class, 'start_transaction', true, false );
-	uopz_set_return( Order::class, 'rollback_transaction', true, false );
-	uopz_set_return( Order::class, 'commit_transaction', true, false );
+	uopz_set_return( DB::class, 'beginTransaction', true, false );
+	uopz_set_return( DB::class, 'rollback', true, false );
+	uopz_set_return( DB::class, 'commit', true, false );
 }
 
 function tec_tickets_tests_fake_transactions_disable() {
-	uopz_unset_return( Order::class, 'start_transaction' );
-	uopz_unset_return( Order::class, 'rollback_transaction' );
-	uopz_unset_return( Order::class, 'commit_transaction' );
+	uopz_unset_return( DB::class, 'beginTransaction' );
+	uopz_unset_return( DB::class, 'rollback' );
+	uopz_unset_return( DB::class, 'commit' );
 }
-
-tec_tickets_tests_fake_transactions_enable();

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -45,7 +45,13 @@ $_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 1;
 
 function tec_tickets_tests_fake_transactions_enable() {
 	uopz_set_return( DB::class, 'beginTransaction', true, false );
-	uopz_set_return( DB::class, 'rollback', true, false );
+	uopz_set_return( DB::class, 'rollback', function () {
+		// On rollback we want to clear any locks and reset the lock id back to empty in runtime.
+		DB::query( DB::prepare( 'UPDATE %i SET post_content_filtered=""', DB::prefix( 'posts' ) ) );
+		uopz_set_return( 'uniqid', '', false );
+		tribe( Order::class )->generate_lock_id();
+		uopz_unset_return( 'uniqid' );
+	}, true );
 	uopz_set_return( DB::class, 'commit', true, false );
 }
 

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -48,9 +48,7 @@ function tec_tickets_tests_fake_transactions_enable() {
 	uopz_set_return( DB::class, 'rollback', function () {
 		// On rollback we want to clear any locks and reset the lock id back to empty in runtime.
 		DB::query( DB::prepare( 'UPDATE %i SET post_content_filtered=""', DB::prefix( 'posts' ) ) );
-		uopz_set_return( 'uniqid', '', false );
-		tribe( Order::class )->generate_lock_id();
-		uopz_unset_return( 'uniqid' );
+		tribe( Order::class )->reset_lock_id();
 	}, true );
 	uopz_set_return( DB::class, 'commit', true, false );
 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -4,7 +4,6 @@
  */
 use Codeception\Util\Autoload;
 use TEC\Tickets\Commerce\Order;
-use TEC\Common\StellarWP\DB\DB;
 
 Autoload::addNamespace( 'Tribe__Events__WP_UnitTestCase', __DIR__ . '/_support' );
 Autoload::addNamespace( 'Tribe\Tickets\Test', __DIR__ . '/_support' );
@@ -42,3 +41,17 @@ if ( isset( $_SERVER['argv'] ) && in_array( '--debug', $_SERVER['argv'], true ) 
 // By default, do not enable the Custom Tables v1 implementation in tests.
 putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=1' );
 $_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 1;
+
+function tec_tickets_tests_fake_transactions_enable() {
+	uopz_set_return( Order::class, 'start_transaction', true, false );
+	uopz_set_return( Order::class, 'rollback_transaction', true, false );
+	uopz_set_return( Order::class, 'commit_transaction', true, false );
+}
+
+function tec_tickets_tests_fake_transactions_disable() {
+	uopz_unset_return( Order::class, 'start_transaction' );
+	uopz_unset_return( Order::class, 'rollback_transaction' );
+	uopz_unset_return( Order::class, 'commit_transaction' );
+}
+
+tec_tickets_tests_fake_transactions_enable();

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -14,6 +14,7 @@ use Closure;
 use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Status\Completed;
 use TEC\Common\StellarWP\DB\DB;
+use TEC\Tickets\Commerce\Attendee;
 
 class Order_Test extends WPTestCase {
 	use Ticket_Maker;
@@ -355,6 +356,23 @@ class Order_Test extends WPTestCase {
 
 		foreach ( self::$clean_callbacks as $callback ) {
 			$callback();
+			// and always clean attendees.
+			DB::query(
+				DB::prepare(
+					"DELETE FROM %i where post_id IN ( SELECT ID FROM %i WHERE post_type = %s )",
+					DB::prefix( 'postmeta' ),
+					DB::prefix( 'posts' ),
+					Attendee::POSTTYPE
+				)
+			);
+
+			DB::query(
+				DB::prepare(
+					"DELETE FROM %i where post_type = %s",
+					DB::prefix( 'posts' ),
+					Order::POSTTYPE
+				)
+			);
 		}
 
 		self::$clean_callbacks = [];

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -9,13 +9,18 @@ use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use WP_Post;
+use Generator;
+use Closure;
 use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Common\StellarWP\DB\DB;
 
 class Order_Test extends WPTestCase {
 	use Ticket_Maker;
 	use With_Uopz;
 	use Order_Maker;
+
+	protected static array $clean_callbacks = [];
 
 	public function test_it_does_not_create_multiple_orders_for_single_cart() {
 		$post = self::factory()->post->create(
@@ -173,6 +178,137 @@ class Order_Test extends WPTestCase {
 		$this->assertTrue( $result );
 	}
 
+	public function modify_status_provider(): Generator {
+		yield 'already locked order' => [
+			function () {
+				tec_tickets_tests_fake_transactions_disable();
+				$post = self::factory()->post->create(
+					[
+						'post_type' => 'page',
+					]
+				);
+				$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
+				$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
+
+				$order = $this->create_order( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ], [ 'order_status' => Pending::SLUG ] );
+
+				tribe( Order::class )->lock_order( $order->ID );
+
+				$post_ids = [ $order->ID, $ticket_id_1, $ticket_id_2, $post ];
+
+				self::$clean_callbacks[] = function () use ( $post_ids ) {
+					foreach ( $post_ids as $post_id ) {
+						wp_delete_post( $post_id, true );
+					}
+					tec_tickets_tests_fake_transactions_enable();
+				};
+
+				tec_tickets_tests_fake_transactions_disable();
+
+				return [ $order->ID, Completed::SLUG, false ];
+			},
+		];
+
+		yield 'could not find order status' => [
+			function () {
+				tec_tickets_tests_fake_transactions_disable();
+				$post = self::factory()->post->create(
+					[
+						'post_type' => 'page',
+					]
+				);
+				$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
+				$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
+
+				$order = $this->create_order( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ], [ 'order_status' => Pending::SLUG ] );
+
+				// current request locked the order at the same time as another request - as a result next request would have diff lock_id.
+				// modifying lock id to simulate this scenario.
+				$callback = static fn() => DB::query( DB::prepare( "UPDATE %i SET post_content_filtered='12345678' where ID=%d", DB::prefix( 'posts' ), $order->ID ) );
+				add_action( 'tec_tickets_commerce_order_locked', $callback );
+
+				$post_ids = [ $order->ID, $ticket_id_1, $ticket_id_2, $post ];
+
+				self::$clean_callbacks[] = function () use ( $post_ids, $callback ) {
+					foreach ( $post_ids as $post_id ) {
+						wp_delete_post( $post_id, true );
+					}
+					remove_action( 'tec_tickets_commerce_order_locked', $callback );
+					tec_tickets_tests_fake_transactions_enable();
+				};
+
+				tec_tickets_tests_fake_transactions_disable();
+
+				return [ $order->ID, Completed::SLUG, false ];
+			},
+		];
+
+		yield 'could not transition order status' => [
+			function () {
+				tec_tickets_tests_fake_transactions_disable();
+				$post = self::factory()->post->create(
+					[
+						'post_type' => 'page',
+					]
+				);
+				$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
+				$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
+
+				$order = $this->create_order( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ], [ 'order_status' => Pending::SLUG ] );
+
+				$post_ids = [ $order->ID, $ticket_id_1, $ticket_id_2, $post ];
+
+				self::$clean_callbacks[] = function () use ( $post_ids ) {
+					foreach ( $post_ids as $post_id ) {
+						wp_delete_post( $post_id, true );
+					}
+					tec_tickets_tests_fake_transactions_enable();
+				};
+
+				tec_tickets_tests_fake_transactions_disable();
+
+				return [ $order->ID, Pending::SLUG, false ];
+			},
+		];
+
+		yield 'updated' => [
+			function () {
+				tec_tickets_tests_fake_transactions_disable();
+				$post = self::factory()->post->create(
+					[
+						'post_type' => 'page',
+					]
+				);
+				$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
+				$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
+
+				$order = $this->create_order( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ], [ 'order_status' => Pending::SLUG ] );
+
+				$post_ids = [ $order->ID, $ticket_id_1, $ticket_id_2, $post ];
+
+				self::$clean_callbacks[] = function () use ( $post_ids ) {
+					foreach ( $post_ids as $post_id ) {
+						wp_delete_post( $post_id, true );
+					}
+					tec_tickets_tests_fake_transactions_enable();
+				};
+
+				return [ $order->ID, Completed::SLUG, true ];
+			},
+		];
+	}
+
+	/**
+	 * @dataProvider modify_status_provider
+	 */
+	public function test_modify_status( Closure $fixture ) {
+		[ $order_id, $status, $expected ] = $fixture();
+
+		$result = tribe( Order::class )->modify_status( $order_id, $status );
+
+		$this->assertSame( $expected, $result );
+	}
+
 	protected function create_order_from_cart( array $items, array $overrides = [] ) {
 		foreach ( $items as $id => $quantity ) {
 			tribe( Cart::class )->get_repository()->add_item( $id, $quantity );
@@ -205,5 +341,22 @@ class Order_Test extends WPTestCase {
 		remove_filter( 'tec_tickets_commerce_order_create_args', $feed_args_callback );
 
 		return $order;
+	}
+
+	/**
+	 * @after
+	 */
+	public function clear_commited_transactions() {
+		if ( empty( self::$clean_callbacks ) ) {
+			return;
+		}
+
+		self::$clean_callbacks = array_reverse( self::$clean_callbacks );
+
+		foreach ( self::$clean_callbacks as $callback ) {
+			$callback();
+		}
+
+		self::$clean_callbacks = [];
 	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -4,10 +4,10 @@ namespace TEC\Tickets\Commerce;
 
 use TEC\Tickets\Commerce\Cart;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Codeception\TestCase\WPTestCase;
 use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
 use Tribe\Tests\Traits\With_Uopz;
-use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use WP_Post;
 use Generator;
 use Closure;

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Status/Status_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Status/Status_Test.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Status;
+
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+
+class Order_Test extends WPTestCase {
+	public function transitions_provider() {
+		return [
+			[ Action_Required::SLUG, Action_Required::SLUG, false ],
+			[ Approved::SLUG, Approved::SLUG, false ],
+			[ Completed::SLUG, Completed::SLUG, false ],
+			[ Created::SLUG, Created::SLUG, false ],
+			[ Denied::SLUG, Denied::SLUG, false ],
+			[ Not_Completed::SLUG, Not_Completed::SLUG, false ],
+			[ Pending::SLUG, Pending::SLUG, false ],
+			[ Refunded::SLUG, Refunded::SLUG, true ],
+			[ Reversed::SLUG, Reversed::SLUG, false ],
+			[ Trashed::SLUG, Trashed::SLUG, false ],
+			[ Undefined::SLUG, Undefined::SLUG, false ],
+			[ Unsupported::SLUG, Unsupported::SLUG, false ],
+			[ Action_Required::SLUG, Approved::SLUG, true ],
+			[ Action_Required::SLUG, Completed::SLUG, true ],
+			[ Action_Required::SLUG, Created::SLUG, true ],
+			[ Action_Required::SLUG, Denied::SLUG, true ],
+			[ Action_Required::SLUG, Not_Completed::SLUG, true ],
+			[ Action_Required::SLUG, Pending::SLUG, true ],
+			[ Action_Required::SLUG, Refunded::SLUG, true ],
+			[ Action_Required::SLUG, Reversed::SLUG, true ],
+			[ Action_Required::SLUG, Trashed::SLUG, true ],
+			[ Action_Required::SLUG, Undefined::SLUG, true ],
+			[ Action_Required::SLUG, Unsupported::SLUG, true ],
+			[ Approved::SLUG, Action_Required::SLUG, true ],
+			[ Approved::SLUG, Completed::SLUG, true ],
+			[ Approved::SLUG, Created::SLUG, true ],
+			[ Approved::SLUG, Denied::SLUG, true ],
+			[ Approved::SLUG, Not_Completed::SLUG, true ],
+			[ Approved::SLUG, Pending::SLUG, true ],
+			[ Approved::SLUG, Refunded::SLUG, true ],
+			[ Approved::SLUG, Reversed::SLUG, true ],
+			[ Approved::SLUG, Trashed::SLUG, true ],
+			[ Approved::SLUG, Undefined::SLUG, true ],
+			[ Approved::SLUG, Unsupported::SLUG, true ],
+			[ Completed::SLUG, Action_Required::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Approved::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Created::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Denied::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Not_Completed::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Pending::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Refunded::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Reversed::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Trashed::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Undefined::SLUG, true ], // Completed is not final ?
+			[ Completed::SLUG, Unsupported::SLUG, true ], // Completed is not final ?
+			[ Created::SLUG, Action_Required::SLUG, true ],
+			[ Created::SLUG, Approved::SLUG, true ],
+			[ Created::SLUG, Completed::SLUG, true ],
+			[ Created::SLUG, Denied::SLUG, true ],
+			[ Created::SLUG, Not_Completed::SLUG, true ],
+			[ Created::SLUG, Pending::SLUG, true ],
+			[ Created::SLUG, Refunded::SLUG, true ],
+			[ Created::SLUG, Reversed::SLUG, true ],
+			[ Created::SLUG, Trashed::SLUG, true ],
+			[ Created::SLUG, Undefined::SLUG, true ],
+			[ Created::SLUG, Unsupported::SLUG, true ],
+			[ Denied::SLUG, Action_Required::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Approved::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Completed::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Created::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Not_Completed::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Pending::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Refunded::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Reversed::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Trashed::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Undefined::SLUG, false ], // Denied is final
+			[ Denied::SLUG, Unsupported::SLUG, false ], // Denied is final
+			[ Not_Completed::SLUG, Action_Required::SLUG, true ],
+			[ Not_Completed::SLUG, Approved::SLUG, true ],
+			[ Not_Completed::SLUG, Completed::SLUG, true ],
+			[ Not_Completed::SLUG, Created::SLUG, true ],
+			[ Not_Completed::SLUG, Denied::SLUG, true ],
+			[ Not_Completed::SLUG, Pending::SLUG, true ],
+			[ Not_Completed::SLUG, Refunded::SLUG, true ],
+			[ Not_Completed::SLUG, Reversed::SLUG, true ],
+			[ Not_Completed::SLUG, Trashed::SLUG, true ],
+			[ Not_Completed::SLUG, Undefined::SLUG, true ],
+			[ Not_Completed::SLUG, Unsupported::SLUG, true ],
+			[ Pending::SLUG, Action_Required::SLUG, true ],
+			[ Pending::SLUG, Approved::SLUG, true ],
+			[ Pending::SLUG, Completed::SLUG, true ],
+			[ Pending::SLUG, Created::SLUG, true ],
+			[ Pending::SLUG, Denied::SLUG, true ],
+			[ Pending::SLUG, Not_Completed::SLUG, true ],
+			[ Pending::SLUG, Refunded::SLUG, true ],
+			[ Pending::SLUG, Reversed::SLUG, true ],
+			[ Pending::SLUG, Trashed::SLUG, true ],
+			[ Pending::SLUG, Undefined::SLUG, true ],
+			[ Pending::SLUG, Unsupported::SLUG, true ],
+			[ Refunded::SLUG, Action_Required::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Approved::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Completed::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Created::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Denied::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Not_Completed::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Pending::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Reversed::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Trashed::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Undefined::SLUG, false ], // Refunded is final.
+			[ Refunded::SLUG, Unsupported::SLUG, false ], // Refunded is final.
+			[ Reversed::SLUG, Action_Required::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Approved::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Completed::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Created::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Denied::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Not_Completed::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Pending::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Refunded::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Trashed::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Undefined::SLUG, false ], // Reversed is final.
+			[ Reversed::SLUG, Unsupported::SLUG, false ], // Reversed is final.
+			[ Trashed::SLUG, Action_Required::SLUG, true ],
+			[ Trashed::SLUG, Approved::SLUG, true ],
+			[ Trashed::SLUG, Completed::SLUG, true ],
+			[ Trashed::SLUG, Created::SLUG, true ],
+			[ Trashed::SLUG, Denied::SLUG, true ],
+			[ Trashed::SLUG, Not_Completed::SLUG, true ],
+			[ Trashed::SLUG, Pending::SLUG, true ],
+			[ Trashed::SLUG, Refunded::SLUG, true ],
+			[ Trashed::SLUG, Reversed::SLUG, true ],
+			[ Trashed::SLUG, Undefined::SLUG, true ],
+			[ Trashed::SLUG, Unsupported::SLUG, true ],
+			[ Undefined::SLUG, Action_Required::SLUG, true ],
+			[ Undefined::SLUG, Approved::SLUG, true ],
+			[ Undefined::SLUG, Completed::SLUG, true ],
+			[ Undefined::SLUG, Created::SLUG, true ],
+			[ Undefined::SLUG, Denied::SLUG, true ],
+			[ Undefined::SLUG, Not_Completed::SLUG, true ],
+			[ Undefined::SLUG, Pending::SLUG, true ],
+			[ Undefined::SLUG, Refunded::SLUG, true ],
+			[ Undefined::SLUG, Reversed::SLUG, true ],
+			[ Undefined::SLUG, Trashed::SLUG, true ],
+			[ Undefined::SLUG, Unsupported::SLUG, true ],
+			[ Unsupported::SLUG, Action_Required::SLUG, true ],
+			[ Unsupported::SLUG, Approved::SLUG, true ],
+			[ Unsupported::SLUG, Completed::SLUG, true ],
+			[ Unsupported::SLUG, Created::SLUG, true ],
+			[ Unsupported::SLUG, Denied::SLUG, true ],
+			[ Unsupported::SLUG, Not_Completed::SLUG, true ],
+			[ Unsupported::SLUG, Pending::SLUG, true ],
+			[ Unsupported::SLUG, Refunded::SLUG, true ],
+			[ Unsupported::SLUG, Reversed::SLUG, true ],
+			[ Unsupported::SLUG, Trashed::SLUG, true ],
+			[ Unsupported::SLUG, Undefined::SLUG, true ],
+		];
+	}
+
+	/**
+	 * @dataProvider transitions_provider
+	 */
+	public function test_it_can_transition_to_status( $from, $to, $result ) {
+		$from = tribe( Status_Handler::class )->get_by_slug( $from );
+		$to   = tribe( Status_Handler::class )->get_by_slug( $to );
+
+		$this->assertSame( $result, $from->can_transition_to_status( $to ), "Failed to transition from {$from->get_slug()} to {$to->get_slug()}" );
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Status/Status_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Status/Status_Test.php
@@ -17,7 +17,7 @@ class Order_Test extends WPTestCase {
 			[ Denied::SLUG, Denied::SLUG, false ],
 			[ Not_Completed::SLUG, Not_Completed::SLUG, false ],
 			[ Pending::SLUG, Pending::SLUG, false ],
-			[ Refunded::SLUG, Refunded::SLUG, true ],
+			[ Refunded::SLUG, Refunded::SLUG, true ], // Only status transition allowed from same to same to support multiple refunds. e.g. in stripe i can refund from X order total, Y at first and then Z where Z + Y <= X.
 			[ Reversed::SLUG, Reversed::SLUG, false ],
 			[ Trashed::SLUG, Trashed::SLUG, false ],
 			[ Undefined::SLUG, Undefined::SLUG, false ],

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Status/Status_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Status/Status_Test.php
@@ -13,13 +13,13 @@ class Status_Test extends WPTestCase {
 
 	public function transitions_provider() {
 		return [
-			// [ Action_Required::SLUG, Action_Required::SLUG, false ],
-			// [ Approved::SLUG, Approved::SLUG, false ],
-			// [ Completed::SLUG, Completed::SLUG, false ],
-			// [ Created::SLUG, Created::SLUG, false ],
-			// [ Denied::SLUG, Denied::SLUG, false ],
-			// [ Not_Completed::SLUG, Not_Completed::SLUG, false ],
-			// [ Pending::SLUG, Pending::SLUG, false ],
+			[ Action_Required::SLUG, Action_Required::SLUG, false ],
+			[ Approved::SLUG, Approved::SLUG, false ],
+			[ Completed::SLUG, Completed::SLUG, false ],
+			[ Created::SLUG, Created::SLUG, false ],
+			[ Denied::SLUG, Denied::SLUG, false ],
+			[ Not_Completed::SLUG, Not_Completed::SLUG, false ],
+			[ Pending::SLUG, Pending::SLUG, false ],
 			[ Refunded::SLUG, Refunded::SLUG, true ], // Only status transition allowed from same to same to support multiple refunds. e.g. in stripe i can refund from X order total, Y at first and then Z where Z + Y <= X.
 			[ Reversed::SLUG, Reversed::SLUG, false ],
 			[ Trashed::SLUG, Trashed::SLUG, false ],

--- a/tests/commerce_integration/_bootstrap.php
+++ b/tests/commerce_integration/_bootstrap.php
@@ -22,3 +22,5 @@ update_option( 'stylesheet', 'twentytwenty' );
 // Start the posts auto-increment from a high number to make it easier to replace the post IDs in HTML snapshots.
 global $wpdb;
 $wpdb->query( "ALTER TABLE $wpdb->posts AUTO_INCREMENT = 5096" );
+
+tec_tickets_tests_fake_transactions_enable();

--- a/tests/ct1_integration/_bootstrap.php
+++ b/tests/ct1_integration/_bootstrap.php
@@ -40,3 +40,5 @@ remove_action( 'tribe_tickets_promoter_trigger', [ tribe( Dispatcher::class ), '
 add_filter( 'tec_tickets_commerce_is_enabled', '__return_true', 100 );
 tribe()->register( Commerce_Provider::class );
 tribe( Commerce_Module::class );
+
+tec_tickets_tests_fake_transactions_enable();

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/OrderReportTest__test_tc_order_report_display__event with a series pass and single ticket orders__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/OrderReportTest__test_tc_order_report_display__event with a series pass and single ticket orders__0.snapshot.html
@@ -57,7 +57,7 @@
 						<div class="tec-tickets__admin-orders-report-overview-ticket-type-list-item-ticket-name">
 							Test TC ticket for {{ID}} &#x24;55.00						</div>
 						<div class="tec-tickets__admin-orders-report-overview-ticket-type-list-item-stat">
-							1 completed | 100 available						</div>
+							1 completed | 99 available						</div>
 					</li>
 									</ul>
 								</div>

--- a/tests/ft_integration/_bootstrap.php
+++ b/tests/ft_integration/_bootstrap.php
@@ -75,3 +75,5 @@ addListener( Events::TEST_BEFORE, function () use ( $custom_tables ) {
 // Deactivate logging.
 global $wp_filter;
 $wp_filter['tribe_log'] = new WP_Hook();
+
+tec_tickets_tests_fake_transactions_enable();

--- a/tests/integration/_bootstrap.php
+++ b/tests/integration/_bootstrap.php
@@ -20,3 +20,5 @@ if ( ! tec_tickets_commerce_is_enabled() ) {
 	$commerce_provider->run_init_hooks();
 }
 tribe( Commerce_Module::class );
+
+tec_tickets_tests_fake_transactions_enable();

--- a/tests/slr_integration/_bootstrap.php
+++ b/tests/slr_integration/_bootstrap.php
@@ -80,3 +80,5 @@ test_add_seating_license_key_callback();
 
 // The Seating Commerce controller might not be registered yet: do it now.
 tribe_register_provider( Seating_Commerce_Controller::class );
+
+tec_tickets_tests_fake_transactions_enable();


### PR DESCRIPTION
### 🎫 Ticket

[ET-2281]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

I am thinking that including the can_apply method in the DB transaction is the correct approach here.

What i suspect was still happening:

1) 2 requests very close to each other - probably a diff of some ms.
2) both would evaluate that the status could_apply_to => true ( e.g. both of them from pending to completed )
3) Since they had a slight difference, each one of them would => lock the order, update the order status using wp_update_post which DOES NOT care if the status actually changed before triggering the post status transition sequence, unlock the order.

What i am trying to do over here:

1) Create a transaction - so all of the following queries fail or succeed together
2) Lock the order - will fail quietly if order already locked.
3) Select the current status of the locked order. - will fail quietly if fail to select because ...
4) Evaluate if new status can be applied on top of current status - considering wp_errors which seems we were missing for a while. - will fail quietly if not.
5) Update the order.
6) Unlock the order.
7) Commit the transaction.

### 🎥 Artifacts <!-- if applicable-->

All the tests passing while modified method is being used by them is artifact enough for such a low level change.
Also added dedicated tests.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2281]: https://stellarwp.atlassian.net/browse/ET-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ