### PR TITLE
Support UTC timezone

### DIFF
--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -438,9 +438,10 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				&& is_null( $this->event_timezone )
 			) {
 				try {
-					$this->event_timezone = new DateTimeZone( Tribe__Events__Timezones::get_event_timezone_string( $this->get_event_id() ) );
+					$timezone_string = Tribe__Events__Timezones::get_event_timezone_string( $this->get_event_id() );
+					$this->event_timezone = new DateTimeZone( $timezone_string );
 				} catch ( Exception $exception ) {
-					$this->event_timezone = null;
+					$this->event_timezone = 'UTC+0' === $timezone_string ? new DateTimeZone( 'UTC' ) : null;
 				}
 			}
 

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -439,6 +439,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			) {
 				try {
 					$timezone_string = Tribe__Events__Timezones::get_event_timezone_string( $this->get_event_id() );
+
 					$this->event_timezone = new DateTimeZone( $timezone_string );
 				} catch ( Exception $exception ) {
 					$this->event_timezone = 'UTC+0' === $timezone_string ? new DateTimeZone( 'UTC' ) : null;


### PR DESCRIPTION
Support UTC timezone. I know offsets can be a serious pain. but UTC itself is not.

Also our tests work on UTC, and when its not supported for time sensitive tests its an issue.