### PR TITLE
Fix for incorrect ticket count in query when running more than one provider.

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -21,7 +21,7 @@ jobs:
       # ------------------------------------------------------------------------------
       - name: Check for PHP file changes
         id: php_check
-        uses: ./.github/actions/check-php-changes@main
+        uses: ./.github/actions/check-php-changes
       # ------------------------------------------------------------------------------
   test:
     needs: check


### PR DESCRIPTION
Discovered while doing prelim work for presets. [ETP-988](https://stellarwp.atlassian.net/browse/ETP-988)
[ET-2317](https://stellarwp.atlassian.net/browse/ET-2317)

This line:
`$args['meta_query'] = array_merge( (array) $args['meta_query'], (array) $module_args['meta_query'] );`

Overwrites the `relation` set in `$args` with the default "AND" 

So if we are running two providers (such as TC and RSVP) and we check for ticket IDs on a post (with an ID of 215 below) the final query will be:
```php
$query = [
	[post_type]      => [
		[rsvp] => tribe_rsvp_tickets,
		[0]    => tec_tc_ticket,
	],
	[posts_per_page] => -1,
	[fields]          => ids,
	[post_status]    => publish,
	[order_by]       => menu_order,
	[order]          => ASC,
	[meta_query]     => [
		[relation]                       => AND,
		[_tribe_rsvp_for_event_in]       => [
			[key]     => _tribe_rsvp_for_event
			[compare] => IN
			[value]   => [ [0] => 215 ]

		
		],
		[_tec_tickets_commerce_event_in] => [
			[key]     => _tec_tickets_commerce_event
			[compare] => IN
			[value]   => [ [0] => 215 ]

		
		],
	]
];
```

Note the "AND" - so this will fail, and the function will always return 0 tickets found. It can't be both an RSVP AND a ticket (or a ticket from two providers simultaneously).

Also fixed the docblocks for `get_tickets_ids()` and the called `Tribe__Tickets__Tickets::set_tickets_query_args()` as neither can currently handle getting a post object passed to them 😞 

[ETP-988]: https://stellarwp.atlassian.net/browse/ETP-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-2317]: https://stellarwp.atlassian.net/browse/ET-2317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ