### PR TITLE
Use coupon code for display instead of coupon name

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -256,7 +256,7 @@ class Coupons extends Base_API {
 				[
 					'success'     => true,
 					'discount'    => $discount->get(),
-					'label'       => esc_html( $coupon->display_name ),
+					'label'       => esc_html( $coupon->slug ),
 					'message'     => sprintf(
 						/* translators: %s: the coupon code */
 						esc_html__( 'Coupon "%s" applied successfully.', 'event-tickets' ),

--- a/src/views/v2/commerce/checkout/order-modifiers/coupons.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/coupons.php
@@ -66,7 +66,7 @@ $applied_container_classes = [
 			<li>
 				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
 					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
-						<?php echo esc_html( $coupon['display_name'] ?? '' ); ?>
+						<?php echo esc_html( $coupon['slug'] ?? '' ); ?>
 					</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img


### PR DESCRIPTION
### 🎫 Ticket

QA Issue spreadsheet – Item `#003`

### 🗒️ Description

This PR adjusts the display of the coupon in the checkout to use the slug instead of the display name.

It also ensures the API only allows one coupon at a time in the cart.

### 🎥 Artifacts <!-- if applicable-->

**Before:**

<img width="677" alt="Screenshot 2025-02-26 at 17 43 33" src="https://github.com/user-attachments/assets/fe933f03-6d99-4046-afb2-896d73bbc825" />

**After:**

<img width="677" alt="Screenshot 2025-02-26 at 17 43 19" src="https://github.com/user-attachments/assets/50d5b55c-5393-469b-8479-6cde75b2d486" />

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
