### PR TITLE
Add status parameter and default to Fee API

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/API/Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Fees.php
@@ -133,6 +133,16 @@ class Fees extends Base_API {
 				'methods'             => Server::READABLE,
 				'callback'            => fn( Request $request ) => $this->get_fees_response( $request ),
 				'permission_callback' => $this->get_permission_callback(),
+				'args'                => [
+					'status' => [
+						'description' => __( 'The status of the fees to retrieve.', 'event-tickets' ),
+						'type'        => 'array',
+						'items'       => [
+							'type' => 'string',
+							'enum' => [ 'active', 'inactive', 'draft' ],
+						],
+					],
+				],
 			]
 		);
 
@@ -180,7 +190,9 @@ class Fees extends Base_API {
 	 */
 	protected function get_fees_response( Request $request ): Response {
 		try {
-			$all = $this->get_all_fees();
+			$status = $request->get_param( 'status' ) ?? [ 'active' ];
+
+			$all = $this->get_all_fees( [ 'status' => $status ] );
 
 			return rest_ensure_response(
 				[


### PR DESCRIPTION
### 🎫 Ticket

[ET-2268]

### 🗒️ Description

This fixes an issue reported when smoketesting when selecting Fee(s) to apply to a ticket. Only Active fees should be shown, but instead Inactive and Draft fees are also shown.

This change updates the Fee API to accept a `status` parameter, and the default without passing the parameter is to show only fees with an active status.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2268]: https://stellarwp.atlassian.net/browse/ET-2268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ