### PR TITLE
[ET-2287] Rework hidden Ticket Provider field in Classic Editor

### DIFF
--- a/changelog/task-ET-2287-rework-hidden-ticket-provider-setting
+++ b/changelog/task-ET-2287-rework-hidden-ticket-provider-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Refactored a hidden ticket provider field within the classic editor for RSVPs and tickets. [ET-2287]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2402,6 +2402,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * Returns the class name of the default module/provider.
 		 *
 		 * @since 4.6
+		 * @since TBD Update default to Tickets Commerce.
 		 *
 		 * @return string
 		 */
@@ -2422,8 +2423,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					$sliced = array_slice( $modules, 0, 1 );
 					self::$default_module = reset( $sliced );
 				} else {
-					// use PayPal tickets
-					self::$default_module = 'Tribe__Tickets__Commerce__PayPal__Main';
+					// Set Tickets Commerce as the default module.
+					self::$default_module = 'TEC\\Tickets\\Commerce\\Module';
 				}
 			}
 

--- a/src/admin-views/commerce/metabox/capacity.php
+++ b/src/admin-views/commerce/metabox/capacity.php
@@ -6,8 +6,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"

--- a/src/admin-views/commerce/metabox/capacity.php
+++ b/src/admin-views/commerce/metabox/capacity.php
@@ -7,7 +7,7 @@
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
 	data-depends="#tec_tickets_ticket_provider"
-	data-condition="Tribe__Tickets__RSVP"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"

--- a/src/admin-views/editor/fieldset/advanced.php
+++ b/src/admin-views/editor/fieldset/advanced.php
@@ -17,7 +17,7 @@ if ( ! isset( $ticket_id ) ) {
 	}
 }
 ?>
-<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		<?php esc_html_e( 'Advanced', 'event-tickets' ); ?>
 	</button>

--- a/src/admin-views/editor/fieldset/advanced.php
+++ b/src/admin-views/editor/fieldset/advanced.php
@@ -17,7 +17,7 @@ if ( ! isset( $ticket_id ) ) {
 	}
 }
 ?>
-<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition="Tribe__Tickets__RSVP">
+<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		<?php esc_html_e( 'Advanced', 'event-tickets' ); ?>
 	</button>

--- a/src/admin-views/editor/fieldset/price.php
+++ b/src/admin-views/editor/fieldset/price.php
@@ -75,8 +75,8 @@ if ( ! empty( $ticket ) ) {
 <div
 	class="price <?php echo $disabled ? 'input_block' : 'tribe-dependent'; ?>"
 	<?php if ( ! $disabled ) : ?>
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 	<?php endif; ?>
 >
 	<div class="input_block">

--- a/src/admin-views/editor/fieldset/price.php
+++ b/src/admin-views/editor/fieldset/price.php
@@ -76,7 +76,7 @@ if ( ! empty( $ticket ) ) {
 	class="price <?php echo $disabled ? 'input_block' : 'tribe-dependent'; ?>"
 	<?php if ( ! $disabled ) : ?>
 	data-depends="#tec_tickets_ticket_provider"
-	data-condition="Tribe__Tickets__RSVP"
+	data-condition-not="Tribe__Tickets__RSVP"
 	<?php endif; ?>
 >
 	<div class="input_block">

--- a/src/admin-views/editor/panel/fields/name.php
+++ b/src/admin-views/editor/panel/fields/name.php
@@ -28,7 +28,7 @@
 	<span
 		class="tribe_soft_note ticket_form_right"
 		data-depends="#tec_tickets_ticket_provider"
-		data-condition="Tribe__Tickets__RSVP"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<?php
 		echo esc_html(

--- a/src/admin-views/editor/panel/fields/name.php
+++ b/src/admin-views/editor/panel/fields/name.php
@@ -27,8 +27,8 @@
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	<?php
 		echo esc_html(
@@ -46,8 +46,8 @@
 	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	<?php
 		echo esc_html(

--- a/src/admin-views/editor/panel/ticket.php
+++ b/src/admin-views/editor/panel/ticket.php
@@ -56,7 +56,7 @@ $ticket_type = $ticket_type ?? 'default';
 			<div
 					class="tribe-dependent"
 					data-depends="#tec_tickets_ticket_provider"
-					data-condition="Tribe__Tickets__RSVP"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -258,7 +258,7 @@ $ticket_type = $ticket_type ?? 'default';
 						name="ticket_form_save"
 						value="<?php echo esc_attr( $ticket_form_save_text ); ?>"
 						data-depends="#tec_tickets_ticket_provider"
-						data-condition="Tribe__Tickets__RSVP"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/src/admin-views/editor/panel/ticket.php
+++ b/src/admin-views/editor/panel/ticket.php
@@ -55,8 +55,8 @@ $ticket_type = $ticket_type ?? 'default';
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -100,8 +100,8 @@ $ticket_type = $ticket_type ?? 'default';
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -186,32 +186,8 @@ $ticket_type = $ticket_type ?? 'default';
 
 				<?php $this->template( 'editor/panel/fields/dates', get_defined_vars() ); ?>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label"><?php esc_html_e( 'Sell using:', 'event-tickets' ); ?></legend>
-					<?php foreach ( $modules as $class => $module ) : ?>
-						<input
-								type="radio"
-								name="ticket_provider"
-								id="<?php echo esc_attr( $class . '_radio' ); ?>"
-								value="<?php echo esc_attr( $class ); ?>"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								<?php checked( true, $provider_class === $class ); ?>
-						>
-						<span>
-							<?php
-							/**
-							 * Allows for the editing of the module name before output
-							 *
-							 * @since 4.6
-							 *
-							 * @param string $module the module name
-							 */
-							echo esc_html( apply_filters( 'tribe_events_tickets_module_name', $module ) );
-							?>
-						</span>
-					<?php endforeach; ?>
-				</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="<?php echo esc_attr( $provider_class ); ?>" />
+
 				<?php
 				/**
 				 * Allows for the insertion of additional content into the ticket edit form - main section
@@ -281,8 +257,8 @@ $ticket_type = $ticket_type ?? 'default';
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="<?php echo esc_attr( $ticket_form_save_text ); ?>"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -290,8 +266,8 @@ $ticket_type = $ticket_type ?? 'default';
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="<?php echo esc_attr( $rsvp_form_save_text ); ?>"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/src/admin-views/rsvp-metabox-capacity.php
+++ b/src/admin-views/rsvp-metabox-capacity.php
@@ -1,7 +1,7 @@
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"

--- a/src/admin-views/rsvp-metabox-not-going.php
+++ b/src/admin-views/rsvp-metabox-not-going.php
@@ -7,8 +7,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"

--- a/src/admin-views/tpp-metabox-capacity.php
+++ b/src/admin-views/tpp-metabox-capacity.php
@@ -6,8 +6,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__Commerce__PayPal__Main tribe-dependent"
-	data-depends="#Tribe__Tickets__Commerce__PayPal__Main_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__Commerce__PayPal__Main"
 >
 	<label
 		for="Tribe__Tickets__Commerce__PayPal__Main_capacity"

--- a/src/admin-views/tpp-metabox-sku.php
+++ b/src/admin-views/tpp-metabox-sku.php
@@ -14,8 +14,8 @@ if ( ! $display_sku ) {
 ?>
 
 <div class="<?php $this->tr_class(); ?> input_block tribe-dependent"
-     data-depends="#Tribe__Tickets__Commerce__PayPal__Main_radio"
-     data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__Commerce__PayPal__Main"
 >
 	<label for="ticket_tpp_sku" class="ticket_form_label ticket_form_left"><?php esc_html_e( 'SKU:', 'event-tickets' ); ?></label>
 	<input

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -144,7 +144,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 		if ( force_rsvp ) {
 			providerValue = 'Tribe__Tickets__RSVP';
 		} else {
-			// Allows default to WooCommerce
+			// Default to Tickets Commerce.
 			providerValue = 'TEC\\Tickets\\Commerce\\Module';
 		}
 

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -29,6 +29,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 	const noTicketsOnRecurring = document.body.classList.contains( 'tec-no-tickets-on-recurring' );
 	const tickets_panel_helper_text_selector = '.tec_ticket-panel__helper_text__wrap';
 	const tickets_panel_hidden_recurrence_warning = '.tec_ticket-panel__recurring-unsupported-warning';
+	const ticket_provider_input_id = '#tec_tickets_ticket_provider';
 	/*
 	 * Null or 'default' are the default ticket; 'rsvp' is the RSVP ticket.
 	 * The backend might use the value, sent over with AJAX panel requests, to modify panels
@@ -124,36 +125,39 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 	 * ticketing provider. Defaults to RSVP if something fails
 	 *
 	 * @since 4.6
-	 *
-	 * @param boolean force selection to RSVP
+	 * @since TBD Updated default provider handling.
+	 * @param {boolean} forceRsvp Whether to force the default provider to RSVP.
 	 * @return void
 	 */
 	function set_default_provider_radio( force_rsvp ) {
 		if ( 'undefined' === typeof force_rsvp ) {
 			force_rsvp = true;
 		}
-		var $checkedProvider = $tribe_tickets.find( '.tribe-ticket-editor-field-default_provider' );
+		let $checkedProvider = $tribe_tickets.find( '.tribe-ticket-editor-field-default_provider' );
 
 		if ( $checkedProvider.is( ':radio' ) ) {
 			$checkedProvider = $checkedProvider.filter( ':checked' );
 		}
 
-		var provider_id;
+		let providerValue;
 
 		if ( force_rsvp ) {
-			provider_id = 'Tribe__Tickets__RSVP_radio';
+			providerValue = 'Tribe__Tickets__RSVP';
 		} else {
 			// Allows default to WooCommerce
-			provider_id = 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main_radio';
+			providerValue = 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main';
 		}
 
 		if ( ! force_rsvp && $checkedProvider.length > 0 ) {
-			provider_id = $checkedProvider.val() + '_radio';
+			providerValue = $checkedProvider.val();
 		}
 
-		const ticketProviderInput = $( document.getElementById( provider_id ) );
+		const ticketProviderInput = $( document.getElementById( ticket_provider_input_id ) );
+		if ( ! ticketProviderInput.val() ) {
+			ticketProviderInput.val( providerValue );
+		}
 		defaultTicketProviderModule = ticketProviderInput.val();
-		ticketProviderInput.prop( 'checked', true ).trigger( 'change' );
+		ticketProviderInput.trigger( 'change' );
 	}
 
 	/**

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -145,7 +145,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			providerValue = 'Tribe__Tickets__RSVP';
 		} else {
 			// Allows default to WooCommerce
-			providerValue = 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main';
+			providerValue = 'TEC\\Tickets\\Commerce\\Module';
 		}
 
 		if ( ! force_rsvp && $checkedProvider.length > 0 ) {

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -214,8 +215,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -234,8 +235,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -278,14 +279,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -392,33 +393,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -495,10 +475,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -517,8 +498,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -537,8 +518,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -556,7 +537,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -599,8 +580,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -608,8 +589,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -224,8 +225,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -244,8 +245,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -288,14 +289,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -402,33 +403,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -505,10 +485,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -527,8 +508,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -547,8 +528,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -566,7 +547,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -609,8 +590,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -618,8 +599,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with tickets and RSVPs__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with tickets and RSVPs__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -141,7 +142,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -225,7 +227,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -289,7 +292,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -431,8 +435,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -451,8 +455,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -495,14 +499,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -609,33 +613,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -712,10 +695,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -734,8 +718,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -754,8 +738,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -773,7 +757,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -816,8 +800,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -825,8 +809,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -121,8 +121,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -141,8 +141,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -185,14 +185,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -299,33 +299,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -402,10 +381,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -424,8 +404,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -444,8 +424,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -463,7 +443,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -506,8 +486,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -515,8 +495,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of a series with passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of a series with passes__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -126,7 +127,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -248,8 +250,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -268,8 +270,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -312,14 +314,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -426,33 +428,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -529,10 +510,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -551,8 +533,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -571,8 +553,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -590,7 +572,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -633,8 +615,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -642,8 +624,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of series with no passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__recurring event part of series with no passes__0.snapshot.html
@@ -121,8 +121,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -141,8 +141,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -185,14 +185,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -299,33 +299,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -402,10 +381,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -424,8 +404,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -444,8 +424,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -463,7 +443,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -506,8 +486,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -515,8 +495,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with no passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with no passes__0.snapshot.html
@@ -79,8 +79,8 @@
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -99,8 +99,8 @@
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -143,14 +143,14 @@
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -257,33 +257,12 @@
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -360,10 +339,11 @@
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -382,8 +362,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -402,8 +382,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -421,7 +401,7 @@
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -464,8 +444,8 @@
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -473,8 +453,8 @@
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__series with passes__0.snapshot.html
@@ -78,7 +78,8 @@
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -142,7 +143,8 @@
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -246,8 +248,8 @@
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -266,8 +268,8 @@
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -310,14 +312,14 @@
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -424,33 +426,12 @@
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -527,10 +508,11 @@
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -549,8 +531,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -569,8 +551,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -588,7 +570,7 @@
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -631,8 +613,8 @@
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -640,8 +622,8 @@
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event by Occurrence provisional ID__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event by Occurrence provisional ID__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -123,7 +124,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -242,8 +244,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -262,8 +264,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -306,14 +308,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -420,33 +422,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -523,10 +504,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -545,8 +527,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -565,8 +547,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -584,7 +566,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -627,8 +609,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -636,8 +618,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets and no series passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets and no series passes__0.snapshot.html
@@ -127,8 +127,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -147,8 +147,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -191,14 +191,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -305,33 +305,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -408,10 +387,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -430,8 +410,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -450,8 +430,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -469,7 +449,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -512,8 +492,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -521,8 +501,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets, series has passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with no tickets, series has passes__0.snapshot.html
@@ -88,7 +88,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -132,7 +133,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -254,8 +256,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -274,8 +276,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -318,14 +320,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -432,33 +434,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -535,10 +516,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -557,8 +539,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -577,8 +559,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -596,7 +578,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -639,8 +621,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -648,8 +630,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with tickets, RSVPs and passes__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event part of a series with tickets, RSVPs and passes__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -141,7 +142,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -225,7 +227,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -289,7 +292,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -384,7 +388,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -428,7 +433,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -550,8 +556,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -570,8 +576,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -614,14 +620,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -728,33 +734,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -831,10 +816,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -853,8 +839,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -873,8 +859,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -892,7 +878,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -935,8 +921,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -944,8 +930,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with RSVP__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with RSVP__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -214,8 +215,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -234,8 +235,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -278,14 +279,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -392,33 +393,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -495,10 +475,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -517,8 +498,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -537,8 +518,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -556,7 +537,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -599,8 +580,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -608,8 +589,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with ticket__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with ticket__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -224,8 +225,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -244,8 +245,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -288,14 +289,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -402,33 +403,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -505,10 +485,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -527,8 +508,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -547,8 +528,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -566,7 +547,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -609,8 +590,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -618,8 +599,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with tickets and RSVPs__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event with tickets and RSVPs__0.snapshot.html
@@ -82,7 +82,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -141,7 +142,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -225,7 +227,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -289,7 +292,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ID}}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -431,8 +435,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -451,8 +455,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -495,14 +499,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -609,33 +613,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -712,10 +695,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -734,8 +718,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -754,8 +738,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -773,7 +757,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -816,8 +800,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -825,8 +809,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event without tickets__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__single event without tickets__0.snapshot.html
@@ -121,8 +121,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -141,8 +141,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -185,14 +185,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -299,33 +299,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -402,10 +381,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -424,8 +404,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -444,8 +424,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -463,7 +443,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -506,8 +486,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -515,8 +495,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__event__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__event__0.snapshot.html
@@ -111,16 +111,16 @@ New ticket</button><button
 </div>
 
 <div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
-	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
-     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+	 data-default-provider="TEC\Tickets\Commerce\Module"
+     data-current-provider="TEC\Tickets\Commerce\Module"
 >
 	
 	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -139,8 +139,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -183,14 +183,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -297,13 +297,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -319,10 +318,11 @@ New ticket</button><button
 				Leave blank for free Ticket			</p>
 				</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -341,8 +341,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -360,7 +360,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -385,8 +385,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -394,8 +394,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__post__0.snapshot.html
+++ b/tests/ft_integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_without_providers__post__0.snapshot.html
@@ -111,16 +111,16 @@ New ticket</button><button
 </div>
 
 <div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
-	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
-     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+	 data-default-provider="TEC\Tickets\Commerce\Module"
+     data-current-provider="TEC\Tickets\Commerce\Module"
 >
 	
 	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -139,8 +139,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -183,14 +183,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -297,13 +297,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -319,10 +318,11 @@ New ticket</button><button
 				Leave blank for free Ticket			</p>
 				</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -341,8 +341,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -360,7 +360,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -385,8 +385,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -394,8 +394,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
@@ -71,7 +71,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ post_id }}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock tribe-tickets__tickets-editor-ticket-available-dates-icon-expired" >
-	January 1, 2021 - January 31, 2021</div>			</div>
+	January 1, 2021 - January 31, 2021</div>
+			</div>
 		</div>
 	</td>
 
@@ -203,8 +204,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -223,8 +224,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -267,14 +268,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -381,33 +382,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="Tribe__Tickets__RSVP" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -484,10 +464,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -506,8 +487,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -525,7 +506,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -550,8 +531,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -559,8 +540,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket and sale price__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket and sale price__0.snapshot.html
@@ -71,7 +71,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ post_id }}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -224,8 +225,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -244,8 +245,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -288,14 +289,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -402,33 +403,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -505,10 +485,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -527,8 +508,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -547,8 +528,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -566,7 +547,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -609,8 +590,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -618,8 +599,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
@@ -71,7 +71,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ post_id }}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -213,8 +214,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -233,8 +234,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -277,14 +278,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -391,33 +392,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -494,10 +474,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -516,8 +497,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -536,8 +517,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -555,7 +536,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -598,8 +579,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -607,8 +588,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event without ticket__0.snapshot.html
@@ -110,8 +110,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -130,8 +130,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -174,14 +174,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -288,33 +288,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -391,10 +370,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -413,8 +393,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -433,8 +413,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -452,7 +432,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -495,8 +475,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -504,8 +484,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -71,7 +71,8 @@ New ticket</button><button
 				
 				Test RSVP ticket for {{ post_id }}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock tribe-tickets__tickets-editor-ticket-available-dates-icon-expired" >
-	January 1, 2021 - January 31, 2021</div>			</div>
+	January 1, 2021 - January 31, 2021</div>
+			</div>
 		</div>
 	</td>
 
@@ -203,8 +204,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -223,8 +224,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -267,14 +268,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -381,33 +382,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="Tribe__Tickets__RSVP" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -484,10 +464,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -506,8 +487,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -525,7 +506,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -550,8 +531,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -559,8 +540,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket and sale price__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket and sale price__0.snapshot.html
@@ -71,7 +71,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ post_id }}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -224,8 +225,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -244,8 +245,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -288,14 +289,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -402,33 +403,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -505,10 +485,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -527,8 +508,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -547,8 +528,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -566,7 +547,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -609,8 +590,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -618,8 +599,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -71,7 +71,8 @@ New ticket</button><button
 				
 				Test TC ticket for {{ post_id }}
 				<div  class="tribe-tickets__tickets-editor-ticket-available-dates dashicons-before dashicons-clock" >
-	January 2, 2020 - March 1, 2050</div>			</div>
+	January 2, 2020 - March 1, 2050</div>
+			</div>
 		</div>
 	</td>
 
@@ -213,8 +214,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -233,8 +234,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -277,14 +278,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -391,33 +392,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -494,10 +474,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -516,8 +497,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -536,8 +517,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -555,7 +536,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -598,8 +579,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -607,8 +588,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post without ticket__0.snapshot.html
@@ -110,8 +110,8 @@ New ticket</button><button
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -130,8 +130,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -174,14 +174,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -288,33 +288,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="Tribe__Tickets__RSVP_radio"
-								value="Tribe__Tickets__RSVP"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-														>
-						<span>
-							RSVPs						</span>
-											<input
-								type="radio"
-								name="ticket_provider"
-								id="TEC\Tickets\Commerce\Module_radio"
-								value="TEC\Tickets\Commerce\Module"
-								class="ticket_field ticket_provider"
-								tabindex="-1"
-								 checked='checked'						>
-						<span>
-							Tickets Commerce						</span>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -391,10 +370,11 @@ New ticket</button><button
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -413,8 +393,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -433,8 +413,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -452,7 +432,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -495,8 +475,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -504,8 +484,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__event__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__event__0.snapshot.html
@@ -97,16 +97,16 @@ New ticket</button><button
 </div>
 
 <div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
-	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
-     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+	 data-default-provider="TEC\Tickets\Commerce\Module"
+     data-current-provider="TEC\Tickets\Commerce\Module"
 >
 	
 	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -125,8 +125,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -169,14 +169,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -283,13 +283,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -305,10 +304,11 @@ New ticket</button><button
 				Leave blank for free Ticket			</p>
 				</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -327,8 +327,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -346,7 +346,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -371,8 +371,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -380,8 +380,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__post__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels_with_no_providers__post__0.snapshot.html
@@ -97,16 +97,16 @@ New ticket</button><button
 </div>
 
 <div id="tribe_panel_edit" class="ticket_panel panel_edit tribe-validation" aria-hidden="true"
-	 data-default-provider="Tribe__Tickets__Commerce__PayPal__Main"
-     data-current-provider="Tribe__Tickets__Commerce__PayPal__Main"
+	 data-default-provider="TEC\Tickets\Commerce\Module"
+     data-current-provider="TEC\Tickets\Commerce\Module"
 >
 	
 	<div id="ticket_form" class="ticket_form tribe_sectionheader tribe-validation">
 		<div id="ticket_form_table" class="eventtable ticket_form">
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-not-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition-not="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="ticket_title_add"
@@ -125,8 +125,8 @@ New ticket</button><button
 			</div>
 			<div
 					class="tribe-dependent"
-					data-depends="#Tribe__Tickets__RSVP_radio"
-					data-condition-is-checked
+					data-depends="#tec_tickets_ticket_provider"
+					data-condition="Tribe__Tickets__RSVP"
 			>
 				<h4
 						id="rsvp_title_add"
@@ -169,14 +169,14 @@ New ticket</button><button
 	/>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition-not="Tribe__Tickets__RSVP"
 	>
 	The ticket name is displayed on the frontend of your website and within ticket emails.	</span>
 	<span
 		class="tribe_soft_note ticket_form_right"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-		data-condition-is-checked
+		data-depends="#tec_tickets_ticket_provider"
+		data-condition="Tribe__Tickets__RSVP"
 	>
 	The RSVP name is displayed on the frontend of your website and within RSVP emails.	</span>
 </div>
@@ -283,13 +283,12 @@ New ticket</button><button
 	</div>
 </div>
 
-				<fieldset id="tribe_ticket_provider_wrapper" class="input_block" aria-hidden="true">
-					<legend class="ticket_form_label">Sell using:</legend>
-									</fieldset>
+				<input type="hidden" id="tec_tickets_ticket_provider" name="ticket_provider" value="TEC\Tickets\Commerce\Module" />
+
 				<div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -305,10 +304,11 @@ New ticket</button><button
 				Leave blank for free Ticket			</p>
 				</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -327,8 +327,8 @@ New ticket</button><button
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -346,7 +346,7 @@ New ticket</button><button
 </div>
 			</section>
 			<div class="accordion">
-				<div class="tribe-dependent" data-depends="#Tribe__Tickets__RSVP_radio" data-condition-is-not-checked>
+				<div class="tribe-dependent" data-depends="#tec_tickets_ticket_provider" data-condition-not="Tribe__Tickets__RSVP">
 	<button class="accordion-header tribe_advanced_meta">
 		Advanced	</button>
 	<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="1">
@@ -371,8 +371,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save ticket"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-not-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition-not="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"
@@ -380,8 +380,8 @@ New ticket</button><button
 						class="button-primary tribe-dependent tribe-validation-submit"
 						name="ticket_form_save"
 						value="Save RSVP"
-						data-depends="#Tribe__Tickets__RSVP_radio"
-						data-condition-is-checked
+						data-depends="#tec_tickets_ticket_provider"
+						data-condition="Tribe__Tickets__RSVP"
 				/>
 				<input
 						type="button"

--- a/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_add_fee_section__0.snapshot.html
+++ b/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_add_fee_section__0.snapshot.html
@@ -1,7 +1,7 @@
 <div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -78,10 +78,11 @@
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -100,8 +101,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -120,8 +121,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -179,5 +180,3 @@
 		
 	</div>
 </div>
-
-

--- a/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_add_fee_section_for_fresh_ticket__0.snapshot.html
+++ b/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_add_fee_section_for_fresh_ticket__0.snapshot.html
@@ -1,7 +1,7 @@
 <div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -78,10 +78,11 @@
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -100,8 +101,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -120,8 +121,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -157,5 +158,3 @@
 		
 	</div>
 </div>
-
-

--- a/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_add_fee_section_for_series__0.snapshot.html
+++ b/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_add_fee_section_for_series__0.snapshot.html
@@ -1,7 +1,7 @@
 <div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -78,10 +78,11 @@
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -100,8 +101,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -120,8 +121,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"
@@ -157,5 +158,3 @@
 		
 	</div>
 </div>
-
-

--- a/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_not_add_fee_section_for_anything_other_than_ticket__0.snapshot.html
+++ b/tests/order_modifiers_integration/Admin/__snapshots__/Order_Modifier_Fee_Metabox_Test__it_should_not_add_fee_section_for_anything_other_than_ticket__0.snapshot.html
@@ -1,7 +1,7 @@
 <div
 	class="price tribe-dependent"
-		data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+		data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 	>
 	<div class="input_block">
 		<label for="ticket_price" class="ticket_form_label ticket_form_left">Price:</label>
@@ -78,10 +78,11 @@
 </div>
 	</div>
 
-	</div><div
+	</div>
+<div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="Tribe__Tickets__RSVP_capacity"
@@ -100,8 +101,8 @@
 
 <div
 	class="input_block ticket_advanced_Tribe__Tickets__RSVP tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition="Tribe__Tickets__RSVP"
 >
 	<label
 		for="tribe-tickets-rsvp-not-going"
@@ -120,8 +121,8 @@
 
 <div
 	class="input_block ticket_advanced_TEC_Tickets_Commerce_Module tribe-dependent"
-	data-depends="#Tribe__Tickets__RSVP_radio"
-	data-condition-is-not-checked
+	data-depends="#tec_tickets_ticket_provider"
+	data-condition-not="Tribe__Tickets__RSVP"
 >
 	<label
 		for="TEC_Tickets_Commerce_Module_capacity"


### PR DESCRIPTION
### 🎫 Ticket
[ET-2287]

### 🗒️ Description
There is a radio input within the RSVP/Ticket Edit/Add HTML in the Classic Editor that is hidden via CSS. It is no longer being used, so we want to switch it to a regular hidden field instead.

Also see the PR for ETP here: https://github.com/the-events-calendar/event-tickets-plus/pull/1711

### 🎥 Artifacts <!-- if applicable-->
https://share.zight.com/9Zu6dknW

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2287]: https://stellarwp.atlassian.net/browse/ET-2287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ