### PR TITLE
Re-enable Coupons

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Controller.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Controller.php
@@ -97,14 +97,15 @@ final class Controller extends Controller_Contract {
 	 * @throws InvalidArgumentException If the method does not exist.
 	 */
 	public function __call( $name, $arguments ) {
+		$method = __CLASS__ . "::{$name}";
 		switch ( $name ) {
 			case 'filter_out_coupons':
-				_deprecated_function( __CLASS__ . "::{$name}", 'TBD', 'No replacement available.' );
+				_deprecated_function( esc_html( $method ), 'TBD', 'No replacement available.' );
 
 				return $arguments[0] ?? [];
 
 			default:
-				throw new InvalidArgumentException( sprintf( 'Method %s does not exist.', $name ) );
+				throw new InvalidArgumentException( sprintf( 'Method %s does not exist.', esc_html( $method ) ) );
 		}
 	}
 

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -199,7 +199,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 				'id'       => static::$slug,
 				'path'     => static::$slug,
 				'parent'   => static::$parent_slug,
-				'title'    => esc_html__( 'Booking Fees', 'event-tickets' ),
+				'title'    => esc_html__( 'Coupons &amp; Fees', 'event-tickets' ),
 				'position' => 1.5,
 				'callback' => [ $this, 'render_tec_order_modifiers_page' ],
 			]

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -118,7 +118,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 	 * @return bool
 	 */
 	public function enqueue_tec_tickets_settings_css( bool $should_enqueue ): bool {
-		return $should_enqueue ? $should_enqueue : $this->is_on_page();
+		return $should_enqueue ?: $this->is_on_page();
 	}
 
 	/**
@@ -134,12 +134,12 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			'admin/order-modifiers/table.js',
 			Tickets_Plugin::VERSION
 		)
-		->add_to_group_path( 'et-core' )
-		->set_condition( fn () => $this->is_on_page() )
-		->set_dependencies( 'jquery', 'wp-util' )
-		->enqueue_on( 'admin_enqueue_scripts' )
-		->add_to_group( 'tec-tickets-order-modifiers' )
-		->register();
+			->add_to_group_path( 'et-core' )
+			->set_condition( fn() => $this->is_on_page() )
+			->set_dependencies( 'jquery', 'wp-util' )
+			->enqueue_on( 'admin_enqueue_scripts' )
+			->add_to_group( 'tec-tickets-order-modifiers' )
+			->register();
 	}
 
 	/**

--- a/src/admin-views/order_modifiers/modifier-table.php
+++ b/src/admin-views/order_modifiers/modifier-table.php
@@ -24,7 +24,7 @@ $form_classes = [
 
 ?>
 <div class="wrap">
-	<h1><?php echo esc_html__( 'Booking Fees', 'event-tickets' ); ?></h1>
+	<h1><?php echo esc_html__( 'Coupons &amp; Fees', 'event-tickets' ); ?></h1>
 	<form
 		id="event-tickets__order-modifiers-admin-form"
 		<?php tribe_classes( $form_classes ); ?>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_table_render_correctly__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_table_render_correctly__0.snapshot.html
@@ -1,5 +1,5 @@
 <div class="wrap">
-	<h1>Booking Fees</h1>
+	<h1>Coupons &amp; Fees</h1>
 	<form
 		id="event-tickets__order-modifiers-admin-form"
 		 class="topics-filter event-tickets__order-modifiers-admin-form" 		method="post"

--- a/tests/order_modifiers_integration/Fees/__snapshots__/Create_Fees_Modifiers_Test__does_table_render_correctly__0.snapshot.html
+++ b/tests/order_modifiers_integration/Fees/__snapshots__/Create_Fees_Modifiers_Test__does_table_render_correctly__0.snapshot.html
@@ -1,5 +1,5 @@
 <div class="wrap">
-	<h1>Booking Fees</h1>
+	<h1>Coupons &amp; Fees</h1>
 	<form
 		id="event-tickets__order-modifiers-admin-form"
 		 class="topics-filter event-tickets__order-modifiers-admin-form" 		method="post"

--- a/tests/order_modifiers_integration/_bootstrap.php
+++ b/tests/order_modifiers_integration/_bootstrap.php
@@ -21,9 +21,6 @@ putenv( 'TEC_TICKETS_COMMERCE=1' );
 putenv( 'TEC_DISABLE_LOGGING=1' );
 putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 
-// Load Coupons for the tests.
-add_filter( 'tec_tickets_commerce_order_modifiers_coupons_enabled', '__return_true' );
-
 // Activate CT1
 tribe()->register( TEC_CT1_Provider::class );
 TEC_CT1_Activation::init();


### PR DESCRIPTION

### 🎫 Ticket

[ET-2198]

### 🗒️ Description

This re-enables the Coupons functionality without the use of a filter. It also deprecates the filter that controlled whether Coupons are enabled.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2198]: https://stellarwp.atlassian.net/browse/ET-2198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ