### PR TITLE
Feat/adding hook for when asc status changes

### DIFF
--- a/changelog/feat-adding-hook-for-when-asc-status-changes
+++ b/changelog/feat-adding-hook-for-when-asc-status-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Firing a hook `tec.tickets.seating.setUsingAssignedSeating` whenever the isUsingAssignedSeating property is set. [ETP-973]

--- a/src/Tickets/Seating/app/blockEditor/store/index.js
+++ b/src/Tickets/Seating/app/blockEditor/store/index.js
@@ -4,6 +4,7 @@ import { controls } from './controls';
 import { selectors } from './selectors';
 import { actions } from './actions';
 import { localizedData } from './localized-data';
+import { doAction } from '@wordpress/hooks';
 
 const storeName = 'tec-tickets-seating';
 
@@ -19,6 +20,15 @@ const store = createReduxStore(storeName, {
 	reducer(state = DEFAULT_STATE, action) {
 		switch (action.type) {
 			case 'SET_USING_ASSIGNED_SEATING':
+				/**
+				 * Fires every time the isUsingAssignedSeating state property is changed.
+				 *
+				 * @since TBD
+				 *
+				 * @param {boolean} isUsingAssignedSeating Whether the event is using assigned seating
+				 */
+				doAction( 'tec.tickets.seating.setUsingAssignedSeating', action.isUsingAssignedSeating );
+
 				return {
 					...state,
 					isUsingAssignedSeating: action.isUsingAssignedSeating,


### PR DESCRIPTION
### 🎫 Ticket

[ETP-973]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Firing a hook `tec.tickets.seating.setUsingAssignedSeating` whenever the isUsingAssignedSeating property is set.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ETP-973]: https://stellarwp.atlassian.net/browse/ETP-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ