### PR TITLE
Fix all tickets CSS and default state

### DIFF
--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -49,7 +49,7 @@ class List_Table extends WP_List_Table {
 	 *
 	 * @var string
 	 */
-	public static $default_status = 'active';
+	public static $default_status = 'all';
 
 	/**
 	 * Default Sort By.

--- a/src/resources/postcss/tickets-admin-tickets.pcss
+++ b/src/resources/postcss/tickets-admin-tickets.pcss
@@ -43,6 +43,10 @@
 			}
 		}
 
+		.column-sold {
+			padding-right: 2em;
+		}
+
 		.column-id {
 			text-align: left;
 			white-space: nowrap;


### PR DESCRIPTION
### 🎫 Ticket

Fixing issues 8 and 10 from gsheet
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
Pushes the sold's column value a bit to the right.
Changed default state from Active tickets to All tickets.

This is an additional request which came along the waitlist feature. 

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
