### PR TITLE
Move events ajax response to be outside of tickets commerce

### DIFF
--- a/changelog/tweak-move-ajax-response-for-events-out-of-ticketscommerce
+++ b/changelog/tweak-move-ajax-response-for-events-out-of-ticketscommerce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Move method `provide_events_results_to_ajax` one level higher so that it loads regardless of Tickets Commerce. [ETP-976]

--- a/src/Tickets/Commerce/Admin_Tables/Orders_Table.php
+++ b/src/Tickets/Commerce/Admin_Tables/Orders_Table.php
@@ -964,7 +964,7 @@ class Orders_Table extends WP_Posts_List_Table {
 			data-freeform="1"
 			data-force-search="1"
 			data-searching-placeholder="<?php esc_attr_e( 'Searching...', 'event-tickets' ); ?>"
-			data-source="tec_tc_order_table_events"
+			data-source="tec_tickets_list_ticketables_ajax"
 			data-source-nonce="<?php echo esc_attr( wp_create_nonce( 'tribe_dropdown' ) ); ?>"
 			data-ajax-delay="400"
 			data-ajax-cache="1"

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -30,6 +30,7 @@ use Tribe__Date_Utils;
 use WP_Query;
 use WP_Post;
 use WP_User_Query;
+use TEC\Tickets\Hooks as Tickets_Hooks;
 
 /**
  * Class Hooks.
@@ -139,7 +140,6 @@ class Hooks extends Service_Provider {
 		add_filter( 'tec_tickets_editor_configuration_localized_data', [ $this, 'filter_block_editor_localized_data' ] );
 		add_action( 'tribe_editor_config', [ $this, 'filter_tickets_editor_config' ] );
 		add_filter( 'wp_list_table_class_name', [ $this, 'filter_wp_list_table_class_name' ], 10, 2 );
-		add_filter( 'tribe_dropdown_tec_tc_order_table_events', [ $this, 'provide_events_results_to_ajax' ], 10, 2 );
 		add_filter( 'tribe_dropdown_tec_tc_order_table_customers', [ $this, 'provide_customers_results_to_ajax' ], 10, 2 );
 
 		add_filter( 'tec_tickets_all_tickets_table_provider_options', [ $this, 'filter_all_tickets_table_provider_options' ] );
@@ -150,6 +150,7 @@ class Hooks extends Service_Provider {
 	 * Provides the results for the events dropdown in the Orders table.
 	 *
 	 * @since 5.13.0
+	 * @deprecated TBD
 	 *
 	 * @param array<string,mixed>  $results The results.
 	 * @param array<string,string> $search The search.
@@ -157,42 +158,8 @@ class Hooks extends Service_Provider {
 	 * @return array<string,mixed>
 	 */
 	public function provide_events_results_to_ajax( $results, $search ) {
-		if ( empty( $search['term'] ) ) {
-			return $results;
-		}
-
-		$term = $search['term'];
-
-		$args = [
-			'no_found_rows'          => true,
-			'update_post_meta_cache' => false,
-			'update_post_term_cache' => false,
-			'post_type'              => (array) tribe_get_option( 'ticket-enabled-post-types', [] ),
-			'post_status'            => 'any',
-			'posts_per_page'         => 10,
-			's'                      => $term,
-			// Default to show most recent first.
-			'orderby'                => 'ID',
-			'order'                  => 'DESC',
-		];
-
-		$query = new WP_Query( $args );
-
-		if ( empty( $query->posts ) ) {
-			return $results;
-		}
-
-		$results = array_map(
-			function ( WP_Post $result ) {
-				return [
-					'id'   => $result->ID,
-					'text' => get_the_title( $result->ID ),
-				];
-			},
-			$query->posts
-		);
-
-		return [ 'results' => $results ];
+		_deprecated_function( __METHOD__, 'TBD', Tickets_Hooks::class . '::provide_events_results_to_ajax' );
+		return tribe( Tickets_Hooks::class )->provide_events_results_to_ajax( $results, $search );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Hooks.php
+++ b/src/Tickets/Commerce/Hooks.php
@@ -158,6 +158,7 @@ class Hooks extends Service_Provider {
 	 * @return array<string,mixed>
 	 */
 	public function provide_events_results_to_ajax( $results, $search ) {
+		// phpcs:ignore StellarWP.XSS.EscapeOutput.OutputNotEscaped
 		_deprecated_function( __METHOD__, 'TBD', Tickets_Hooks::class . '::provide_events_results_to_ajax' );
 		return tribe( Tickets_Hooks::class )->provide_events_results_to_ajax( $results, $search );
 	}

--- a/src/Tickets/Hooks.php
+++ b/src/Tickets/Hooks.php
@@ -19,6 +19,8 @@ namespace TEC\Tickets;
 
 use TEC\Common\Contracts\Service_Provider;
 use TEC\Tickets\Commerce\Payments_Tab;
+use WP_Query;
+use WP_Post;
 
 /**
  * Class Hooks.
@@ -52,6 +54,55 @@ class Hooks extends Service_Provider {
 	}
 
 	/**
+	 * Provides the results for the events dropdown in the Orders table.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed>  $results The results.
+	 * @param array<string,string> $search The search.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function provide_events_results_to_ajax( $results, $search ) {
+		if ( empty( $search['term'] ) ) {
+			return $results;
+		}
+
+		$term = $search['term'];
+
+		$args = [
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'post_type'              => (array) tribe_get_option( 'ticket-enabled-post-types', [] ),
+			'post_status'            => 'any',
+			'posts_per_page'         => 10,
+			's'                      => $term,
+			// Default to show most recent first.
+			'orderby'                => 'ID',
+			'order'                  => 'DESC',
+		];
+
+		$query = new WP_Query( $args );
+
+		if ( empty( $query->posts ) ) {
+			return $results;
+		}
+
+		$results = array_map(
+			function ( WP_Post $result ) {
+				return [
+					'id'   => $result->ID,
+					'text' => get_the_title( $result->ID ),
+				];
+			},
+			$query->posts
+		);
+
+		return [ 'results' => $results ];
+	}
+
+	/**
 	 * Generate TicketsCommerce Pages.
 	 *
 	 * @since 5.2.1
@@ -67,5 +118,6 @@ class Hooks extends Service_Provider {
 	 */
 	protected function add_filters() {
 		add_filter( 'tec_tickets_settings_tabs_ids', [ tribe( Payments_Tab::class ), 'settings_add_tab_id' ] );
+		add_filter( 'tribe_dropdown_tec_tickets_list_ticketables_ajax', [ $this, 'provide_events_results_to_ajax' ], 10, 2 );
 	}
 }

--- a/tests/ft_integration/Tribe/Tickets/OrderReportTest.php
+++ b/tests/ft_integration/Tribe/Tickets/OrderReportTest.php
@@ -179,6 +179,23 @@ class OrderReportTest extends WPTestCase {
 				wp_update_post( [ 'ID' => $order_a->ID, 'menu_order' => 0 ] );
 				wp_update_post( [ 'ID' => $order_b->ID, 'menu_order' => 1 ] );
 
+				// Manually set the `post_date` of each order in sequence to ensure the order is consistent in the snapshot.
+				global $wpdb;
+				foreach (
+					[
+						$order_a->ID => '2022-01-01 00:00:00',
+						$order_b->ID => '2022-01-02 00:00:00',
+					] as $order_id => $post_date
+				) {
+					$wpdb->query(
+						$wpdb->prepare(
+							"UPDATE {$wpdb->posts} SET post_date = %s WHERE ID = %d",
+							$post_date,
+							$order_id
+						)
+					);
+				}
+
 				return [ $series_id, [ $series_id, $series_pass_id_a, $order_a->ID, $order_b->ID ] ];
 			}
 		];

--- a/tests/integration/TEC/Tickets/Commerce/Admin_Tables/Orders_TableTest.php
+++ b/tests/integration/TEC/Tickets/Commerce/Admin_Tables/Orders_TableTest.php
@@ -10,6 +10,7 @@ use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Tribe\Tests\Traits\With_Uopz;
 use TEC\Tickets\Commerce\Hooks;
+use TEC\Tickets\Hooks as Tickets_Hooks;
 use WP_Screen;
 use WP_Query;
 use Tribe__Date_Utils as Dates;
@@ -235,7 +236,7 @@ class Orders_TableTest extends WPTestCase {
 		$this->prepare_test_data( true );
 
 		$test_events = function ( $term ) {
-			return tribe( Hooks::class )->provide_events_results_to_ajax( [], [ 'term' => $term ] );
+			return tribe( Tickets_Hooks::class )->provide_events_results_to_ajax( [], [ 'term' => $term ] );
 		};
 
 		$test_customers = function ( $term ) {

--- a/tests/integration/TEC/Tickets/Commerce/Admin_Tables/__snapshots__/Orders_TableTest__it_should_match_display__0.snapshot.html
+++ b/tests/integration/TEC/Tickets/Commerce/Admin_Tables/__snapshots__/Orders_TableTest__it_should_match_display__0.snapshot.html
@@ -37,7 +37,7 @@
 			data-freeform="1"
 			data-force-search="1"
 			data-searching-placeholder="Searching..."
-			data-source="tec_tc_order_table_events"
+			data-source="tec_tickets_list_ticketables_ajax"
 			data-source-nonce="1234567890"
 			data-ajax-delay="400"
 			data-ajax-cache="1"
@@ -129,4 +129,3 @@
 <span class="tablenav-pages-navspan button disabled" aria-hidden="true">&raquo;</span></span></div>
 		<br class="clear" />
 	</div>
-		

--- a/tests/integration/Tribe/Admin/OrderReportTest.php
+++ b/tests/integration/Tribe/Admin/OrderReportTest.php
@@ -326,6 +326,20 @@ class OrderReportTest extends WPTestCase {
 					);
 				}
 
+				wp_update_post(
+					[
+						'ID'         => $ticket_id_a,
+						'menu_order' => 0,
+					]
+				);
+
+				wp_update_post(
+					[
+						'ID'         => $ticket_id_b,
+						'menu_order' => 1,
+					]
+				);
+
 				return [
 					$event_id,
 					[


### PR DESCRIPTION
### 🎫 Ticket

[ETP-976]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Move method `provide_events_results_to_ajax` one level higher so that it loads regardless of Tickets Commerce.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ETP-976]: https://stellarwp.atlassian.net/browse/ETP-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ