### PR TITLE
Fix Faker deprecation notices in test suite

### DIFF
--- a/tests/_support/Commerce/Attendee_Maker.php
+++ b/tests/_support/Commerce/Attendee_Maker.php
@@ -3,8 +3,6 @@
 
 namespace Tribe\Tickets\Test\Commerce;
 
-
-use Tribe__Utils__Array as Arr;
 use Faker\Factory;
 use ReflectionClass;
 use RuntimeException;
@@ -79,20 +77,20 @@ trait Attendee_Maker {
 
 		$default_sku = $provider instanceof Tribe__Tickets__RSVP ? '' : 'test-attnd' . self::$generated;
 
-		$user_id = absint( Arr::get( $overrides, 'user_id', 0 ) );
+		$user_id = absint( $overrides['user_id'] ?? 0 );
 
 		$user_info = $this->get_data_for_name_props( $user_id, $overrides );
 
 		$meta = [
-			$provider->checkin_key              => (bool) Arr::get( $overrides, 'checkin', false ),
-			$provider->checkin_key . '_details' => Arr::get( $overrides, 'checkin_details', false ),
-			$provider->security_code            => Arr::get( $overrides, 'security_code', md5( uniqid() ) ),
-			$post_key                           => $post_id,
-			$product_key                        => $ticket_id,
-			$optout_key                         => Arr::get( $overrides, 'optout', false ),
-			$user_id_key                        => $user_id,
-			$ticket_sent_key                    => Arr::get( $overrides, 'ticket_sent', true ),
-			'_sku'                              => \Tribe__Utils__Array::get( $overrides, 'sku', $default_sku ),
+			$provider->checkin_key             => (bool) ( $overrides['checkin'] ?? false ),
+			"{$provider->checkin_key}_details" => $overrides['checkin_details'] ?? false,
+			$provider->security_code           => $overrides['security_code'] ?? md5( uniqid() ),
+			$post_key                          => $post_id,
+			$product_key                       => $ticket_id,
+			$optout_key                        => $overrides['optout'] ?? false,
+			$user_id_key                       => $user_id,
+			$ticket_sent_key                   => $overrides['ticket_sent'] ?? true,
+			'_sku'                             => $overrides['sku'] ?? $default_sku,
 		];
 
 		foreach ( $user_info as $key => $value ) {
@@ -188,7 +186,7 @@ trait Attendee_Maker {
 
 		$order = $provider instanceof Tribe__Tickets__RSVP
 			? $attendee_id
-			: \Tribe__Utils__Array::get( $overrides, 'order_id', md5( uniqid()) );
+			: $overrides['order_id'] ?? md5( uniqid() );
 
 		update_post_meta( $attendee_id, $order_key, $order );
 

--- a/tests/_support/Commerce/Attendee_Maker.php
+++ b/tests/_support/Commerce/Attendee_Maker.php
@@ -255,10 +255,10 @@ trait Attendee_Maker {
 		$faker = Factory::create();
 
 		$result = [
-			'first_name' => Arr::get( $overrides, 'first_name', $faker->firstName ),
-			'last_name'  => Arr::get( $overrides, 'last_name', $faker->lastName ),
-			'full_name'  => Arr::get( $overrides, 'full_name', $faker->name ),
-			'email'      => Arr::get( $overrides, 'email', $faker->email ),
+			'first_name' => $overrides['first_name'] ?? $faker->firstName(),
+			'last_name'  => $overrides['last_name'] ?? $faker->lastName(),
+			'full_name'  => $overrides['full_name'] ?? $faker->name(),
+			'email'      => $overrides['email'] ?? $faker->email(),
 		];
 
 		$user = get_userdata( $user_id );


### PR DESCRIPTION
### 🗒️ Description

When running the unit test suite, I noticed that we had some deprecation notices from the Faker library. These were due to calling object properties instead of class methods. This PR fixes those deprecation issues that I saw, and tweaks a few other things about the test file I noticed while going through it.

[skip-changelog]

### 🎥 Artifacts <!-- if applicable-->

<img width="1831" alt="Screenshot 2025-02-17 at 16 00 50" src="https://github.com/user-attachments/assets/3c56d5a3-7c45-45f3-b513-f71d6ffb23e8" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
