### PR TITLE
Make increase sales action idempotent

### DIFF
--- a/changelog/fix-increase-sales-action-to-idempotent
+++ b/changelog/fix-increase-sales-action-to-idempotent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ticket sales will be counted correctly during status transitions of the orders they belong to. [ET-2286]

--- a/src/Tickets/Commerce/Flag_Actions/Increase_Sales.php
+++ b/src/Tickets/Commerce/Flag_Actions/Increase_Sales.php
@@ -42,11 +42,14 @@ class Increase_Sales extends Flag_Action_Abstract {
 	 *
 	 * @since 5.2.0
 	 * @since 5.13.3 Check shared capacity before sending to the `Ticket::increase_ticket_sales_by` method.
+	 * @since TBD
 	 */
 	public function handle( Status_Interface $new_status, $old_status, \WP_Post $post ) {
 		if ( empty( $post->items ) ) {
 			return;
 		}
+
+		$tickets_that_have_already_increased_their_sales_because_of_this_order = (array) get_post_meta( $post->ID, '_tribe_tickets_sales_increased', true );
 
 		foreach ( $post->items as $item ) {
 			if ( ! $this->is_ticket( $item ) ) {
@@ -60,12 +63,24 @@ class Increase_Sales extends Flag_Action_Abstract {
 
 			$quantity = Arr::get( $item, 'quantity' );
 
-			if ( ! $quantity ) {
+			if ( ! $quantity || ! is_numeric( $quantity ) ) {
 				continue;
 			}
 
+			$quantity     = (int) $quantity;
+			$new_quantity = $quantity;
+
+			if (
+				! empty( $tickets_that_have_already_increased_their_sales_because_of_this_order[ $item['ticket_id'] ] ) &&
+				$tickets_that_have_already_increased_their_sales_because_of_this_order[ $item['ticket_id'] ] > 0
+			) {
+				$new_quantity = $quantity - $tickets_that_have_already_increased_their_sales_because_of_this_order[ $item['ticket_id'] ];
+			}
+
+			$tickets_that_have_already_increased_their_sales_because_of_this_order[ $item['ticket_id'] ] = $quantity;
+
 			// Skip generating for zero-ed items.
-			if ( 0 >= $quantity ) {
+			if ( 0 >= $new_quantity ) {
 				continue;
 			}
 
@@ -75,7 +90,9 @@ class Increase_Sales extends Flag_Action_Abstract {
 			$global_stock_mode  = $ticket->global_stock_mode();
 			$is_shared_capacity = ! empty( $global_stock_mode ) && 'own' !== $global_stock_mode;
 
-			tribe( Ticket::class )->increase_ticket_sales_by( $ticket->ID, $quantity, $is_shared_capacity, $global_stock );
+			tribe( Ticket::class )->increase_ticket_sales_by( $ticket->ID, $new_quantity, $is_shared_capacity, $global_stock );
 		}
+
+		update_post_meta( $post->ID, '_tribe_tickets_sales_increased', $tickets_that_have_already_increased_their_sales_because_of_this_order );
 	}
 }

--- a/src/Tickets/Commerce/Flag_Actions/Increase_Sales.php
+++ b/src/Tickets/Commerce/Flag_Actions/Increase_Sales.php
@@ -42,7 +42,7 @@ class Increase_Sales extends Flag_Action_Abstract {
 	 *
 	 * @since 5.2.0
 	 * @since 5.13.3 Check shared capacity before sending to the `Ticket::increase_ticket_sales_by` method.
-	 * @since TBD
+	 * @since TBD    Making the action idempotent. Self aware of which tickets have already increased their sales and how many times.
 	 */
 	public function handle( Status_Interface $new_status, $old_status, \WP_Post $post ) {
 		if ( empty( $post->items ) ) {


### PR DESCRIPTION
[ET-2286]

Makes the increase sales action idempotent.

As a result is self aware whether the current order has increased the sales for which tickets and how many times for each.
Avoiding redoing the same sales increase on every consecutive fire of said action.

[ET-2286]: https://stellarwp.atlassian.net/browse/ET-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ