### PR TITLE
Add coupons section to single order display

### DIFF
--- a/src/admin-views/commerce/orders/single/order-items-coupons.php
+++ b/src/admin-views/commerce/orders/single/order-items-coupons.php
@@ -10,8 +10,6 @@
  * @var WP_Post $order   The current post object (with added properties).
  */
 
-use TEC\Tickets\Commerce\Admin\Singular_Order_Page;
-
 // If we don't have any coupons, we don't need to display anything; just add a comment to the HTML.
 if ( empty( $coupons ) ) {
 	printf(

--- a/src/admin-views/commerce/orders/single/order-items-coupons.php
+++ b/src/admin-views/commerce/orders/single/order-items-coupons.php
@@ -10,13 +10,8 @@
  * @var WP_Post $order   The current post object (with added properties).
  */
 
-// If we don't have any coupons, we don't need to display anything; just add a comment to the HTML.
+// If we don't have any coupons, we don't need to display anything.
 if ( empty( $coupons ) ) {
-	printf(
-		'<!-- %s -->',
-		esc_html__( 'No coupons found.', 'event-tickets' )
-	);
-
 	return;
 }
 

--- a/src/admin-views/commerce/orders/single/order-items-coupons.php
+++ b/src/admin-views/commerce/orders/single/order-items-coupons.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Single order - Coupons section.
+ *
+ * @since TBD
+ *
+ * @version TBD
+ *
+ * @var array   $coupons The coupons for the order.
+ * @var WP_Post $order   The current post object (with added properties).
+ */
+
+use TEC\Tickets\Commerce\Admin\Singular_Order_Page;
+
+// If we don't have any coupons, we don't need to display anything; just add a comment to the HTML.
+if ( empty( $coupons ) ) {
+	printf(
+		'<!-- %s -->',
+		esc_html__( 'No coupons found.', 'event-tickets' )
+	);
+
+	return;
+}
+
+?>
+<tr class="tec-tickets-commerce__coupons-section">
+	<td colspan="5"><h2><?php esc_html_e( 'Coupons', 'event-tickets' ); ?></h2></td>
+</tr>
+<?php foreach ( $coupons as $coupon ) : ?>
+	<tr class="tec-tickets-commerce-single-order--items--table--row">
+		<td><?php echo esc_html( $coupon['display_name'] ); ?></td>
+		<td><code><?php echo esc_html( $coupon['slug'] ); ?></code></td>
+		<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
+		<td style="padding-left:0;">
+			<div class="tec-tickets-commerce-price-container">
+				<ins>
+					<span class="tec-tickets-commerce-price">
+						<?php echo esc_html( $coupon['sub_total']->get_currency() ); ?>
+					</span>
+				</ins>
+			</div>
+		</td>
+	</tr>
+<?php endforeach; ?>

--- a/src/admin-views/commerce/orders/single/order-items-metabox-item.php
+++ b/src/admin-views/commerce/orders/single/order-items-metabox-item.php
@@ -17,7 +17,7 @@ use TEC\Tickets\Commerce\Order;
 <tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td><?php echo esc_html( $ticket->name ); ?></td>
 	<td class="tribe-desktop-only"><?php echo 'series_pass' === $ticket->type ? esc_html__( 'Series Pass', 'event-tickets' ) : esc_html__( 'Standard Ticket', 'event-tickets' ); ?></td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><?php /* @todo dpan: this is were Refunded would go */ ?></td>
 	<td style="padding-left:0;">
 		<?php
 		$current  = tribe( Order::class )->get_item_value( $item );

--- a/src/admin-views/commerce/orders/single/order-items-metabox.php
+++ b/src/admin-views/commerce/orders/single/order-items-metabox.php
@@ -3,15 +3,18 @@
  * Single order - Items metabox.
  *
  * @since 5.13.3
+ * @since TBD Added the coupons section.
  *
- * @version 5.13.3
+ * @version TBD
  *
- * @var WP_Post                                         $order             The current post object.
- * @var \TEC\Tickets\Commerce\Admin\Singular_Order_Page $single_page       The orders table output.
+ * @var WP_Post             $order       The current post object.
+ * @var Singular_Order_Page $single_page The orders table output.
  */
 
+use TEC\Tickets\Commerce\Admin\Singular_Order_Page;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Order;
+
 ?>
 <div class="tec-tickets-commerce-single-order--items">
 	<table class="tec-tickets-commerce-single-order--items--table widefat fixed">

--- a/src/admin-views/commerce/orders/single/order-items-metabox.php
+++ b/src/admin-views/commerce/orders/single/order-items-metabox.php
@@ -75,6 +75,14 @@ use TEC\Tickets\Commerce\Order;
 					);
 				}
 			}
+
+			$this->template(
+				'order-items-coupons',
+				[
+					'coupons' => $order->coupons ?? [],
+					'order'   => $order,
+				]
+			);
 			?>
 		</tbody>
 		<tfoot>

--- a/tests/_support/Traits/With_Test_Orders.php
+++ b/tests/_support/Traits/With_Test_Orders.php
@@ -35,14 +35,14 @@ trait With_Test_Orders {
 	 *
 	 * @return array
 	 */
-	protected function prepare_test_data( $with_wp_users = false ) {
+	protected function prepare_test_data() {
 		if ( ! empty( $this->orders ) ) {
 			return [ $this->orders, $this->tickets, $this->event_ids ];
 		}
 
 		$this->event_ids  = $this->create_test_events();
 		$this->tickets    = $this->create_test_tickets( $this->event_ids );
-		$this->orders     = $this->create_test_orders( $this->tickets, 2 , $with_wp_users );
+		$this->orders     = $this->create_test_orders( $this->tickets );
 
 		return [ $this->orders, $this->tickets, $this->event_ids ];
 	}

--- a/tests/integration/TEC/Tickets/Commerce/Admin/Singular_Order_PageTest.php
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/Singular_Order_PageTest.php
@@ -2,19 +2,23 @@
 
 namespace TEC\Tickets\Commerce\Admin;
 
+use Codeception\TestCase\WPTestCase;
 use TEC\Tickets\Commerce\Order;
-use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
-use TEC\Tickets\Commerce\Status\Completed;
 use TEC\Tickets\Commerce\Status\Denied;
+use TEC\Tickets\Commerce\Traits\Type;
 use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Commerce\OrderModifiers\Coupon_Creator;
 use Tribe\Tickets\Test\Traits\With_Test_Orders;
 use WP_Screen;
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 
-class Singular_Order_PageTest extends \Codeception\TestCase\WPTestCase {
+class Singular_Order_PageTest extends WPTestCase {
 
+	use Coupon_Creator;
 	use SnapshotAssertions;
-	use With_Uopz;
+	use Type;
 	use With_Test_Orders;
+	use With_Uopz;
 
 	/**
 	 * Created orders.
@@ -177,5 +181,46 @@ class Singular_Order_PageTest extends \Codeception\TestCase\WPTestCase {
 
 			$this->assertEquals( tribe( Denied::class )->get_wp_slug(), get_post_status( $order->ID ) );
 		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_coupons() {
+		// First, we should ensure that there is a comment about not having coupons.
+		$this->prepare_test_data();
+
+		/** @var Singular_Order_Page $singular_page */
+		$singular_page = tribe( Singular_Order_Page::class );
+
+		foreach ( $this->orders as $order ) {
+			ob_start();
+			$singular_page->render_order_items( $order );
+			$html = ob_get_clean();
+
+			// These orders don't have coupons, so we should see the message.
+			$this->assertTrue(
+				str_contains( $html, '<!-- No coupons found. -->' ),
+				'Orders without coupons should have an HTML comment that no coupons are found.'
+			);
+		}
+
+		// Now, we should add a coupon to the order and ensure it is displayed.
+		$coupon = $this->create_coupon();
+		$order  = $this->create_order(
+			[
+				$this->tickets[0] => 1,
+				$coupon->id       => [
+					'id'     => $this->get_unique_type_id( $coupon->id, 'coupon' ),
+					'extras' => [ 'type' => 'coupon' ],
+				],
+			]
+		);
+
+		ob_start();
+		$singular_page->render_order_items( $order );
+		$html = ob_get_clean();
+
+		$this->assertMatchesHtmlSnapshot( $html );
 	}
 }

--- a/tests/integration/TEC/Tickets/Commerce/Admin/Singular_Order_PageTest.php
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/Singular_Order_PageTest.php
@@ -187,7 +187,7 @@ class Singular_Order_PageTest extends WPTestCase {
 	 * @test
 	 */
 	public function it_should_render_coupons() {
-		// First, we should ensure that there is a comment about not having coupons.
+		// First, we should ensure that orders with no coupons have no mention of coupons.
 		$this->prepare_test_data();
 
 		/** @var Singular_Order_Page $singular_page */
@@ -198,10 +198,10 @@ class Singular_Order_PageTest extends WPTestCase {
 			$singular_page->render_order_items( $order );
 			$html = ob_get_clean();
 
-			// These orders don't have coupons, so we should see the message.
-			$this->assertTrue(
-				str_contains( $html, '<!-- No coupons found. -->' ),
-				'Orders without coupons should have an HTML comment that no coupons are found.'
+			// These orders don't have coupons, so they shouldn't mention them at all.
+			$this->assertFalse(
+				stripos( $html, 'coupon' ),
+				'Orders without coupons should have no mention of coupons in the HTML.'
 			);
 		}
 

--- a/tests/integration/TEC/Tickets/Commerce/Admin/Singular_Order_PageTest.php
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/Singular_Order_PageTest.php
@@ -221,6 +221,10 @@ class Singular_Order_PageTest extends WPTestCase {
 		$singular_page->render_order_items( $order );
 		$html = ob_get_clean();
 
+		$html = str_replace( $this->tickets, '{{TICKET_ID}}', $html );
+		$html = str_replace( $order->ID, '{{ORDER_ID}}', $html );
+		$html = str_replace( $this->event_ids, '{{EVENT_ID}}', $html );
+
 		$this->assertMatchesHtmlSnapshot( $html );
 	}
 }

--- a/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_match_order_items__0.snapshot.html
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_match_order_items__0.snapshot.html
@@ -25,7 +25,7 @@
 					</div>
 	</td>
 </tr>
-		</tbody>
+<!-- No coupons found. -->		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -72,7 +72,7 @@
 					</div>
 	</td>
 </tr>
-		</tbody>
+<!-- No coupons found. -->		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -119,7 +119,7 @@
 					</div>
 	</td>
 </tr>
-		</tbody>
+<!-- No coupons found. -->		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -166,7 +166,7 @@
 					</div>
 	</td>
 </tr>
-		</tbody>
+<!-- No coupons found. -->		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -213,7 +213,7 @@
 					</div>
 	</td>
 </tr>
-		</tbody>
+<!-- No coupons found. -->		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -260,7 +260,7 @@
 					</div>
 	</td>
 </tr>
-		</tbody>
+<!-- No coupons found. -->		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>

--- a/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_match_order_items__0.snapshot.html
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_match_order_items__0.snapshot.html
@@ -13,7 +13,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>
@@ -25,7 +25,7 @@
 					</div>
 	</td>
 </tr>
-<!-- No coupons found. -->		</tbody>
+		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -60,7 +60,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>
@@ -72,7 +72,7 @@
 					</div>
 	</td>
 </tr>
-<!-- No coupons found. -->		</tbody>
+		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -107,7 +107,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>
@@ -119,7 +119,7 @@
 					</div>
 	</td>
 </tr>
-<!-- No coupons found. -->		</tbody>
+		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -154,7 +154,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>
@@ -166,7 +166,7 @@
 					</div>
 	</td>
 </tr>
-<!-- No coupons found. -->		</tbody>
+		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -201,7 +201,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>
@@ -213,7 +213,7 @@
 					</div>
 	</td>
 </tr>
-<!-- No coupons found. -->		</tbody>
+		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>
@@ -248,7 +248,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>
@@ -260,7 +260,7 @@
 					</div>
 	</td>
 </tr>
-<!-- No coupons found. -->		</tbody>
+		</tbody>
 		<tfoot>
 			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
 				<td>

--- a/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_render_coupons__0.snapshot.html
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_render_coupons__0.snapshot.html
@@ -1,0 +1,61 @@
+<div class="tec-tickets-commerce-single-order--items">
+	<table class="tec-tickets-commerce-single-order--items--table widefat fixed">
+		<thead>
+			<tr>
+				<th>Item name</th>
+				<th class="tribe-desktop-only">Type</th>
+				<th class="tec-tickets-commerce-single-order--items--table--row--info-column"></th>
+				<th style="padding-left:0;">Price</th>
+				<th></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="tec-tickets-commerce-single-order--items--table--row">
+	<td>Test TC ticket for 5204</td>
+	<td class="tribe-desktop-only">Standard Ticket</td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td style="padding-left:0;">
+		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
+	<td>
+		<div class="tec-tickets-commerce-single-order--items--table--row--actions">
+			<a href="javascript:void(0)" class="tribe-dashicons">
+				<span class="dashicons tribe-icon-trash"></span>
+				<span class="tribe-mobile-hidden">Delete</span>
+			</a>
+					</div>
+	</td>
+</tr>
+<tr class="tec-tickets-commerce__coupons-section">
+	<td colspan="5"><h2>Coupons</h2></td>
+</tr>
+	<tr class="tec-tickets-commerce-single-order--items--table--row">
+		<td>Test Coupon 1</td>
+		<td><code>test-coupon-1</code></td>
+		<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
+		<td style="padding-left:0;">
+			<div class="tec-tickets-commerce-price-container">
+				<ins>
+					<span class="tec-tickets-commerce-price">
+						&#x24;-0.10					</span>
+				</ins>
+			</div>
+		</td>
+	</tr>
+		</tbody>
+		<tfoot>
+			<tr class="tec-tickets-commerce-single-order--items--table--row tec-tickets-commerce-single-order--items--table--row--gray-bg">
+				<td>
+					<button type="button" class="button button-secodnary">
+						Refund					</button>
+				</td>
+				<td class="tribe-desktop-only"></td>
+				<td class="tec-tickets-commerce-single-order--items--table--row--info-column">
+					<strong>Total</strong>
+				</td>
+				<td style="padding-left:0;">
+					<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;0.90</span></ins></div>				</td>
+				<td></td>
+			</tr>
+		</tfoot>
+	</table>
+</div>

--- a/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_render_coupons__0.snapshot.html
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_render_coupons__0.snapshot.html
@@ -11,7 +11,7 @@
 		</thead>
 		<tbody>
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
-	<td>Test TC ticket for 5204</td>
+	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
 	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
 	<td style="padding-left:0;">

--- a/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_render_coupons__0.snapshot.html
+++ b/tests/integration/TEC/Tickets/Commerce/Admin/__snapshots__/Singular_Order_PageTest__it_should_render_coupons__0.snapshot.html
@@ -13,7 +13,7 @@
 			<tr class="tec-tickets-commerce-single-order--items--table--row">
 	<td>Test TC ticket for {{EVENT_ID}}</td>
 	<td class="tribe-desktop-only">Standard Ticket</td>
-	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"><!-- @todo dpan: this is were Refunded would go --></td>
+	<td class="tec-tickets-commerce-single-order--items--table--row--info-column"></td>
 	<td style="padding-left:0;">
 		<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;1.00</span></ins></div>	</td>
 	<td>


### PR DESCRIPTION
### 🎫 Ticket

[ET-2247] (Part 1)

### 🗒️ Description

This PR adds coupons to the single order admin view. It adds a new template file tailored to displaying coupons attached to the order.

### 🎥 Artifacts <!-- if applicable-->

<img width="1519" alt="Screenshot 2025-02-24 at 09 36 06" src="https://github.com/user-attachments/assets/5599225e-9622-47d9-93ae-142f55bd13ab" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2247]: https://stellarwp.atlassian.net/browse/ET-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ