### PR TITLE
Amend listener for RSVP date start/end

### DIFF
--- a/src/Tickets/Ticket_Actions.php
+++ b/src/Tickets/Ticket_Actions.php
@@ -109,7 +109,7 @@ class Ticket_Actions extends Controller_Contract {
 		add_action( 'update_post_meta', [ $this, 'pre_update_listener' ], 1000, 3 );
 		add_action( 'added_post_meta', [ $this, 'meta_keys_listener' ], 1000, 4 );
 		add_action( 'updated_postmeta', [ $this, 'meta_keys_listener' ], 1000, 4 );
-		add_action( 'tec_shutdown', [ $this, 'sync_rsvp_dates_for_all' ] );
+		add_action( 'tec_shutdown', [ $this, 'sync_rsvp_dates' ] );
 		add_action( self::TICKET_START_SALES_HOOK, [ $this, 'fire_ticket_start_date_action' ], 10, 2 );
 		add_action( self::TICKET_END_SALES_HOOK, [ $this, 'fire_ticket_end_date_action' ], 10, 2 );
 	}
@@ -126,7 +126,7 @@ class Ticket_Actions extends Controller_Contract {
 		remove_action( 'update_post_meta', [ $this, 'pre_update_listener' ], 1000 );
 		remove_action( 'added_post_meta', [ $this, 'meta_keys_listener' ], 1000 );
 		remove_action( 'updated_postmeta', [ $this, 'meta_keys_listener' ], 1000 );
-		remove_action( 'tec_shutdown', [ $this, 'sync_rsvp_dates_for_all' ] );
+		remove_action( 'tec_shutdown', [ $this, 'sync_rsvp_dates' ] );
 		remove_action( self::TICKET_START_SALES_HOOK, [ $this, 'fire_ticket_start_date_action' ] );
 		remove_action( self::TICKET_END_SALES_HOOK, [ $this, 'fire_ticket_end_date_action' ] );
 	}
@@ -268,7 +268,8 @@ class Ticket_Actions extends Controller_Contract {
 			return;
 		}
 
-		$this->sync_rsvp_dates_actions( $ticket_id );
+		// We avoid checking in_array multiple times and we will rather do array_unique once.
+		self::$rsvp_ids_to_sync[] = $ticket_id;
 	}
 
 	/**
@@ -279,7 +280,7 @@ class Ticket_Actions extends Controller_Contract {
 	 *
 	 * @return void
 	 */
-	public function sync_rsvp_dates_for_all() {
+	public function sync_rsvp_dates() {
 		/**
 		 * Filters the RSVP IDs to sync.
 		 *
@@ -342,18 +343,6 @@ class Ticket_Actions extends Controller_Contract {
 		 * @param int $old_stock The old stock value.
 		 */
 		do_action( 'tec_tickets_ticket_stock_changed', $ticket->ID, $new_stock, $old_stock );
-	}
-
-	/**
-	 * Syncs rsvp dates actions.
-	 *
-	 * @since TBD
-	 *
-	 * @param int $ticket_id The ticket id.
-	 */
-	protected function sync_rsvp_dates_actions( int $ticket_id ): void {
-		// We avoid checking in_array multiple times and we will rather do array_unique once.
-		self::$rsvp_ids_to_sync[] = $ticket_id;
 	}
 
 	/**

--- a/src/Tickets/Ticket_Actions.php
+++ b/src/Tickets/Ticket_Actions.php
@@ -352,20 +352,6 @@ class Ticket_Actions extends Controller_Contract {
 	 * @param int $ticket_id The ticket id.
 	 */
 	protected function sync_rsvp_dates_actions( int $ticket_id ): void {
-		$ticket = Tickets::load_ticket_object( $ticket_id );
-
-		if ( ! $ticket instanceof Ticket_Object ) {
-			// Not a ticket anymore...
-			return;
-		}
-
-		$event = $ticket->get_event();
-
-		if ( ! $event instanceof WP_Post || 0 === $event->ID ) {
-			// Parent event, no longer exists.
-			return;
-		}
-
 		// We avoid checking in_array multiple times and we will rather do array_unique once.
 		self::$rsvp_ids_to_sync[] = $ticket_id;
 	}

--- a/tests/_support/Commerce/RSVP/Ticket_Maker.php
+++ b/tests/_support/Commerce/RSVP/Ticket_Maker.php
@@ -43,11 +43,11 @@ trait Ticket_Maker {
 
 		$merged_meta_input = array_merge(
 			[
-				'_tribe_rsvp_for_event'                          => $post_id,
 				tribe( 'tickets.handler' )->key_capacity         => $capacity,
 				'_manage_stock'                                  => 'yes',
 				'_ticket_start_date'                             => date( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
 				'_ticket_end_date'                               => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'_tribe_rsvp_for_event'                          => $post_id,
 			],
 			$meta_input
 		);


### PR DESCRIPTION
Continuing work of PRs:

1) https://github.com/the-events-calendar/event-tickets/pull/3532
2) https://github.com/the-events-calendar/event-tickets/pull/3551

I noticed that the RSVP would not create start/end actions during its initial creation. That was because for our code, the WP_Post that would was created it was not yet a Ticket_Object.

So i am sending every request to sync RSVP dates to be performed during the request's end.

The conditionals being removed are already happening in `sync_ticket_dates_actions` - so the only thing that is affected by said change is that more IDs would be eligible for date sync during the request's end. But they will be correctly be filtered based on if they are Tickets or not.

## Why wasn't that caught by tests?

The reason is simple: order of meta keys is different for tests vs production.

see in tests: https://github.com/the-events-calendar/event-tickets/blob/4fbfb79fc4e487ef99517825a2fbddbdf57869e1/tests/_support/Commerce/RSVP/Ticket_Maker.php#L46

`_tribe_rsvp_for_event` key comes before start/end dates, while in production comes later.

As a result our `load_ticket_object` method would fail [here](https://github.com/the-events-calendar/event-tickets/blob/4fbfb79fc4e487ef99517825a2fbddbdf57869e1/src/Tribe/Tickets.php#L633) because an event would not be found for the ticket in production, but in tests would!