### PR TITLE
[ET-2287] JavaScript fix to force RSVP provider being set

### DIFF
--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -29,7 +29,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 	const noTicketsOnRecurring = document.body.classList.contains( 'tec-no-tickets-on-recurring' );
 	const tickets_panel_helper_text_selector = '.tec_ticket-panel__helper_text__wrap';
 	const tickets_panel_hidden_recurrence_warning = '.tec_ticket-panel__recurring-unsupported-warning';
-	const ticket_provider_input_id = '#tec_tickets_ticket_provider';
+	const ticket_provider_input_id = 'tec_tickets_ticket_provider';
 	/*
 	 * Null or 'default' are the default ticket; 'rsvp' is the RSVP ticket.
 	 * The backend might use the value, sent over with AJAX panel requests, to modify panels
@@ -152,7 +152,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			providerValue = $checkedProvider.val();
 		}
 
-		const ticketProviderInput = $( ticket_provider_input_id );
+		const ticketProviderInput = $( document.getElementById( ticket_provider_input_id ) );
 		if ( force_rsvp || ! ticketProviderInput.val() ) {
 			ticketProviderInput.val( providerValue );
 		}

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -152,8 +152,8 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			providerValue = $checkedProvider.val();
 		}
 
-		const ticketProviderInput = $( document.getElementById( ticket_provider_input_id ) );
-		if ( ! ticketProviderInput.val() ) {
+		const ticketProviderInput = $( ticket_provider_input_id );
+		if ( force_rsvp || ! ticketProviderInput.val() ) {
 			ticketProviderInput.val( providerValue );
 		}
 		defaultTicketProviderModule = ticketProviderInput.val();


### PR DESCRIPTION
### 🎫 Ticket
[ET-2287]

### 🗒️ Description
Fixes the JavaScript for this ticket. We were getting the input wrong using the selector and we weren't forcing it to switch to RSVP when we needed to.

See original PR for changelog, artifacts, tests, etc:
https://github.com/the-events-calendar/event-tickets/pull/3497


[ET-2287]: https://stellarwp.atlassian.net/browse/ET-2287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ