### PR TITLE
[ET-2293] Remove Moment from product-taskmaster

### DIFF
--- a/changelog/fix-update_product_taskmaster
+++ b/changelog/fix-update_product_taskmaster
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added version number to the `editor.js` script to stop caching. [ET-2293]

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@moderntribe/tickets": "file:src/modules",
     "@nfen/redux-reducer-injector": "0.0.3",
     "@redux-devtools/extension": "^3.3.0",
-    "@the-events-calendar/product-taskmaster": "^4.0.0",
+    "@the-events-calendar/product-taskmaster": "^4.0.1",
     "@wordpress/a11y": "^4.11.0",
     "@wordpress/data": "^10.11.0",
     "@wordpress/date": "^5.13.0",

--- a/src/Tickets/Blocks/Ticket/Block.php
+++ b/src/Tickets/Blocks/Ticket/Block.php
@@ -93,13 +93,15 @@ class Block extends Abstract_Block {
 		wp_register_script(
 			'tec-tickets-ticket-item-block-editor-script',
 			$plugin->plugin_url . "build/Tickets/Blocks/Ticket/editor.js",
-			[ 'tribe-common-gutenberg-vendor', 'tribe-tickets-gutenberg-vendor', 'tec-common-php-date-formatter' ]
+			[ 'tribe-common-gutenberg-vendor', 'tribe-tickets-gutenberg-vendor', 'tec-common-php-date-formatter' ],
+			Tickets_Main::VERSION
 		);
 
 		wp_register_style(
 			'tec-tickets-ticket-item-block-editor-style',
 			$plugin->plugin_url . "build/Tickets/Blocks/Ticket/editor{$min}.css",
-			[ 'tribe-tickets-gutenberg-main-styles' ]
+			[ 'tribe-tickets-gutenberg-main-styles' ],
+			Tickets_Main::VERSION
 		);
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-2293]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

This issue mainly occurred on versions of WordPress lower than 7.2. When you would edit an event on the block editor that contained the ticket block using ET 5.18, and then update ET to 5.19 and edit the same event, the block would throw an error.

```
Uncaught TypeError: modules[moduleId] is undefined
    __webpack_require__ https://optimistic-rook-b2a876.instawp.xyz/wp-content/plugins/event-tickets/build/Tickets/Blocks/Ticket/editor.js?ver=6.5.2:80
```

Upon trying different scenarios, we were able to find out that `moment` was being loaded as an external dependency due to Taskmaster. By removing the requirement for `moment` here that fixes the issue in ET.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[Screencast from 02-06-2025 11:31:40 AM.webm](https://github.com/user-attachments/assets/c001d02b-5b71-4f6f-a7e1-2591161a81f8)
### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2293]: https://stellarwp.atlassian.net/browse/ET-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ