### PR TITLE
Coupons – fix location of negative sign

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -34,7 +34,6 @@ use WP_REST_Server as Server;
 class Coupons extends Base_API {
 
 	use CouponsTrait;
-	use Type;
 
 	/**
 	 * TThe modifier manager instance to handle relationship updates.
@@ -246,11 +245,7 @@ class Coupons extends Base_API {
 			$original_total = Currency_Value::create_from_float( $cart->get_cart_total() );
 
 			// Add the coupon to the cart.
-			$cart->upsert_item(
-				$this->get_unique_type_id( $coupon->id, 'coupon' ),
-				1,
-				[ 'type' => 'coupon' ]
-			);
+			$coupon->add_to_cart( $cart );
 			$cart->save();
 
 			$cart_total = Currency_Value::create_from_float( $cart->get_cart_total() );
@@ -312,10 +307,12 @@ class Coupons extends Base_API {
 			/** @var Cart $cart_page */
 			$cart_page = tribe( Cart::class );
 			$cart_page->set_cart_hash( $request->get_param( 'cart_hash' ) );
+
+			/** @var Abstract_Cart $cart */
 			$cart = $cart_page->get_repository();
 
 			// Remove the item from the cart.
-			$cart->remove_item( $this->get_unique_type_id( $coupon->id, 'coupon' ) );
+			$coupon->remove_from_cart( $cart );
 			$cart->save();
 
 			$cart_total = Currency_Value::create_from_float( $cart->get_cart_total() );
@@ -360,9 +357,6 @@ class Coupons extends Base_API {
 	 * @return array
 	 */
 	protected function prepare_coupon_for_response( Order_Modifier $coupon ) {
-		// @todo: better processing of the response.
-		$raw_amount = $coupon->raw_amount;
-
 		return [
 			'id'         => $coupon->id,
 			'slug'       => $coupon->slug,

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -20,7 +20,6 @@ use TEC\Tickets\Commerce\Order_Modifiers\Modifiers\Coupon_Modifier_Manager as Ma
 use TEC\Tickets\Commerce\Order_Modifiers\Repositories\Coupons as Coupons_Repository;
 use TEC\Tickets\Commerce\Order_Modifiers\Traits\Coupons as CouponsTrait;
 use TEC\Tickets\Commerce\Values\Currency_Value;
-use TEC\Tickets\Commerce\Traits\Type;
 use WP_Error;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -242,7 +242,7 @@ class Coupons extends Base_API {
 			}
 
 			// Store the previous total for use with the coupon calculation.
-			$original_total = Currency_Value::create_from_float( $cart->get_cart_total() );
+			$original_total = Currency_Value::create_from_float( $cart->get_cart_subtotal() );
 
 			// Add the coupon to the cart.
 			$coupon->add_to_cart( $cart );

--- a/src/Tickets/Commerce/Order_Modifiers/Models/Coupon.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Models/Coupon.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace TEC\Tickets\Commerce\Order_Modifiers\Models;
 
+use TEC\Tickets\Commerce\Cart\Cart_Interface;
+use TEC\Tickets\Commerce\Traits\Type;
 use TEC\Tickets\Commerce\Values\Percent_Value;
 use TEC\Tickets\Commerce\Values\Precision_Value;
 
@@ -20,6 +22,8 @@ use TEC\Tickets\Commerce\Values\Precision_Value;
  * @property Percent_Value $raw_amount The raw amount.
  */
 class Coupon extends Order_Modifier {
+
+	use Type;
 
 	/**
 	 * The modifier type.
@@ -46,5 +50,34 @@ class Coupon extends Order_Modifier {
 		$discount   = $base_price->multiply( $this->attributes['raw_amount'] );
 
 		return -1 * $discount->get();
+	}
+
+	/**
+	 * Add the coupon to the cart.
+	 *
+	 * @since TBD
+	 *
+	 * @param Cart_Interface $cart     The cart repository.
+	 * @param int            $quantity The quantity.
+	 */
+	public function add_to_cart( Cart_Interface $cart, int $quantity = 1 ) {
+		$cart->upsert_item(
+			$this->get_unique_type_id( $this->id, 'coupon' ),
+			$quantity,
+			[ 'type' => 'coupon' ]
+		);
+	}
+
+	/**
+	 * Remove the coupon from the cart.
+	 *
+	 * @since TBD
+	 *
+	 * @param Cart_Interface $cart The cart repository.
+	 *
+	 * @return void
+	 */
+	public function remove_from_cart( Cart_Interface $cart ) {
+		$cart->remove_item( $this->get_unique_type_id( $this->id, 'coupon' ) );
 	}
 }

--- a/src/Tickets/Commerce/Order_Modifiers/Models/Order_Modifier.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Models/Order_Modifier.php
@@ -85,6 +85,11 @@ class Order_Modifier extends Model implements ModelCrud, ModelFromQueryBuilderOb
 			return;
 		}
 
+		// If we don't have the raw amount set, nothing else to do.
+		if ( ! array_key_exists( 'raw_amount', $this->attributes ) ) {
+			return;
+		}
+
 		if ( $this->attributes['raw_amount'] instanceof Percent_Value ) {
 			return;
 		}

--- a/src/Tickets/Commerce/Order_Modifiers/Models/Order_Modifier.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Models/Order_Modifier.php
@@ -71,6 +71,28 @@ class Order_Modifier extends Model implements ModelCrud, ModelFromQueryBuilderOb
 	protected static string $order_modifier_type;
 
 	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string,mixed> $attributes Attributes.
+	 */
+	public function __construct( array $attributes = [] ) {
+		parent::__construct( $attributes );
+
+		// If we have a percent sub_type, we need to ensure the raw_amount is a Percent_Value.
+		if ( 'flat' === $this->sub_type ) {
+			return;
+		}
+
+		if ( $this->attributes['raw_amount'] instanceof Percent_Value ) {
+			return;
+		}
+
+		$this->setAttribute( 'raw_amount', new Percent_Value( $this->raw_amount ) );
+	}
+
+	/**
 	 * Finds a model by its ID.
 	 *
 	 * @since 5.18.0

--- a/src/Tickets/Commerce/Order_Modifiers/Modifiers/Modifier_Abstract.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifiers/Modifier_Abstract.php
@@ -302,8 +302,8 @@ abstract class Modifier_Abstract implements Modifier_Strategy_Interface {
 
 			case 'flat':
 			default:
-				$precision_value  = ( new Precision_Value( $value ) );
-				$formatted_amount = ( new Currency_Value( $precision_value ) )->get();
+				$precision_value  = new Precision_Value( $value );
+				$formatted_amount = ( Currency_Value::create( $precision_value ) )->get();
 				break;
 		}
 

--- a/src/Tickets/Commerce/Order_Modifiers/Traits/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Traits/Coupons.php
@@ -156,6 +156,11 @@ trait Coupons {
 		$available = $meta->find_by_order_modifier_id_and_meta_key( $coupon_id, 'coupons_available' );
 
 		// If we got null, the coupon is unlimited.
+		if ( null === $available ) {
+			return -1;
+		}
+
+		// If we got null, the coupon is unlimited.
 		if ( ! property_exists( $available, 'meta_value' ) || empty( $available->meta_value ) ) {
 			return -1;
 		}

--- a/src/Tickets/Commerce/Values/Base_Value.php
+++ b/src/Tickets/Commerce/Values/Base_Value.php
@@ -17,6 +17,7 @@ use InvalidArgumentException;
  * @since 5.18.0
  */
 abstract class Base_Value implements Value_Interface {
+
 	/**
 	 * The value.
 	 *
@@ -59,5 +60,5 @@ abstract class Base_Value implements Value_Interface {
 	 * @return void
 	 * @throws InvalidArgumentException When the value is not valid.
 	 */
-	abstract protected function validate( $value ): void;
+	protected function validate( $value ): void {}
 }

--- a/src/Tickets/Commerce/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Values/Currency_Value.php
@@ -31,6 +31,13 @@ class Currency_Value extends Base_Value {
 	protected $currency_symbol_position;
 
 	/**
+	 * The decimal separator.
+	 *
+	 * @var string
+	 */
+	protected $decimal_separator;
+
+	/**
 	 * The thousands separator.
 	 *
 	 * @var string
@@ -38,11 +45,11 @@ class Currency_Value extends Base_Value {
 	protected $thousands_separator;
 
 	/**
-	 * The decimal separator.
+	 * The value.
 	 *
-	 * @var string
+	 * @var Precision_Value
 	 */
-	protected $decimal_separator;
+	protected $value;
 
 	/**
 	 * Default values.

--- a/src/Tickets/Commerce/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Values/Currency_Value.php
@@ -130,18 +130,30 @@ class Currency_Value extends Base_Value {
 	 * Create a new instance of the class.
 	 *
 	 * @since 5.18.0
+	 * @since TBD Added currency_symbol, thousands_separator, decimal_separator, and currency_symbol_position params.
 	 *
-	 * @param Precision_Value $value The value to store.
+	 * @param Precision_Value $value                    The value to store.
+	 * @param ?string         $currency_symbol          The currency symbol. Will use the default if not provided.
+	 * @param ?string         $thousands_separator      The thousands separator. Will use the default if not provided.
+	 * @param ?string         $decimal_separator        The decimal separator. Will use the default if not provided.
+	 * @param ?string         $currency_symbol_position The currency symbol position. Will use the default if
+	 *                                                  not provided.
 	 *
 	 * @return Currency_Value The new instance.
 	 */
-	public static function create( Precision_Value $value ): self {
+	public static function create(
+		Precision_Value $value,
+		?string $currency_symbol = null,
+		?string $thousands_separator = null,
+		?string $decimal_separator = null,
+		?string $currency_symbol_position = null
+	): self {
 		return new self(
 			$value,
-			self::$defaults['currency_symbol'],
-			self::$defaults['thousands_separator'],
-			self::$defaults['decimal_separator'],
-			self::$defaults['currency_symbol_position']
+			$currency_symbol ?? self::$defaults['currency_symbol'],
+			$thousands_separator ?? self::$defaults['thousands_separator'],
+			$decimal_separator ?? self::$defaults['decimal_separator'],
+			$currency_symbol_position ?? self::$defaults['currency_symbol_position']
 		);
 	}
 

--- a/src/Tickets/Commerce/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Values/Currency_Value.php
@@ -96,20 +96,29 @@ class Currency_Value extends Base_Value {
 	 * @return string The value.
 	 */
 	public function get(): string {
+		// If the value is negative, we need to remove the negative sign before formatting.
+		if ( $this->value->get() < 0 ) {
+			$value  = $this->value->invert_sign();
+			$prefix = '- ';
+		} else {
+			$value  = $this->value;
+			$prefix = '';
+		}
+
 		$formatted = number_format(
-			$this->value->get(),
-			$this->value->get_precision(),
+			$value->get(),
+			$value->get_precision(),
 			$this->decimal_separator,
 			$this->thousands_separator
 		);
 
 		switch ( $this->currency_symbol_position ) {
 			case 'after':
-				return "{$formatted}{$this->currency_symbol}";
+				return "{$prefix}{$formatted}{$this->currency_symbol}";
 
 			case 'before':
 			default:
-				return "{$this->currency_symbol}{$formatted}";
+				return "{$prefix}{$this->currency_symbol}{$formatted}";
 		}
 	}
 

--- a/src/Tickets/Commerce/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Values/Currency_Value.php
@@ -81,11 +81,11 @@ class Currency_Value extends Base_Value {
 		string $decimal_separator = '.',
 		string $currency_symbol_position = 'before'
 	) {
-		$this->value                    = $value;
 		$this->currency_symbol          = $currency_symbol;
 		$this->thousands_separator      = $thousands_separator;
 		$this->decimal_separator        = $decimal_separator;
 		$this->currency_symbol_position = $currency_symbol_position;
+		parent::__construct( $value );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Values/Currency_Value.php
@@ -9,8 +9,6 @@ declare( strict_types=1 );
 
 namespace TEC\Tickets\Commerce\Values;
 
-use InvalidArgumentException;
-
 /**
  * Class Currency_Value
  *
@@ -263,16 +261,4 @@ class Currency_Value extends Base_Value {
 			$this->currency_symbol_position
 		);
 	}
-
-	/**
-	 * Validate that the value is valid.
-	 *
-	 * @since 5.18.0
-	 *
-	 * @param mixed $value The value to validate.
-	 *
-	 * @return void
-	 * @throws InvalidArgumentException When the value is not valid.
-	 */
-	protected function validate( $value ): void {}
 }

--- a/src/Tickets/Commerce/Values/Legacy_Value_Factory.php
+++ b/src/Tickets/Commerce/Values/Legacy_Value_Factory.php
@@ -46,4 +46,23 @@ class Legacy_Value_Factory {
 	public static function to_precision_value( LegacyValue $value ): Precision_Value {
 		return new Precision_Value( $value->get_float(), $value->get_precision() );
 	}
+
+	/**
+	 * Convert a legacy value object to a Currency_Value object.
+	 *
+	 * @since TBD
+	 *
+	 * @param LegacyValue $value The value to convert.
+	 *
+	 * @return Currency_Value The new value object.
+	 */
+	public static function to_currency_value( LegacyValue $value ): Currency_Value {
+		return Currency_Value::create(
+			static::to_precision_value( $value ),
+			$value->get_currency_symbol(),
+			$value->get_currency_separator_thousands(),
+			$value->get_currency_separator_decimal(),
+			$value->get_currency_symbol_position()
+		);
+	}
 }

--- a/src/Tickets/Commerce/Values/Precision_Value.php
+++ b/src/Tickets/Commerce/Values/Precision_Value.php
@@ -259,6 +259,19 @@ class Precision_Value extends Base_Value {
 	}
 
 	/**
+	 * Invert the sign of the value.
+	 *
+	 * Converts a negative value to a positive value, and vice versa.
+	 *
+	 * @since TBD
+	 *
+	 * @return Precision_Value The new value object.
+	 */
+	public function invert_sign(): Precision_Value {
+		return $this->multiply_by_integer( new Integer_Value( -1 ) );
+	}
+
+	/**
 	 * Get the value as a string.
 	 *
 	 * @since TBD

--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -416,11 +416,13 @@ tribe.tickets.commerce = {};
 				success( response ) {
 					if ( response.success ) {
 						// Show input and apply button again.
-						$inputContainer.show();
+						$inputContainer.removeClass( obj.selectors.hiddenElement.className() );
 						$( obj.selectors.couponInput ).val( '' );
 
 						// Hide the applied coupon section.
-						$( obj.selectors.couponAppliedSection ).hide();
+						$( obj.selectors.couponAppliedSection ).addClass(
+							obj.selectors.hiddenElement.className()
+						);
 						obj.updateTotalPrice( response.cart_amount );
 					} else {
 						$errorMessage

--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -421,7 +421,7 @@ tribe.tickets.commerce = {};
 
 						// Hide the applied coupon section.
 						$( obj.selectors.couponAppliedSection ).addClass(
-							obj.selectors.hiddenElement.className()
+							obj.selectors.hiddenElement.className(),
 						);
 						obj.updateTotalPrice( response.cart_amount );
 					} else {

--- a/src/views/v2/commerce/checkout/order-modifiers/coupons.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/coupons.php
@@ -72,7 +72,7 @@ $applied_container_classes = [
 						<img
 							src="<?php echo esc_url( tribe_resource_url( 'images/icons/close.svg', false, null, Tribe__Main::instance() ) ); ?>"
 							alt="<?php esc_attr_e( 'Close icon', 'event-tickets' ); ?>"
-							title="<?php esc_attr_e( 'Remove ticket', 'event-tickets' ); ?>"
+							title="<?php esc_attr_e( 'Remove coupon', 'event-tickets' ); ?>"
 						>
 					</button>
 				</span>

--- a/src/views/v2/commerce/checkout/order-modifiers/coupons.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/coupons.php
@@ -11,6 +11,7 @@
  */
 
 use TEC\Tickets\Commerce\Utils\Value;
+use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
 
 // Filter coupon items. If we have any coupons, always use the first one. There *shouldn't* be more than one.
 $coupon_items = array_filter( $items, fn( $item ) => 'coupon' === ( $item['type'] ?? '' ) );
@@ -19,7 +20,7 @@ $coupon       = array_shift( $coupon_items ) ?? [];
 // Determine the discount to display.
 $discount = '';
 if ( isset( $coupon['sub_total'] ) && $coupon['sub_total'] instanceof Value ) {
-	$discount = $coupon['sub_total']->get_currency();
+	$discount = Legacy_Value_Factory::to_currency_value( $coupon['sub_total'] )->get();
 }
 
 // Set up classes for all of the elements.

--- a/tests/_support/Commerce/TicketsCommerce/Order_Maker.php
+++ b/tests/_support/Commerce/TicketsCommerce/Order_Maker.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tribe\Tickets\Test\Commerce\TicketsCommerce;
 
 use TEC\Tickets\Commerce\Cart;
@@ -7,6 +8,7 @@ use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Completed;
 use TEC\Tickets\Commerce\Status\Pending;
 use Tribe\Tickets\Test\Commerce\Ticket_Maker as Ticket_Maker_Base;
+use Tribe__Repository__Usage_Error;
 use WP_Post;
 
 trait Order_Maker {
@@ -42,6 +44,24 @@ trait Order_Maker {
 			}
 		}
 
+		$order = $this->create_order_from_cart( $cart, $overrides );
+		$cart->clear_cart();
+
+		return $order;
+	}
+
+	/**
+	 * Create an order from a cart.
+	 *
+	 * Does NOT clear the cart afterwards.
+	 *
+	 * @param Cart  $cart      The cart to create the order from.
+	 * @param array $overrides An array of overrides for the purchaser.
+	 *
+	 * @return false|WP_Post The order post object or false if the order could not be created.
+	 * @throws Tribe__Repository__Usage_Error
+	 */
+	protected function create_order_from_cart( Cart $cart, array $overrides = [] ) {
 		$default_purchaser = [
 			'purchaser_user_id'    => 0,
 			'purchaser_full_name'  => 'Test Purchaser',
@@ -80,8 +100,6 @@ trait Order_Maker {
 		clean_post_cache( $order->ID );
 
 		remove_filter( 'tec_tickets_commerce_order_create_args', $feed_args_callback );
-
-		$cart->clear_cart();
 
 		return $order;
 	}

--- a/tests/_support/Traits/Tribe_URL.php
+++ b/tests/_support/Traits/Tribe_URL.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tribe\Tests\Tickets\Traits;
+
+use Tribe\Tests\Traits\With_Uopz;
+
+/**
+ * Trait Tribe_URL
+ *
+ * @since TBD
+ */
+trait Tribe_URL {
+
+	use With_Uopz;
+
+	/**
+	 * @before
+	 */
+	public function replace_image_path() {
+		$this->set_fn_return(
+			'tribe_resource_url',
+			function ( $path ) {
+				$path = ltrim( $path, '/' );
+				return "https://example.com/{$path}";
+			},
+			true
+		);
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Order_Test.php
@@ -51,14 +51,14 @@ class Order_Test extends WPTestCase {
 		$this->assertSame( 'abcdefghijklmnop', $hash );
 
 		// Each next order includes previous order's items as well since we are not clearing the cart in between.
-		$order_1 = $this->create_order_from_cart( [ $ticket_id_1 => 1 ] );
+		$order_1 = $this->create_order_from_cart_items( [ $ticket_id_1 => 1 ] );
 		$this->assertSame( 'abcdefghijklmnop', $cart->get_cart_hash() );
 
-		$order_2 = $this->create_order_from_cart( [ $ticket_id_2 => 1 ] );
+		$order_2 = $this->create_order_from_cart_items( [ $ticket_id_2 => 1 ] );
 		$this->assertSame( 'abcdefghijklmnop', $cart->get_cart_hash() );
 
 		// This will update the quantity of both tickets in the cart.
-		$order_3 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
+		$order_3 = $this->create_order_from_cart_items( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
 		$this->assertSame( 'abcdefghijklmnop', $cart->get_cart_hash() );
 
 		// All of the orders should be an instance of the WP_Post class.
@@ -87,15 +87,15 @@ class Order_Test extends WPTestCase {
 
 		$cart->clear_cart();
 		$cart->get_cart_hash( true );
-		$order_4 = $this->create_order_from_cart( [ $ticket_id_1 => 1 ] );
+		$order_4 = $this->create_order_from_cart_items( [ $ticket_id_1 => 1 ] );
 		$this->assertSame( 'abcdefghijklmnop-1', $cart->get_cart_hash() );
 		$cart->clear_cart();
 		$cart->get_cart_hash( true );
-		$order_5 = $this->create_order_from_cart( [ $ticket_id_2 => 1 ] );
+		$order_5 = $this->create_order_from_cart_items( [ $ticket_id_2 => 1 ] );
 		$this->assertSame( 'abcdefghijklmnop-2', $cart->get_cart_hash() );
 		$cart->clear_cart();
 		$cart->get_cart_hash( true );
-		$order_6 = $this->create_order_from_cart( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
+		$order_6 = $this->create_order_from_cart_items( [ $ticket_id_1 => 2, $ticket_id_2 => 2 ] );
 		$this->assertSame( 'abcdefghijklmnop-3', $cart->get_cart_hash() );
 		$cart->clear_cart();
 
@@ -152,7 +152,7 @@ class Order_Test extends WPTestCase {
 		$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
 		$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
 
-		$order = $this->create_order_from_cart( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ] );
+		$order = $this->create_order_from_cart_items( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ] );
 		tribe( Cart::class )->clear_cart();
 
 		$this->assertFalse( tribe( Order::class )->is_checkout_completed( $order->ID ) );
@@ -172,7 +172,7 @@ class Order_Test extends WPTestCase {
 		$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
 		$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
 
-		$order = $this->create_order_from_cart( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ] );
+		$order = $this->create_order_from_cart_items( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ] );
 		tribe( Cart::class )->clear_cart();
 
 		$this->assertFalse( tribe( Order::class )->has_on_checkout_screen_hold( $order->ID ) );
@@ -199,7 +199,7 @@ class Order_Test extends WPTestCase {
 		}, 10, 3 );
 
 		$this->assertEquals( 0, did_action( 'tec_tickets_commerce_order_status_transition' ) );
-		$order = $this->create_order_from_cart( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ] );
+		$order = $this->create_order_from_cart_items( [ $ticket_id_1 => 1, $ticket_id_2 => 2 ] );
 		tribe( Cart::class )->clear_cart();
 
 		$this->assertFalse( tribe( Order::class )->is_order_locked( $order->ID ) );
@@ -382,7 +382,7 @@ class Order_Test extends WPTestCase {
 		$this->assertEquals( 50, $global_stock->get_stock_level(), 'Global stock should be 50' );
 
 		// Create an Order for 5 on each Ticket.
-		$order_id = $this->create_order_from_cart(
+		$order_id = $this->create_order_from_cart_items(
 			[
 				$ticket_a_id => 5,
 				$ticket_b_id => 6,
@@ -741,7 +741,7 @@ class Order_Test extends WPTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
-	protected function create_order_from_cart( array $items, array $overrides = [] ) {
+	protected function create_order_from_cart_items( array $items, array $overrides = [] ) {
 		foreach ( $items as $id => $quantity ) {
 			tribe( Cart::class )->get_repository()->upsert_item( $id, $quantity );
 		}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/CartFooterTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/CartFooterTest.php
@@ -3,9 +3,12 @@
 namespace TEC\Tickets\Commerce\Partials\Checkout\Cart;
 
 use TEC\Tickets\Commerce\Utils\Value;
+use Tribe\Tests\Tickets\Traits\Tribe_URL;
 use Tribe\Tickets\Test\Testcases\TicketsCommerceSnapshotTestCase;
 
 class CartFooterTest extends TicketsCommerceSnapshotTestCase {
+
+	use Tribe_URL;
 
 	protected $partial_path = 'checkout/cart/footer';
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/CartTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/CartTest.php
@@ -3,9 +3,12 @@
 namespace TEC\Tickets\Commerce\Partials\Checkout\Cart;
 
 use TEC\Tickets\Commerce\Utils\Value;
+use Tribe\Tests\Tickets\Traits\Tribe_URL;
 use Tribe\Tickets\Test\Testcases\TicketsCommerceSnapshotTestCase;
 
 class CartTest extends TicketsCommerceSnapshotTestCase {
+
+	use Tribe_URL;
 
 	protected $partial_path = 'checkout/cart';
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
@@ -29,7 +29,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
@@ -27,7 +27,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
@@ -42,7 +42,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
@@ -40,7 +40,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
@@ -107,7 +107,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -127,7 +127,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
@@ -157,7 +157,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
@@ -222,7 +222,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
@@ -107,7 +107,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
@@ -172,7 +172,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/API/Coupons_Test.php
+++ b/tests/order_modifiers_integration/API/Coupons_Test.php
@@ -68,21 +68,7 @@ class Coupons_Test extends Controller_Test_Case {
 
 		yield 'apply coupon -> valid response' => [
 			function () use ( $coupon_15_percent ) {
-				// Create an event.
-				$event_id = self::factory()->post->create( [ 'post_title' => 'The Event' ] );
-
-				// Create a ticket.
-				$ticket = $this->create_tc_ticket( $event_id, 10 );
-
-				// Set up the cart with the ticket.
-				$commerce_cart = tribe( Cart::class );
-				$commerce_cart->set_cart_hash( 'fake-cart-hash' );
-
-				/** @var Abstract_Cart $cart */
-				$cart = $commerce_cart->get_repository();
-				$cart->upsert_item( $ticket, 1 );
-
-				$this->assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
+				$cart = $this->set_up_cart_with_ticket();
 				$this->assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
 
 				// Set up the fake payment intent update handler.
@@ -94,7 +80,7 @@ class Coupons_Test extends Controller_Test_Case {
 					'POST',
 					[
 						'coupon'            => $coupon_15_percent()->slug,
-						'cart_hash'         => 'fake-cart-hash',
+						'cart_hash'         => $cart->get_hash(),
 						'payment_intent_id' => 'fake-payment-intent-id',
 					],
 				];
@@ -205,5 +191,25 @@ class Coupons_Test extends Controller_Test_Case {
 		}
 
 		return rest_do_request( $request );
+	}
+
+	protected function set_up_cart_with_ticket() {
+		// Create an event.
+		$event_id = self::factory()->post->create( [ 'post_title' => 'The Event' ] );
+
+		// Create a ticket.
+		$ticket = $this->create_tc_ticket( $event_id, 10 );
+
+		// Set up the cart with the ticket.
+		$commerce_cart = tribe( Cart::class );
+		$commerce_cart->set_cart_hash( 'fake-cart-hash' );
+
+		/** @var Abstract_Cart $cart */
+		$cart = $commerce_cart->get_repository();
+		$cart->upsert_item( $ticket, 1 );
+
+		$this->assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
+
+		return $cart;
 	}
 }

--- a/tests/order_modifiers_integration/API/Coupons_Test.php
+++ b/tests/order_modifiers_integration/API/Coupons_Test.php
@@ -92,7 +92,9 @@ class Coupons_Test extends Controller_Test_Case {
 			return $response;
 		}
 
-		$this->assertSame( 200, $response->get_status() );
+		$this->assertGreaterThanOrEqual( 200, $response->get_status(), 'A response code should be returned >= 200' );
+		$this->assertLessThan( 300, $response->get_status(), 'A response code should be returned < 300' );
+		$this->assertSame( 200, $response->get_status(), 'A successful response code shoudl be returned' );
 		$this->assertFalse( $response->is_error(), "Expected a successful response for path: {$path}" );
 		$this->assertNull( $response->as_error() );
 

--- a/tests/order_modifiers_integration/API/Coupons_Test.php
+++ b/tests/order_modifiers_integration/API/Coupons_Test.php
@@ -5,10 +5,16 @@ namespace TEC\Tickets\Commerce\Order_Modifiers\API;
 use Closure;
 use Generator;
 use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Cart\Abstract_Cart;
+use TEC\Tickets\Commerce\Gateways\Stripe\Payment_Intent;
+use TEC\Tickets\Commerce\Order_Modifiers\Models\Coupon;
 use TEC\Tickets\Commerce\Order_Modifiers\Repositories\Coupons as CouponsRepository;
+use TEC\Tickets\Commerce\Values\Currency_Value;
 use Tribe\Tests\Traits\With_Clock_Mock;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\OrderModifiers\Coupon_Creator;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use WP_Error;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
@@ -17,6 +23,7 @@ use WP_REST_Server as Server;
 class Coupons_Test extends Controller_Test_Case {
 
 	use Coupon_Creator;
+	use Ticket_Maker;
 	use With_Clock_Mock;
 	use With_Uopz;
 
@@ -26,22 +33,105 @@ class Coupons_Test extends Controller_Test_Case {
 	 * @dataProvider rest_endpoints_data_provider
 	 * @test
 	 */
-	public function it_should_provide_expected_responses( Closure $fixture ) {
+	public function it_should_provide_expected_responses( Closure $fixture, ?Closure $post_checks = null ) {
 		$this->make_controller()->register();
 		[ $path, $should_fail, $method, $data ] = $fixture();
 		$result = $this->assert_endpoint( $path, $method, $should_fail, $data, 401 );
+
+		if ( null !== $post_checks ) {
+			$post_checks( $result );
+		}
 	}
 
 	public function rest_endpoints_data_provider(): Generator {
 		yield 'coupons archive -> unauthorized' => [
 			function () {
 				$coupons = $this->create_data();
+
 				return [
 					'/coupons',
 					true,
 					'GET',
-					[]
+					[],
 				];
+			},
+		];
+
+		$coupon_15_percent = function (): Coupon {
+			static $coupon = null;
+			if ( null === $coupon ) {
+				$coupon = $this->create_coupon( [ 'raw_amount' => 15 ] );
+			}
+
+			return $coupon;
+		};
+
+		yield 'apply coupon -> valid response' => [
+			function () use ( $coupon_15_percent ) {
+				// Create an event.
+				$event_id = self::factory()->post->create( [ 'post_title' => 'The Event' ] );
+
+				// Create a ticket.
+				$ticket = $this->create_tc_ticket( $event_id, 10 );
+
+				// Set up the cart with the ticket.
+				$commerce_cart = tribe( Cart::class );
+				$commerce_cart->set_cart_hash( 'fake-cart-hash' );
+
+				/** @var Abstract_Cart $cart */
+				$cart = $commerce_cart->get_repository();
+				$cart->upsert_item( $ticket, 1 );
+
+				$this->assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
+				$this->assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
+
+				// Set up the fake payment intent update handler.
+				$this->set_class_fn_return( Payment_Intent::class, 'update', true );
+
+				return [
+					'/coupons/apply',
+					false,
+					'POST',
+					[
+						'coupon'            => $coupon_15_percent()->slug,
+						'cart_hash'         => 'fake-cart-hash',
+						'payment_intent_id' => 'fake-payment-intent-id',
+					],
+				];
+			},
+			function ( Response $response ) use ( $coupon_15_percent ) {
+				// Check that the coupon was applied to the cart.
+				/** @var Abstract_Cart $cart */
+				$cart = tribe( Cart::class )->get_repository();
+
+				$this->assertCount( 2, $cart->get_items_in_cart( false, 'all' ) );
+				$this->assertCount( 1, $cart->get_items_in_cart( false, 'coupon' ) );
+
+				// Check that the response has the correct data.
+				$data = $response->get_data();
+				$this->assertArrayHasKey( 'success', $data );
+				$this->assertArrayHasKey( 'discount', $data );
+				$this->assertArrayHasKey( 'label', $data );
+				$this->assertArrayHasKey( 'message', $data );
+				$this->assertArrayHasKey( 'cart_amount', $data );
+
+				// Check that the data has been generated correctly.
+				$this->assertTrue( $data['success'] );
+				$this->assertSame( '- $1.50', $data['discount'] );
+				$this->assertSame( $coupon_15_percent()->slug, $data['label'] );
+				$this->assertSame(
+					esc_html(
+						sprintf(
+							'Coupon "%s" applied successfully.',
+							$coupon_15_percent()->slug,
+						)
+					),
+					$data['message']
+				);
+				$this->assertSame(
+					Currency_Value::create_from_float( $cart->get_cart_total() )->get(),
+					$data['cart_amount']
+				);
 			},
 		];
 	}

--- a/tests/order_modifiers_integration/Checkout/Coupons_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Coupons_Test.php
@@ -117,7 +117,7 @@ class Coupons_Test extends Controller_Test_Case {
 	/**
 	 * @test
 	 */
-	public function it_should_calculate_fees_and_store_them_correctly_simple_math() {
+	public function it_should_calculate_coupons_simple_math() {
 		$post        = static::factory()->post->create( [ 'post_title' => 'The Coupon Event' ] );
 		$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
 		$ticket_id_2 = $this->create_tc_ticket( $post, 20 );

--- a/tests/order_modifiers_integration/Checkout/Coupons_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Coupons_Test.php
@@ -13,7 +13,6 @@ use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Coupons;
 use TEC\Tickets\Commerce\Shortcodes\Checkout_Shortcode;
 use TEC\Tickets\Commerce\Traits\Type;
 use TEC\Tickets\Commerce\Utils\Value;
-use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
 use TEC\Tickets\Flexible_Tickets\Test\Traits\Series_Pass_Factory;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
@@ -23,6 +22,7 @@ use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Tribe\Tickets\Test\Traits\Reservations_Maker;
 use Tribe\Tickets\Test\Traits\With_No_Object_Storage;
 use Tribe\Tickets\Test\Traits\With_Tickets_Commerce;
+use Tribe\Tests\Tickets\Traits\Tribe_URL;
 
 class Coupons_Test extends Controller_Test_Case {
 
@@ -33,6 +33,7 @@ class Coupons_Test extends Controller_Test_Case {
 	use Series_Pass_Factory;
 	use SnapshotAssertions;
 	use Ticket_Maker;
+	use Tribe_URL;
 	use Type;
 	use With_No_Object_Storage;
 	use With_Tickets_Commerce;

--- a/tests/order_modifiers_integration/Checkout/Coupons_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Coupons_Test.php
@@ -4,11 +4,16 @@ declare( strict_types=1 );
 
 namespace TEC\Tickets\Tests\Order_Modifiers_Integration\Checkout;
 
+
+use PHPUnit\Framework\Assert;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Tickets\Commerce\Cart as Commerce_Cart;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Coupons;
+use TEC\Tickets\Commerce\Shortcodes\Checkout_Shortcode;
 use TEC\Tickets\Commerce\Traits\Type;
 use TEC\Tickets\Commerce\Utils\Value;
+use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
 use TEC\Tickets\Flexible_Tickets\Test\Traits\Series_Pass_Factory;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
@@ -85,9 +90,9 @@ class Coupons_Test extends Controller_Test_Case {
 		/** @var Value $total */
 		$total = $order->total_value;
 
-		$this->assertEquals( 9.0, $total->get_float() );
-		$this->assertEquals( 1, count( $order->items ) );
-		$this->assertEquals( 1, count( $order->coupons ) );
+		Assert::assertEquals( 9.0, $total->get_float() );
+		Assert::assertEquals( 1, count( $order->items ) );
+		Assert::assertEquals( 1, count( $order->coupons ) );
 
 		$order_2 = $this->create_order(
 			[
@@ -103,8 +108,112 @@ class Coupons_Test extends Controller_Test_Case {
 		/** @var Value $total */
 		$total = $order_2->total_value;
 
-		$this->assertEquals( 8.0, $total->get_float() );
-		$this->assertEquals( 1, count( $order_2->items ) );
-		$this->assertEquals( 1, count( $order_2->coupons ) );
+		Assert::assertEquals( 8.0, $total->get_float() );
+		Assert::assertEquals( 1, count( $order_2->items ) );
+		Assert::assertEquals( 1, count( $order_2->coupons ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_calculate_fees_and_store_them_correctly_simple_math() {
+		$post        = static::factory()->post->create( [ 'post_title' => 'The Coupon Event' ] );
+		$ticket_id_1 = $this->create_tc_ticket( $post, 10 );
+		$ticket_id_2 = $this->create_tc_ticket( $post, 20 );
+		$ticket_id_3 = $this->create_tc_ticket( $post, 30 );
+		$ticket_id_4 = $this->create_tc_ticket( $post, 40 );
+		$ticket_id_5 = $this->create_tc_ticket( $post, 50 );
+
+		// 10% off coupon.
+		$coupon_1 = $this->create_coupon(
+			[
+				'raw_amount' => 10,
+				'sub_type'   => 'percent',
+			]
+		);
+
+		// $3 off coupon.
+		$coupon_2 = $this->create_coupon(
+			[
+				'raw_amount' => 3,
+				'sub_type'   => 'flat',
+			]
+		);
+
+		// Basic checks to ensure the coupon is calculating values correctly.
+		Assert::assertEquals( -9.0, $coupon_1->get_discount_amount( 90 ), '10% of 90 should be 9' );
+		Assert::assertEquals( -80.0, $coupon_1->get_discount_amount( 800 ), '10% of 800 should be 80' );
+
+		Assert::assertEquals( -3.0, $coupon_2->get_discount_amount( 90 ), '3 off 90 should be 3' );
+		Assert::assertEquals( -3.0, $coupon_2->get_discount_amount( 800 ), '3 off 800 should be 3' );
+
+		// Register the controller.
+		$this->make_controller()->register();
+
+		// Get the cart and start adding tickets.
+		/** @var Commerce_Cart $cart */
+		$cart = tribe( Commerce_Cart::class );
+		$cart->add_ticket( $ticket_id_1, 2 );
+		$cart->add_ticket( $ticket_id_2, 3 );
+		$cart->add_ticket( $ticket_id_3, 4 );
+		$cart->add_ticket( $ticket_id_4, 5 );
+		$cart->add_ticket( $ticket_id_5, 6 );
+
+		// Grab the total and subtotal.
+		$cart_subtotal = $cart->get_cart_subtotal();
+		$cart_total    = $cart->get_cart_total();
+
+		// With only tickets in the cart and no coupons applied, the total and subtotal should be the same.
+		Assert::assertEquals( $cart_subtotal, $cart_total );
+
+		// Cart subtotal should be (10 * 2) + (20 * 3) + (30 * 4) + (40 * 5) + (50 * 6) = 20 + 60 + 120 + 200 + 300 = 700.
+		Assert::assertEquals( 700.0, $cart_subtotal );
+
+		$order1 = $this->create_order_from_cart( $cart );
+
+		// Validate that the order has the correct amounts.
+		Assert::assertCount( 5, $order1->items, 'Order should have 5 different tickets' );
+		Assert::assertObjectHasAttribute( 'coupons', $order1, 'Order object should have coupons property' );
+		Assert::assertCount( 0, $order1->coupons, 'Coupons should be empty when no coupons added' );
+		Assert::assertEquals( 700.0, $order1->subtotal->get_float() );
+		Assert::assertEquals( 700.0, $order1->total_value->get_float() );
+
+		// Let's add a coupon and create a new order.
+		$coupon_1->add_to_cart( $cart->get_repository() );
+
+		// Grab the total and subtotal.
+		$cart_subtotal = $cart->get_cart_subtotal();
+		$cart_total    = $cart->get_cart_total();
+
+		// Cart subtotal should be (10 * 2) + (20 * 3) + (30 * 4) + (40 * 5) + (50 * 6) = 20 + 60 + 120 + 200 + 300 = 700.
+		Assert::assertEquals( 700.0, $cart_subtotal );
+
+		// Cart total should be 700 - 10% = 700 - 70 = 630.
+		Assert::assertEquals( 630.0, $cart_total );
+
+		$order2 = $this->create_order_from_cart( $cart );
+
+		// Validate that the order has the correct amounts.
+		Assert::assertCount( 5, $order2->items, 'Order should have 5 different tickets' );
+		Assert::assertObjectHasAttribute( 'coupons', $order2, 'Order object should have coupons property' );
+		Assert::assertCount( 1, $order2->coupons, 'Coupons should have 1 coupon' );
+		Assert::assertEquals( 700.0, $order2->subtotal->get_float() );
+		Assert::assertEquals( 630.0, $order2->total_value->get_float(), 'Order should be discounted by 10% ($70)' );
+
+		// Inspect the cart HTML to ensure the coupon is displayed.
+		$this->set_fn_return( 'wp_create_nonce', esc_attr( __METHOD__ ) );
+		$this->assertMatchesHtmlSnapshot(
+			ltrim(
+				preg_replace(
+					'#<link rel=(.*)/>#',
+					'',
+					str_replace(
+						[ $post, $ticket_id_1, $ticket_id_2, $ticket_id_3, $ticket_id_4, $ticket_id_5, $coupon_1->id ],
+						[ '{POST_ID}', '{TICKET_ID_1}', '{TICKET_ID_2}', '{TICKET_ID_3}', '{TICKET_ID_4}', '{TICKET_ID_5}', '{COUPON_ID_1}' ],
+						tribe( Checkout_Shortcode::class )->get_html()
+					)
+				)
+			)
+		);
 	}
 }

--- a/tests/order_modifiers_integration/Checkout/Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Fees_Test.php
@@ -1022,4 +1022,18 @@ class Fees_Test extends Controller_Test_Case {
 	public function reset_fees() {
 		$this->test_services->get( PayPalFees::class )->reset_fees_and_subtotal();
 	}
+
+	/**
+	 * @before
+	 */
+	public function replace_image_path() {
+		$this->set_fn_return(
+			'tribe_resource_url',
+			function ( $path ) {
+				$path = ltrim( $path, '/' );
+				return "https://example.com/{$path}";
+			},
+			true
+		);
+	}
 }

--- a/tests/order_modifiers_integration/Checkout/Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Fees_Test.php
@@ -24,6 +24,7 @@ use Tribe\Tickets\Test\Traits\With_No_Object_Storage;
 use Tribe\Tickets\Test\Traits\With_Test_Orders;
 use Tribe\Tickets\Test\Traits\With_Tickets_Commerce;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+use Tribe\Tests\Tickets\Traits\Tribe_URL;
 
 class Fees_Test extends Controller_Test_Case {
 
@@ -34,6 +35,7 @@ class Fees_Test extends Controller_Test_Case {
 	use Series_Pass_Factory;
 	use SnapshotAssertions;
 	use Ticket_Maker;
+	use Tribe_URL;
 	use With_No_Object_Storage;
 	use With_Test_Orders;
 	use With_Tickets_Commerce;
@@ -1021,19 +1023,5 @@ class Fees_Test extends Controller_Test_Case {
 	 */
 	public function reset_fees() {
 		$this->test_services->get( PayPalFees::class )->reset_fees_and_subtotal();
-	}
-
-	/**
-	 * @before
-	 */
-	public function replace_image_path() {
-		$this->set_fn_return(
-			'tribe_resource_url',
-			function ( $path ) {
-				$path = ltrim( $path, '/' );
-				return "https://example.com/{$path}";
-			},
-			true
-		);
 	}
 }

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
@@ -2,7 +2,7 @@
 	<section
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
-		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="TEC\Tickets\Tests\Order_Modifiers_Integration\Checkout\Coupons_Test::it_should_calculate_fees_and_store_them_correctly_simple_math" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
+		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="TEC\Tickets\Tests\Order_Modifiers_Integration\Checkout\Coupons_Test::it_should_calculate_coupons_simple_math" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
 	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
 	Purchase Tickets</h3>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -305,7 +305,7 @@
 						test-coupon-4					</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/the-events-calendar/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>
@@ -337,7 +337,8 @@
 </div>
 				<div class="tribe-tickets__form tribe-tickets__commerce-checkout-purchaser-info-wrapper tribe-common-b2">
 	<h4 class="tribe-common-h5 tribe-tickets__commerce-checkout-purchaser-info-title">Purchaser info</h4>
-	<div class="tribe-tickets__commerce-checkout-purchaser-info-field tribe-tickets__form-field tribe-tickets__form-field--text">
+	<form class="tribe-tickets__commerce-checkout-purchaser-info-wrapper__form">
+		<div class="tribe-tickets__commerce-checkout-purchaser-info-field tribe-tickets__form-field tribe-tickets__form-field--text">
 	<label for="tec-tc-purchaser-name"  class="tribe-tickets__form-field-label tribe-tickets__commerce-checkout-purchaser-info-name-field-label" >
 		Person purchasing tickets:	</label>
 	<div class="tribe-tickets__form-field-input-wrapper">
@@ -348,12 +349,12 @@
 			autocomplete="off"
 			placeholder="First and last name"
 			 class="tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-name tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your first and last names are required		</div>
 	</div>
 </div>
-	<div class="tribe-tickets__commerce-checkout-purchaser-info-field tribe-tickets__form-field tribe-tickets__form-field--email">
+		<div class="tribe-tickets__commerce-checkout-purchaser-info-field tribe-tickets__form-field tribe-tickets__form-field--email">
 	<label for="tec-tc-purchaser-email"  class="tribe-tickets__form-field-label tribe-tickets__commerce-checkout-purchaser-info-email-field-label" >
 		Email address	</label>
 
@@ -364,14 +365,15 @@
 			name="purchaser-email"
 			autocomplete="off"
 			 class="tribe-common-b2 tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-email tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your email address is required		</div>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description">
 			Your tickets will be sent to this email address		</div>
 	</div>
 </div>
-	</div>
+			</form>
+</div>
 				<footer class="tribe-tickets__commerce-checkout-footer">
 	<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-footer-notice-error--no-gateway" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Unavailable!</h3>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -1,0 +1,384 @@
+<div class="tribe-common event-tickets">
+	<section
+		class="tribe-tickets__commerce-checkout"
+		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
+		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="TEC\Tickets\Tests\Order_Modifiers_Integration\Checkout\Coupons_Test::it_should_calculate_fees_and_store_them_correctly_simple_math" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
+	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h3>
+	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
+	
+<a
+	class="tribe-common-anchor-alt tribe-tickets__commerce-checkout-header-link-back-to-event"
+	href="http://wordpress.test/?p={POST_ID}"
+>back to event</a>
+</div>
+</header>
+					
+<div class="tribe-tickets__commerce-checkout-cart">
+
+	<header class="tribe-tickets__commerce-checkout-cart-header">
+	<h4 class="tribe-common-h4 tribe-common-h--alt tribe-tickets__commerce-checkout-cart-header-title">
+		<a href="http://wordpress.test/?p={POST_ID}">
+			The Coupon Event		</a>
+	</h4>
+</header>
+
+	<div class="tribe-tickets__commerce-checkout-cart-items">
+	<article
+	 class="tribe-tickets__commerce-checkout-cart-item post-{TICKET_ID_1} tec_tc_ticket type-tec_tc_ticket status-publish hentry tribe-common-b1" 	 data-ticket-id="{TICKET_ID_1}" data-ticket-quantity="2" data-ticket-price="10.00" >
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	Test TC ticket for {POST_ID}</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_1}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Open the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			More info		</span>
+	</button>
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--less"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_1}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Close the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			Less info		</span>
+	</button>
+</div>
+
+	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_1}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+	Test TC ticket description for {POST_ID}
+	</div>
+
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-price">
+	
+<span class="tec-tickets-price amount">
+	&#x24;10.00</span>
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-quantity">
+	2</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-subtotal">
+	&#x24;20.00</div>
+
+</article>
+<article
+	 class="tribe-tickets__commerce-checkout-cart-item post-{TICKET_ID_2} tec_tc_ticket type-tec_tc_ticket status-publish hentry tribe-common-b1" 	 data-ticket-id="{TICKET_ID_2}" data-ticket-quantity="3" data-ticket-price="20.00" >
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	Test TC ticket for {POST_ID}</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_2}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Open the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			More info		</span>
+	</button>
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--less"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_2}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Close the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			Less info		</span>
+	</button>
+</div>
+
+	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_2}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+	Test TC ticket description for {POST_ID}
+	</div>
+
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-price">
+	
+<span class="tec-tickets-price amount">
+	&#x24;20.00</span>
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-quantity">
+	3</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-subtotal">
+	&#x24;60.00</div>
+
+</article>
+<article
+	 class="tribe-tickets__commerce-checkout-cart-item post-{TICKET_ID_3} tec_tc_ticket type-tec_tc_ticket status-publish hentry tribe-common-b1" 	 data-ticket-id="{TICKET_ID_3}" data-ticket-quantity="4" data-ticket-price="30.00" >
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	Test TC ticket for {POST_ID}</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_3}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Open the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			More info		</span>
+	</button>
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--less"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_3}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Close the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			Less info		</span>
+	</button>
+</div>
+
+	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_3}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+	Test TC ticket description for {POST_ID}
+	</div>
+
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-price">
+	
+<span class="tec-tickets-price amount">
+	&#x24;30.00</span>
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-quantity">
+	4</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-subtotal">
+	&#x24;120.00</div>
+
+</article>
+<article
+	 class="tribe-tickets__commerce-checkout-cart-item post-{TICKET_ID_4} tec_tc_ticket type-tec_tc_ticket status-publish hentry tribe-common-b1" 	 data-ticket-id="{TICKET_ID_4}" data-ticket-quantity="5" data-ticket-price="40.00" >
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	Test TC ticket for {POST_ID}</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_4}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Open the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			More info		</span>
+	</button>
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--less"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_4}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Close the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			Less info		</span>
+	</button>
+</div>
+
+	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_4}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+	Test TC ticket description for {POST_ID}
+	</div>
+
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-price">
+	
+<span class="tec-tickets-price amount">
+	&#x24;40.00</span>
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-quantity">
+	5</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-subtotal">
+	&#x24;200.00</div>
+
+</article>
+<article
+	 class="tribe-tickets__commerce-checkout-cart-item post-{TICKET_ID_5} tec_tc_ticket type-tec_tc_ticket status-publish hentry tribe-common-b1" 	 data-ticket-id="{TICKET_ID_5}" data-ticket-quantity="6" data-ticket-price="50.00" >
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	Test TC ticket for {POST_ID}</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_5}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Open the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			More info		</span>
+	</button>
+	<button
+		type="button"
+		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--less"
+		aria-controls="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_5}"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">
+			Close the ticket description in checkout.		</span>
+		<span class="tribe-tickets__commerce-checkout-cart-item-details-button-text">
+			Less info		</span>
+	</button>
+</div>
+
+	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{TICKET_ID_5}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+	Test TC ticket description for {POST_ID}
+	</div>
+
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-price">
+	
+<span class="tec-tickets-price amount">
+	&#x24;50.00</span>
+</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-quantity">
+	6</div>
+
+	<div class="tribe-tickets__commerce-checkout-cart-item-subtotal">
+	&#x24;300.00</div>
+
+</article>
+</div>
+
+	
+<footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
+	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+		<input
+			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			type="text"
+			id="coupon_input"
+			name="coupons"
+			aria-describedby="coupon_error"
+			aria-label="Enter coupon code"
+			placeholder="Enter coupon code"
+			value="test-coupon-4"
+		/>
+		<button
+			id="coupon_apply"
+			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+			Apply		</button>
+	</div>
+	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+		Invalid coupon code	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied" >
+		<ul>
+			<li>
+				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
+					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+						test-coupon-4					</span>
+					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+						<img
+							src="http://wordpress.test/wp-content/plugins/the-events-calendar/common/src/resources/images/icons/close.svg"
+							alt="Close icon"
+							title="Remove coupon"
+						>
+					</button>
+				</span>
+				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+					- &#x24;70.00				</span>
+			</li>
+		</ul>
+	</div>
+</div>
+<div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
+	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">21</span></div>
+<div class="tribe-tickets__commerce-checkout-cart-footer-total">
+	<span class="tribe-tickets__commerce-checkout-cart-footer-total-label">Total: </span><span class="tribe-tickets__commerce-checkout-cart-footer-total-wrap">&#x24;630.00</span></div>
+</footer>
+
+</div>
+				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
+	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+</div>
+		<div id=""  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
+			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
+	
+	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
+		Something went wrong!	</div>
+</div>
+				<div class="tribe-tickets__form tribe-tickets__commerce-checkout-purchaser-info-wrapper tribe-common-b2">
+	<h4 class="tribe-common-h5 tribe-tickets__commerce-checkout-purchaser-info-title">Purchaser info</h4>
+	<div class="tribe-tickets__commerce-checkout-purchaser-info-field tribe-tickets__form-field tribe-tickets__form-field--text">
+	<label for="tec-tc-purchaser-name"  class="tribe-tickets__form-field-label tribe-tickets__commerce-checkout-purchaser-info-name-field-label" >
+		Person purchasing tickets:	</label>
+	<div class="tribe-tickets__form-field-input-wrapper">
+		<input
+			type="text"
+			id="tec-tc-purchaser-name"
+			name="purchaser-name"
+			autocomplete="off"
+			placeholder="First and last name"
+			 class="tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-name tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
+		/>
+		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
+			Your first and last names are required		</div>
+	</div>
+</div>
+	<div class="tribe-tickets__commerce-checkout-purchaser-info-field tribe-tickets__form-field tribe-tickets__form-field--email">
+	<label for="tec-tc-purchaser-email"  class="tribe-tickets__form-field-label tribe-tickets__commerce-checkout-purchaser-info-email-field-label" >
+		Email address	</label>
+
+	<div class="tribe-tickets__form-field-input-wrapper">
+		<input
+			type="email"
+			id="tec-tc-purchaser-email"
+			name="purchaser-email"
+			autocomplete="off"
+			 class="tribe-common-b2 tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-email tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
+		/>
+		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
+			Your email address is required		</div>
+		<div class="tribe-common-b3 tribe-tickets__form-field-description">
+			Your tickets will be sent to this email address		</div>
+	</div>
+</div>
+	</div>
+				<footer class="tribe-tickets__commerce-checkout-footer">
+	<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-footer-notice-error--no-gateway" >
+			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Unavailable!</h3>
+	
+	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
+		Checkout is not available at this time because a payment method has not been set up. Please notify the site administrator.	</div>
+</div>
+</footer>
+			</section>
+</div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -307,7 +307,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -305,7 +305,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -307,7 +307,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -305,7 +305,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -107,7 +107,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -105,7 +105,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -107,7 +107,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -105,7 +105,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -107,7 +107,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -105,7 +105,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -107,7 +107,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -105,7 +105,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
@@ -266,7 +266,7 @@
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
 							alt="Close icon"
-							title="Remove ticket"
+							title="Remove coupon"
 						>
 					</button>
 				</span>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
@@ -264,7 +264,7 @@
 											</span>
 					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
 						<img
-							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
+							src="https://example.com/images/icons/close.svg"
 							alt="Close icon"
 							title="Remove coupon"
 						>

--- a/tests/wpunit/TEC/Tickets/Order_Modifiers/Values/Currency_Value_Test.php
+++ b/tests/wpunit/TEC/Tickets/Order_Modifiers/Values/Currency_Value_Test.php
@@ -39,4 +39,41 @@ class Currency_Value_Test extends WPTestCase {
 		$this->assertEquals( '$1,000.00', $currency_value->get() );
 		$this->assertEquals( '$1,000.00', (string) $currency_value );
 	}
+
+	/**
+	 * @test
+	 * @dataProvider format_values_data_provider
+	 */
+	public function it_should_properly_format_values( array $constructor_args, string $expected ) {
+		$currency_value = Currency_Value::create( ...$constructor_args );
+		$this->assertEquals( $expected, $currency_value->get() );
+		$this->assertEquals( $expected, (string) $currency_value );
+	}
+
+	public function format_values_data_provider() {
+		yield 'default values' => [
+			[ new Precision_Value( 100 ) ],
+			'$100.00',
+		];
+
+		yield 'custom values' => [
+			[ new Precision_Value( 100 ), '€', '.', ',', 'before' ],
+			'€100,00',
+		];
+
+		yield 'custom values with different thousands' => [
+			[ new Precision_Value( 1000 ), '€', '.', ',', 'after' ],
+			'1.000,00€',
+		];
+
+		yield 'negative value' => [
+			[ new Precision_Value( -100 ) ],
+			'- $100.00',
+		];
+
+		yield 'value with different precision' => [
+			[ new Precision_Value( 100, 0 ), '¢', null, null, 'after' ],
+			'100¢',
+		];
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

QA Issue spreadsheet – Item `#003`

### 🗒️ Description

This PR adjusts the display of the coupon discount so that the negative sign is separate from the number. For currencies with the symbol before the number, this means that the `-` sign will be output before the currency symbol instead of after it.

As part of this PR, I took the opportunity to add some enhancements to the `Currency_Value` class and the `Legacy_Value_Factory` class.

#### Updates

After some flaws in the coupon calculations were pointed out, I added the following changes:

1. I updated the cart to calculate coupons (and any other dynamic items) within the `get_cart_total()` method. These were previously being done in the `get_cart_subtotal()` method. The flaw in logic was that the amount generated from the `get_cart_subtotal()` calculation was used to determine the value that the coupon displayed, so it was essentially being calculated twice.
2. I added a method to the `Models/Coupon` class to add/remove itself to/from the cart, given a `$cart` object to work with. This ensures consistency in generating a unique ID to ensure there isn't any conflict with any other item IDs.
3. I updated the `Precision_Value::create()` method to allow for passing custom symbols when it is used. Previously, the *only* option was to use the default values.
4. I added a method `to_currency_value()` to the `Legacy_Value_Factory` class.
5. I enhanced the unit tests and included additional tests for the Coupons REST API. I also added more calculation testing based on the coupons being added to the cart (Fun side note: I let AI generate some of the testing data, and I had to go back and correct some of the numbers it came up with. Turns out AI might not know how to handle floats and rounding as well as we do!).

### 🎥 Artifacts <!-- if applicable-->

**Before:**

![Screenshot 2025-02-27 at 16 19 25](https://github.com/user-attachments/assets/e75093a0-bb5f-4312-8741-ae8e64b4f8fc)

**After (old – wrong calculations):**
![Screenshot 2025-02-27 at 16 20 40](https://github.com/user-attachments/assets/c858b3ef-be17-4a45-970d-bb052d1c6bf8)

**After (NEW – correct calculations):**

<img width="651" alt="Screenshot 2025-03-05 at 12 10 32" src="https://github.com/user-attachments/assets/172ed419-b1e9-47d4-b596-38a854980de3" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
