### PR TITLE
[ET-2296] Correct template override path for My Tickets page

### DIFF
--- a/changelog/fix-ET-2296-order-page-template-override-path-correction
+++ b/changelog/fix-ET-2296-order-page-template-override-path-correction
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Corrected template override path for My Tickets page. [ET-2296]

--- a/src/views/tickets/orders.php
+++ b/src/views/tickets/orders.php
@@ -2,22 +2,23 @@
 /**
  * Edit Event Tickets.
  *
- * Override this template in your own theme by creating a file at [your-theme]/tribe/tickets/orders.php
+ * Override this template in your own theme by creating a file at [your-theme]/tribe-events/tickets/orders.php
  *
- * @link    https://evnt.is/1amp Help article for RSVP & Ticket template files.
+ * @link  https://evnt.is/1amp Help article for RSVP & Ticket template files.
  *
- * @since   4.7.4
- * @since   4.10.2 Only show Update button if ticket has meta.
- * @since   4.10.8 Show Update button if current user has either RSVP or Ticket with meta. Do not use the now-deprecated third parameter of `get_description_rsvp_ticket()`.
- * @since   4.10.9 Use function for text.
- * @since   4.11.3 Correct getting `$event_id` when using The Events Calendar's "Default Page Template" display template. `$event_id` now relies on the `WP_Query` queried object ID instead of the global `$post` object.
- * @since   4.11.3 Reformat a bit of the code around the button - no functional changes.
- * @since   4.12.1 Account for empty post type object, such as if post type got disabled.
- * @since   4.12.3 Account for inactive ticket providers.
- * @since   5.0.3 Add filter to control the re-sending emails option on email alteration.
- * @since   5.9.1 Corrected template override filepath
+ * @since 4.7.4
+ * @since 4.10.2 Only show Update button if ticket has meta.
+ * @since 4.10.8 Show Update button if current user has either RSVP or Ticket with meta. Do not use the now-deprecated third parameter of `get_description_rsvp_ticket()`.
+ * @since 4.10.9 Use function for text.
+ * @since 4.11.3 Correct getting `$event_id` when using The Events Calendar's "Default Page Template" display template. `$event_id` now relies on the `WP_Query` queried object ID instead of the global `$post` object.
+ * @since 4.11.3 Reformat a bit of the code around the button - no functional changes.
+ * @since 4.12.1 Account for empty post type object, such as if post type got disabled.
+ * @since 4.12.3 Account for inactive ticket providers.
+ * @since 5.0.3 Add filter to control the re-sending emails option on email alteration.
+ * @since 5.9.1 Corrected template override filepath.
+ * @since TBD Reverted template override filepath.
  *
- * @version 5.9.1
+ * @version TBD
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### 🎫 Ticket

[ET-2296]

### 🗒️ Description

A user reported that the template override path is slightly off and `tribe-events` works while `tribe` is inaccurate. 

### 🎥 Artifacts 
Using the previous template path:
![CleanShot 2025-02-11 at 13 01 02](https://github.com/user-attachments/assets/99e73964-e6ce-4ebf-9720-2c3a2fcf78a5)

Using the updated template path:
![image](https://github.com/user-attachments/assets/74105feb-6e9d-49c3-a286-2b02de5fdd9d)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2296]: https://stellarwp.atlassian.net/browse/ET-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ