### PR TITLE
Update modifier messages to use correct modifier type

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -394,8 +394,9 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		} catch ( InvalidArgumentException $exception ) {
 			$this->render_error_message(
 				sprintf(
-					/* translators: %s: error message */
-					__( 'Error saving modifier: %s', 'event-tickets' ),
+					/* translators: 1: the modifier name 2:error message */
+					__( 'Error saving %1$s: %2$s', 'event-tickets' ),
+					$modifier_strategy->get_modifier_display_name(),
 					$exception->getMessage()
 				)
 			);

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -516,7 +516,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			$redirect_url = add_query_arg( 'deleted', $success ? 'success' : 'fail', $redirect_url );
 
 			// Redirect to the original page to avoid resubmitting the form upon refresh.
-			wp_safe_redirect( $redirect_url ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect
+			wp_safe_redirect( $redirect_url ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect,StellarWP.CodeAnalysis.RedirectAndDie
 			tribe_exit();
 		} catch ( Exception $e ) {
 			// Handle invalid modifier strategy.

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -224,7 +224,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 	 */
 	public function render_tec_order_modifiers_page(): void {
 		// Get and sanitize request vars for modifier and modifier_id.
-		$modifier_type = sanitize_key( tec_get_request_var( 'modifier', $this->get_default_type() ) );
+		$modifier_type = $this->get_modifier_type_from_request();
 		$modifier_id   = absint( tec_get_request_var( 'modifier_id', '0' ) );
 		$is_edit       = tribe_is_truthy( tec_get_request_var( 'edit', '0' ) );
 
@@ -286,7 +286,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 	 */
 	protected function get_modifier_data_by_id( int $modifier_id ): ?array {
 		// Get the modifier type from the request or use the default.
-		$modifier_type = tec_get_request_var( 'modifier', $this->get_default_type() );
+		$modifier_type = $this->get_modifier_type_from_request();
 
 		// Get the appropriate strategy for the selected modifier type.
 		$modifier_strategy = tribe( Controller::class )->get_modifier( $modifier_type );
@@ -361,7 +361,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		}
 
 		// Get and sanitize request vars for modifier and modifier_id.
-		$modifier_type = sanitize_key( tec_get_request_var( 'modifier', $this->get_default_type() ) );
+		$modifier_type = $this->get_modifier_type_from_request();
 		$modifier_id   = absint( tec_get_request_var( 'modifier_id', '0' ) );
 		$is_edit       = tribe_is_truthy( tec_get_request_var( 'edit', '0' ) );
 
@@ -434,8 +434,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			return;
 		}
 
-		$modifier_type = sanitize_key( tec_get_request_var( 'modifier', $this->get_default_type() ) );
-
+		$modifier_type     = $this->get_modifier_type_from_request();
 		$modifier_strategy = tribe( Controller::class )->get_modifier( $modifier_type );
 
 		if ( ! $modifier_strategy ) {
@@ -497,7 +496,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		$action        = tec_get_request_var( 'action', '' );
 		$modifier_id   = absint( tec_get_request_var( 'modifier_id', '' ) );
 		$nonce         = tec_get_request_var( '_wpnonce', '' );
-		$modifier_type = sanitize_key( tec_get_request_var( 'modifier', '' ) );
+		$modifier_type = $this->get_modifier_type_from_request();
 
 		// Early bail if the action is not 'delete_modifier'.
 		if ( 'delete_modifier' !== $action ) {

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -244,12 +244,12 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			return;
 		}
 
-		if ( ! $is_edit ) {
+		// Render the appropriate view based on the context.
+		if ( $is_edit ) {
+			$this->render_edit_view( $manager, $context );
+		} else {
 			$this->render_table_view( $manager, $context );
-
-			return;
 		}
-		$this->render_edit_view( $manager, $context );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -9,14 +9,14 @@
 
 namespace TEC\Tickets\Commerce\Order_Modifiers;
 
-use InvalidArgumentException;
 use Exception;
+use InvalidArgumentException;
+use TEC\Common\Asset;
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\StellarWP\Assets\Assets;
 use TEC\Tickets\Commerce\Order_Modifiers\Modifiers\Modifier_Manager;
 use TEC\Tickets\Commerce\Order_Modifiers\Traits\Valid_Types;
-use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use Tribe__Tickets__Main as Tickets_Plugin;
-use TEC\Common\StellarWP\Assets\Assets;
-use TEC\Common\Asset;
 
 /**
  * Class Modifier_Settings.

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -363,18 +363,9 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		// Get and sanitize request vars for modifier and modifier_id.
 		$modifier_type = $this->get_modifier_type_from_request();
 		$modifier_id   = absint( tec_get_request_var( 'modifier_id', '0' ) );
-		$is_edit       = tribe_is_truthy( tec_get_request_var( 'edit', '0' ) );
-
-		// Prepare the context for the page.
-		$context = [
-			'event_id'    => 0,
-			'modifier'    => $modifier_type,
-			'modifier_id' => $modifier_id,
-			'is_edit'     => $is_edit,
-		];
 
 		// Get the appropriate strategy for the selected modifier.
-		$modifier_strategy = tribe( Controller::class )->get_modifier( $context['modifier'] );
+		$modifier_strategy = tribe( Controller::class )->get_modifier( $modifier_type );
 
 		// Early bail if the strategy doesn't exist.
 		if ( ! $modifier_strategy ) {
@@ -383,7 +374,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		}
 
 		$raw_data                      = tribe_get_request_vars( true );
-		$raw_data['order_modifier_id'] = $context['modifier_id'];
+		$raw_data['order_modifier_id'] = $modifier_id;
 
 		try {
 			// Use the Modifier Manager to sanitize and save the data.

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -504,24 +504,24 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			wp_die( esc_html__( 'Nonce verification failed.', 'event-tickets' ) );
 		}
 
-		// Get the appropriate strategy for the selected modifier type.
-		$modifier_strategy = tribe( Controller::class )->get_modifier( $modifier_type );
+		try {
+			// Get the appropriate strategy for the selected modifier type.
+			$modifier_strategy = tribe( Controller::class )->get_modifier( $modifier_type );
 
-		// Handle invalid modifier strategy.
-		if ( ! $modifier_strategy ) {
-			wp_die( esc_html__( 'Invalid modifier type.', 'event-tickets' ) );
+			// Perform the deletion logic.
+			$success = $modifier_strategy->delete_modifier( $modifier_id );
+
+			// Construct the redirect URL with a success or failure flag.
+			$redirect_url = remove_query_arg( [ 'action', 'modifier_id', '_wpnonce' ], wp_get_referer() );
+			$redirect_url = add_query_arg( 'deleted', $success ? 'success' : 'fail', $redirect_url );
+
+			// Redirect to the original page to avoid resubmitting the form upon refresh.
+			wp_safe_redirect( $redirect_url );
+			tribe_exit();
+		} catch ( Exception $e ) {
+			// Handle invalid modifier strategy.
+			tribe_exit( esc_html__( 'Invalid modifier type.', 'event-tickets' ) );
 		}
-
-		// Perform the deletion logic.
-		$deletion_success = $modifier_strategy->delete_modifier( $modifier_id );
-
-		// Construct the redirect URL with a success or failure flag.
-		$redirect_url = remove_query_arg( [ 'action', 'modifier_id', '_wpnonce' ], wp_get_referer() );
-		$redirect_url = add_query_arg( 'deleted', $deletion_success ? 'success' : 'fail', $redirect_url );
-
-		// Redirect to the original page to avoid resubmitting the form upon refresh.
-		wp_safe_redirect( $redirect_url );
-		tribe_exit();
 	}
 
 	/**

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -516,7 +516,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			$redirect_url = add_query_arg( 'deleted', $success ? 'success' : 'fail', $redirect_url );
 
 			// Redirect to the original page to avoid resubmitting the form upon refresh.
-			wp_safe_redirect( $redirect_url );
+			wp_safe_redirect( $redirect_url ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect
 			tribe_exit();
 		} catch ( Exception $e ) {
 			// Handle invalid modifier strategy.

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -500,7 +500,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 		}
 
 		// Verify nonce.
-		if ( ! wp_verify_nonce( $nonce, 'delete_modifier_' . $modifier_id ) ) {
+		if ( ! wp_verify_nonce( $nonce, "delete_modifier_{$modifier_id}" ) ) {
 			wp_die( esc_html__( 'Nonce verification failed.', 'event-tickets' ) );
 		}
 

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -445,7 +445,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			return;
 		}
 
-		$this->render_success_message( __( 'Modifier saved successfully!', 'event-tickets' ) );
+		$this->render_success_message( $this->get_successful_save_message( $modifier_type ) );
 	}
 
 	/**
@@ -565,5 +565,37 @@ class Modifier_Admin_Handler extends Controller_Contract {
 	 */
 	protected function get_modifier_type_from_request(): string {
 		return sanitize_key( tec_get_request_var( 'modifier', $this->get_default_type() ) );
+	}
+
+	/**
+	 * Get the successful save message for the modifier type.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $modifier_type The type of modifier that was saved.
+	 *
+	 * @return string The success message to display.
+	 */
+	protected function get_successful_save_message( string $modifier_type ): string {
+		switch ( $modifier_type ) {
+			case 'coupon':
+				return __( 'Coupon saved successfully!', 'event-tickets' );
+
+			case 'fee':
+				return __( 'Fee saved successfully!', 'event-tickets' );
+
+			default:
+				$message = __( 'Modifier saved successfully!', 'event-tickets' );
+
+				/**
+				 * Filters the successful save message for order modifiers.
+				 *
+				 * @since TBD
+				 *
+				 * @param string $message       The success message to display.
+				 * @param string $modifier_type The type of modifier that was saved.
+				 */
+				return (string) apply_filters( 'tec_tickets_commerce_order_modifiers_successful_save_message', $message, $modifier_type );
+		}
 	}
 }

--- a/src/Tickets/Commerce/Order_Modifiers/Modifiers/Modifier_Abstract.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifiers/Modifier_Abstract.php
@@ -570,7 +570,7 @@ abstract class Modifier_Abstract implements Modifier_Strategy_Interface {
 	public function delete_modifier( int $modifier_id ): bool {
 		// Check if the modifier exists before attempting to delete it.
 		try {
-			$modifier = $this->repository->find_by_id( $modifier_id );
+			$this->repository->find_by_id( $modifier_id );
 		} catch ( Exception $e ) {
 			// Return false if the modifier does not exist.
 			return false;

--- a/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
+++ b/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
@@ -647,7 +647,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 		if ( $data['should_display_message'] ) {
 			$this->assertNotNull( $captured_success_message, 'Success message should be displayed.' );
 			$this->assertEquals(
-				__( 'Modifier saved successfully!', 'event-tickets' ),
+				$this->get_success_message( $data['get_data']['modifier'] ),
 				$captured_success_message,
 				'Success message does not match the expected value.'
 			);
@@ -656,14 +656,39 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 		}
 	}
 
+	protected function get_success_message( string $modifier_type ) {
+		switch ( $modifier_type ) {
+			case 'fee':
+				return 'Fee saved successfully!';
+			case 'coupon':
+				return 'Coupon saved successfully!';
+			default:
+				return 'Modifier saved successfully!';
+		}
+	}
+
 	public function handle_notices_data_provider(): Generator {
-		yield 'Valid notice display' => [
+		yield 'Valid notice display – Fee' => [
 			function () {
 				return [
 					'get_data'               => [
 						'updated'  => 1,
 						'edit'     => 1,
 						'modifier' => 'fee',
+						'page'     => 'tec-tickets-order-modifiers',
+					],
+					'should_display_message' => true,
+				];
+			},
+		];
+
+		yield 'Valid notice display – Coupon' => [
+			function () {
+				return [
+					'get_data'               => [
+						'updated'  => 1,
+						'edit'     => 1,
+						'modifier' => 'coupon',
 						'page'     => 'tec-tickets-order-modifiers',
 					],
 					'should_display_message' => true,


### PR DESCRIPTION
### 🎫 Ticket

QA Issue spreadsheeet – item `#002`

### 🗒️ Description

This updates the messages that are displayed in the modifier admin area to use the actual modifier type (e.g. "Coupon" or "Fee").

I also did some cleanup of some of the logic in relevant places nearby in the codebase.

### 🎥 Artifacts <!-- if applicable-->

**Before:**

<img width="913" alt="Screenshot 2025-02-26 at 16 09 12" src="https://github.com/user-attachments/assets/4383fa45-2e6d-4c19-ba4e-23f2b60ef86a" />

**After:**

<img width="913" alt="Screenshot 2025-02-26 at 15 55 51" src="https://github.com/user-attachments/assets/1bb8b14e-94b2-4997-b199-8c0e27b3d563" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
