### PR TITLE
ET-2311 Table creation compatibiliy fix

### DIFF
--- a/changelog/fix-ET-2311-table-creation-compatibiliy-fix
+++ b/changelog/fix-ET-2311-table-creation-compatibiliy-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure a table creation script is compatible with MySQL Server version 8 and above. [ET-2311]

--- a/src/Tickets/Flexible_Tickets/Custom_Tables/Ticket_Groups.php
+++ b/src/Tickets/Flexible_Tickets/Custom_Tables/Ticket_Groups.php
@@ -56,7 +56,7 @@ class Ticket_Groups extends Table {
 			CREATE TABLE `$table_name` (
 				`id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 				`slug` varchar(255) DEFAULT '' NOT NULL,
-				`data` text DEFAULT '' NOT NULL,
+				`data` text DEFAULT ('') NOT NULL,
 				PRIMARY KEY (`id`)
 			) $charset_collate;
 		";


### PR DESCRIPTION
### 🎫 Ticket

[ET-2311]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The table creation script is not compatible with MySQL Server 8+, because it doesn’t allow default values for BLOB, TEXT, GEOMETRY or JSON columns.
The PR adjust the script so it also runs on MySQL server without failure.

### 🎥 Artifacts <!-- if applicable-->
n/a

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
