### PR TITLE
Use "Add coupon code" button before showing coupon input

### DIFF
--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -55,16 +55,16 @@ tribe.tickets.commerce = {};
 		purchaserEmail: '.tribe-tickets__commerce-checkout-purchaser-info-form-field-email',
 
 		// Coupon related selectors.
-		couponAddLink: '.tec-tickets__commerce-checkout-cart-coupons__add-coupon-link',
-		couponAppliedDiscount: '.tec-tickets__commerce-checkout-cart-coupons__applied-discount',
-		couponAppliedLabel: '.tec-tickets__commerce-checkout-cart-coupons__applied-label',
-		couponAppliedSection: '.tec-tickets__commerce-checkout-cart-coupons__applied',
-		couponApplyButton: '#coupon_apply',
-		couponError: '.tec-tickets__commerce-checkout-cart-coupons__error',
-		couponInput: '#coupon_input',
-		couponInputContainer: '.tec-tickets__commerce-checkout-cart-coupons',
+		couponAddLink: '.tec-tickets-commerce-checkout-cart__coupons-add-link',
+		couponAppliedDiscount: '.tec-tickets-commerce-checkout-cart__coupons-discount-amount',
+		couponAppliedLabel: '.tec-tickets-commerce-checkout-cart__coupons-applied-label',
+		couponAppliedSection: '.tec-tickets-commerce-checkout-cart__coupons-applied-container',
+		couponApplyButton: '.tec-tickets-commerce-checkout-cart__coupons-apply-button',
+		couponError: '.tec-tickets-commerce-checkout-cart__coupons-input-error',
+		couponInput: '.tec-tickets-commerce-checkout-cart__coupons-input-field',
+		couponInputContainer: '.tec-tickets-commerce-checkout-cart__coupons-input-container',
 		couponInputErrorClass: 'tribe-tickets__form-field-input--error',
-		couponRemoveButton: '.tec-tickets__commerce-checkout-cart-coupons__remove-button',
+		couponRemoveButton: '.tec-tickets-commerce-checkout-cart__coupons-remove-button',
 	};
 
 	/**
@@ -280,7 +280,7 @@ tribe.tickets.commerce = {};
 
 	obj.bindAddCouponLink = function() {
 		const hiddenName = obj.selectors.hiddenElement.className();
-		$document.on( 'click', `${ obj.selectors.couponAddLink } > button`, function() {
+		$document.on( 'click', obj.selectors.couponAddLink, function() {
 			$( obj.selectors.couponAddLink ).addClass( hiddenName );
 			$( obj.selectors.couponInputContainer ).removeClass( hiddenName );
 		} );
@@ -308,18 +308,20 @@ tribe.tickets.commerce = {};
 				return;
 			}
 
-			const $inputContainer = $( obj.selectors.couponInputContainer );
 			const $couponInput = $( obj.selectors.couponInput );
 			const couponValue = $couponInput.val().trim();
-			const nonce = $( obj.selectors.nonce ).val();
 			const $errorMessage = $( obj.selectors.couponError );
+			const hiddenName = obj.selectors.hiddenElement.className();
+			const $inputContainer = $( obj.selectors.couponInputContainer );
+			const nonce = $( obj.selectors.nonce ).val();
 
 			// Hide the error message initially.
-			$errorMessage.hide();
+			$errorMessage.addClass( hiddenName );
 
 			// Ensure the coupon is not empty.
 			if ( ! couponValue ) {
-				$errorMessage.text( tecTicketsCommerce.i18n.couponCodeEmpty ).show();
+				$errorMessage.text( tecTicketsCommerce.i18n.couponCodeEmpty );
+				$errorMessage.removeClass( hiddenName );
 				$couponInput.addClass( obj.selectors.couponInputErrorClass );
 				return;
 			}
@@ -333,7 +335,7 @@ tribe.tickets.commerce = {};
 			const requestData = {
 				coupon: couponValue,
 				nonce: nonce,
-				payment_intent_id: window.tecTicketsCommerceGatewayStripeCheckout.paymentIntentData.id,
+				payment_intent_id: window.tecTicketsCommerceGatewayStripeCheckout.paymentIntentData.id || '',
 				purchaser_data: obj.getPurchaserData( $( obj.selectors.purchaserFormContainer ) ),
 				cart_hash: cartHash[ 1 ],
 			};
@@ -346,24 +348,27 @@ tribe.tickets.commerce = {};
 					if ( response.success ) {
 						// Hide input and button, show applied coupon.
 						$couponInput.removeClass( obj.selectors.couponInputErrorClass );
-						$inputContainer.addClass( obj.selectors.hiddenElement.className() );
+						$inputContainer.addClass( hiddenName );
 
 						// Display coupon value and discount.
 						obj.updateCouponDiscount( response.discount );
 						obj.updateCouponLabel( response.label );
 						obj.updateTotalPrice( response.cart_amount );
-						$( obj.selectors.couponAppliedSection )
-							.removeClass( obj.selectors.hiddenElement.className() );
+						$( obj.selectors.couponAppliedSection ).removeClass( hiddenName );
 					} else {
-						$errorMessage.text( response.message || tecTicketsCommerce.i18n.invalidCoupon ).show();
+						$errorMessage
+							.text( response.message || tecTicketsCommerce.i18n.invalidCoupon )
+							.removeClass( hiddenName );
 						$couponInput.addClass( obj.selectors.couponInputErrorClass );
-						$inputContainer.removeClass( obj.selectors.hiddenElement.className() );
+						$inputContainer.removeClass( hiddenName );
 					}
 				},
 				error() {
-					$errorMessage.text( tecTicketsCommerce.i18n.couponApplyError ).show();
+					$errorMessage
+						.text( tecTicketsCommerce.i18n.couponApplyError )
+						.removeClass( hiddenName );
 					$couponInput.addClass( obj.selectors.couponInputErrorClass );
-					$inputContainer.removeClass( obj.selectors.hiddenElement.className() );
+					$inputContainer.removeClass( hiddenName );
 				},
 				complete() {
 					obj.loaderHide();
@@ -388,15 +393,18 @@ tribe.tickets.commerce = {};
 			}
 
 			const couponValue = $( obj.selectors.couponInput ).val().trim();
-			const nonce = $( obj.selectors.nonce ).val();
 			const $errorMessage = $( obj.selectors.couponError );
+			const hiddenName = obj.selectors.hiddenElement.className();
+			const nonce = $( obj.selectors.nonce ).val();
 
 			// Hide the error message initially.
-			$errorMessage.hide();
+			$errorMessage.addClass( hiddenName );
 
 			// Ensure the coupon is not empty.
 			if ( ! couponValue ) {
-				$errorMessage.text( tecTicketsCommerce.i18n.cantDetermineCoupon ).show();
+				$errorMessage
+					.text( tecTicketsCommerce.i18n.cantDetermineCoupon )
+					.removeClass( hiddenName );
 				return;
 			}
 
@@ -423,22 +431,22 @@ tribe.tickets.commerce = {};
 				success( response ) {
 					if ( response.success ) {
 						// Show input and apply button again.
-						$( obj.selectors.couponAddLink ).removeClass( obj.selectors.hiddenElement.className() );
+						$( obj.selectors.couponAddLink ).removeClass( hiddenName );
 						$( obj.selectors.couponInput ).val( '' );
 
 						// Hide the applied coupon section.
-						$( obj.selectors.couponAppliedSection ).addClass(
-							obj.selectors.hiddenElement.className(),
-						);
+						$( obj.selectors.couponAppliedSection ).addClass( hiddenName );
 						obj.updateTotalPrice( response.cart_amount );
 					} else {
 						$errorMessage
 							.text( response.message || tecTicketsCommerce.i18n.couponRemoveFail )
-							.show();
+							.removeClass( hiddenName );
 					}
 				},
 				error() {
-					$errorMessage.text( tecTicketsCommerce.i18n.couponRemoveError ).show();
+					$errorMessage
+						.text( tecTicketsCommerce.i18n.couponRemoveError )
+						.removeClass( hiddenName );
 				},
 				complete() {
 					obj.loaderHide();

--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -55,6 +55,7 @@ tribe.tickets.commerce = {};
 		purchaserEmail: '.tribe-tickets__commerce-checkout-purchaser-info-form-field-email',
 
 		// Coupon related selectors.
+		couponAddLink: '.tec-tickets__commerce-checkout-cart-coupons__add-coupon-link',
 		couponAppliedDiscount: '.tec-tickets__commerce-checkout-cart-coupons__applied-discount',
 		couponAppliedLabel: '.tec-tickets__commerce-checkout-cart-coupons__applied-label',
 		couponAppliedSection: '.tec-tickets__commerce-checkout-cart-coupons__applied',
@@ -173,10 +174,9 @@ tribe.tickets.commerce = {};
 	obj.bindCheckoutEvents = function( $container ) {
 		$document.trigger( 'beforeSetup.tecTicketsCommerce', [ $container ] );
 
-		// Bind coupon apply event.
+		// Bind coupon events.
+		obj.bindAddCouponLink();
 		obj.bindCouponApply();
-
-		// Bind coupon remove event.
 		obj.bindCouponRemove();
 
 		// Bind container based events.
@@ -276,6 +276,14 @@ tribe.tickets.commerce = {};
 		).body.textContent;
 
 		$couponLabelElement.text( unescapedLabel );
+	};
+
+	obj.bindAddCouponLink = function() {
+		const hiddenName = obj.selectors.hiddenElement.className();
+		$document.on( 'click', `${ obj.selectors.couponAddLink } > button`, function() {
+			$( obj.selectors.couponAddLink ).addClass( hiddenName );
+			$( obj.selectors.couponInputContainer ).removeClass( hiddenName );
+		} );
 	};
 
 	obj.bindCouponApply = function() {
@@ -379,7 +387,6 @@ tribe.tickets.commerce = {};
 				return;
 			}
 
-			const $inputContainer = $( obj.selectors.couponInputContainer );
 			const couponValue = $( obj.selectors.couponInput ).val().trim();
 			const nonce = $( obj.selectors.nonce ).val();
 			const $errorMessage = $( obj.selectors.couponError );
@@ -416,7 +423,7 @@ tribe.tickets.commerce = {};
 				success( response ) {
 					if ( response.success ) {
 						// Show input and apply button again.
-						$inputContainer.removeClass( obj.selectors.hiddenElement.className() );
+						$( obj.selectors.couponAddLink ).removeClass( obj.selectors.hiddenElement.className() );
 						$( obj.selectors.couponInput ).val( '' );
 
 						// Hide the applied coupon section.

--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -314,6 +314,7 @@ tribe.tickets.commerce = {};
 			const hiddenName = obj.selectors.hiddenElement.className();
 			const $inputContainer = $( obj.selectors.couponInputContainer );
 			const nonce = $( obj.selectors.nonce ).val();
+			const intentId = window.tecTicketsCommerceGatewayStripeCheckout.paymentIntentData.id || '';
 
 			// Hide the error message initially.
 			$errorMessage.addClass( hiddenName );
@@ -335,7 +336,7 @@ tribe.tickets.commerce = {};
 			const requestData = {
 				coupon: couponValue,
 				nonce: nonce,
-				payment_intent_id: window.tecTicketsCommerceGatewayStripeCheckout.paymentIntentData.id || '',
+				payment_intent_id: intentId,
 				purchaser_data: obj.getPurchaserData( $( obj.selectors.purchaserFormContainer ) ),
 				cart_hash: cartHash[ 1 ],
 			};

--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -163,7 +163,7 @@
 			.tec-tickets-price__regular-price {
 				color: var(--tec-color-text-secondary);
 				font-size: var(--tec-font-size-2);
-				font-weight: var(--tec-font-weight-normal);
+				font-weight: var(--tec-font-weight-regular);
 				text-decoration: line-through;
 			}
 

--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -423,7 +423,6 @@
 			padding: 6px 0 6px var(--tec-spacer-2);
 			width: auto;
 
-
 			&:focus,
 			&:hover {
 				background-color: var(--tec-color-background);

--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -399,6 +399,12 @@
 	.tec-tickets__commerce-checkout-coupons-wrapper {
 		text-align: right;
 
+		.tec-tickets__commerce-checkout-cart-coupons__add-coupon-link {
+			color: var(--tec-color-accent-primary);
+			font-size: var(--tec-font-size-2);
+			padding-bottom: var(--tec-spacer-1);
+		}
+
 		.tec-tickets__commerce-checkout-cart-coupons__input {
 			border: 1px solid var(--tec-color-border-default);
 			border-radius: var(--tec-border-radius-default);

--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -210,7 +210,7 @@
 	}
 
 	.tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees,
-	.tec-tickets__commerce-checkout-cart-coupons {
+	.tec-tickets-commerce-checkout-cart__coupons-input-container {
 		text-align: right;
 	}
 
@@ -396,44 +396,49 @@
 		}
 	}
 
-	.tec-tickets__commerce-checkout-coupons-wrapper {
+	.tec-tickets-commerce-checkout-cart__coupons {
 		text-align: right;
 
-		.tec-tickets__commerce-checkout-cart-coupons__add-coupon-link {
+		.tec-tickets-commerce-checkout-cart__coupons-input-error {
+			color: red;
+		}
+
+		.tec-tickets-commerce-checkout-cart__coupons-add-link {
 			color: var(--tec-color-accent-primary);
 			font-size: var(--tec-font-size-2);
 			padding-bottom: var(--tec-spacer-1);
 		}
 
-		.tec-tickets__commerce-checkout-cart-coupons__input {
+		.tec-tickets-commerce-checkout-cart__coupons-input-field {
 			border: 1px solid var(--tec-color-border-default);
 			border-radius: var(--tec-border-radius-default);
 			padding: var(--tec-spacer-1) var(--tec-spacer-3);
 			width: auto;
 		}
 
-		.tec-tickets__commerce-checkout-cart-coupons__apply-button {
+		.tec-tickets-commerce-checkout-cart__coupons-apply-button {
 			border: 0;
 			border-radius: var(--tec-border-radius-default);
-			color: var(--tec-color-background);
-			padding: 6px var(--tec-spacer-2);
+			font-weight: var(--tec-font-weight-regular);
+			padding: 6px 0 6px var(--tec-spacer-2);
 			width: auto;
 
-			&:active,
+
 			&:focus,
 			&:hover {
-				padding: 6px var(--tec-spacer-2);
+				background-color: var(--tec-color-background);
+				color: var(--tec-color-button-primary);
 			}
 		}
 
-		.tec-tickets__commerce-checkout-cart-coupons__applied {
+		.tec-tickets-commerce-checkout-cart__coupons-applied-container {
 			font-size: var(--tec-font-size-3);
 
-			.tec-tickets__commerce-checkout-cart-coupons__applied-text {
+			.tec-tickets-commerce-checkout-cart__coupons-applied-text {
 				background-color: #eaecff;
-				border-radius: 6px;
+				border-radius: var(--tec-border-radius-default);
 				letter-spacing: 0.2px;
-				line-height: 26px;
+				line-height: var(--tec-line-height-3);
 				padding: var(--tec-spacer-1) var(--tec-spacer-2);
 			}
 
@@ -442,7 +447,7 @@
 			}
 		}
 
-		.tec-tickets__commerce-checkout-cart-coupons__remove-button {
+		.tec-tickets-commerce-checkout-cart__coupons-remove-button {
 			margin-left: var(--tec-spacer-2);
 
 			& img {

--- a/src/resources/postcss/tickets-forms.pcss
+++ b/src/resources/postcss/tickets-forms.pcss
@@ -121,7 +121,7 @@
 			box-shadow: none;
 		}
 
-		&.tec-tickets__commerce-checkout-cart-coupons__input {
+		&.tec-tickets-commerce-checkout-cart__coupons-input-field {
 			width: auto;
 		}
 

--- a/src/views/v2/commerce/checkout/order-modifiers/coupons.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/coupons.php
@@ -25,69 +25,69 @@ if ( isset( $coupon['sub_total'] ) && $coupon['sub_total'] instanceof Value ) {
 
 // Set up classes for all of the elements.
 $apply_button_classes = [
-	'tec-tickets__commerce-checkout-cart-coupons__apply-button',
-	'tribe-common-c-btn',
+	'tribe-common-c-btn-border',
+	'tec-tickets-commerce-checkout-cart__coupons-apply-button',
 ];
 
 $input_container_classes = [
-	'tec-tickets__commerce-checkout-cart-coupons',
+	'tec-tickets-commerce-checkout-cart__coupons-input-container',
 	'tribe-common-a11y-hidden',
 ];
 
 $add_coupon_link_classes = [
-	'tec-tickets__commerce-checkout-cart-coupons__add-coupon-link' => true,
-	'tribe-common-a11y-hidden'                                     => ! empty( $coupon ),
+	'tec-tickets-commerce-checkout-cart__coupons-add-link',
+	'tribe-common-a11y-hidden' => ! empty( $coupon ),
 ];
 
 $applied_container_classes = [
-	'tec-tickets__commerce-checkout-cart-coupons__applied' => true,
-	'tribe-common-a11y-hidden'                             => empty( $coupon ),
+	'tec-tickets-commerce-checkout-cart__coupons-applied-container',
+	'tribe-common-a11y-hidden' => empty( $coupon ),
 ];
 
 ?>
-<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p <?php tribe_classes( $add_coupon_link_classes ); ?>>
-		<button>
-			<?php esc_html_e( 'Add coupon code', 'event-tickets' ); ?>
-		</button>
-	</p>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button <?php tribe_classes( $add_coupon_link_classes ); ?>>
+		<?php esc_html_e( 'Add coupon code', 'event-tickets' ); ?>
+	</button>
 	<div <?php tribe_classes( $input_container_classes ); ?>>
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="<?php esc_attr_e( 'Enter coupon code', 'event-tickets' ); ?>"
 			placeholder="<?php esc_attr_e( 'Enter coupon code', 'event-tickets' ); ?>"
 			value="<?php echo esc_attr( $coupon['slug'] ?? '' ); ?>"
 		/>
-		<button
-			id="coupon_apply"
-			<?php tribe_classes( $apply_button_classes ); ?>
-		>
+		<button <?php tribe_classes( $apply_button_classes ); ?>>
 			<?php echo esc_html_x( 'Apply', 'button to apply a coupon code', 'event-tickets' ); ?>
 		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		<?php esc_html_e( 'Invalid coupon code', 'event-tickets' ); ?>
 	</p>
 	<div <?php tribe_classes( $applied_container_classes ); ?>>
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 						<?php echo esc_html( $coupon['slug'] ?? '' ); ?>
 					</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="<?php echo esc_url( tribe_resource_url( 'images/icons/close.svg', false, null, Tribe__Main::instance() ) ); ?>"
-							alt="<?php esc_attr_e( 'Close icon', 'event-tickets' ); ?>"
+							alt="<?php esc_attr_e( 'Icon to remove coupon', 'event-tickets' ); ?>"
 							title="<?php esc_attr_e( 'Remove coupon', 'event-tickets' ); ?>"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 					<?php echo esc_html( $discount ); ?>
 				</span>
 			</li>

--- a/src/views/v2/commerce/checkout/order-modifiers/coupons.php
+++ b/src/views/v2/commerce/checkout/order-modifiers/coupons.php
@@ -30,8 +30,13 @@ $apply_button_classes = [
 ];
 
 $input_container_classes = [
-	'tec-tickets__commerce-checkout-cart-coupons' => true,
-	'tribe-common-a11y-hidden'                    => ! empty( $coupon ),
+	'tec-tickets__commerce-checkout-cart-coupons',
+	'tribe-common-a11y-hidden',
+];
+
+$add_coupon_link_classes = [
+	'tec-tickets__commerce-checkout-cart-coupons__add-coupon-link' => true,
+	'tribe-common-a11y-hidden'                                     => ! empty( $coupon ),
 ];
 
 $applied_container_classes = [
@@ -41,6 +46,11 @@ $applied_container_classes = [
 
 ?>
 <div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
+	<p <?php tribe_classes( $add_coupon_link_classes ); ?>>
+		<button>
+			<?php esc_html_e( 'Add coupon code', 'event-tickets' ); ?>
+		</button>
+	</p>
 	<div <?php tribe_classes( $input_container_classes ); ?>>
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
@@ -1,43 +1,44 @@
 
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartFooterTest__test_should_render_cart__0.snapshot.html
@@ -1,7 +1,11 @@
 
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
@@ -14,7 +14,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/__snapshots__/CartTest__test_should_render_cart__0.snapshot.html
@@ -13,44 +13,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
@@ -78,44 +78,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
@@ -79,7 +79,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -98,44 +98,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -99,7 +99,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
@@ -6,14 +6,14 @@
 	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
 	Purchase Tickets</h3>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
-
+	
 <a
 	class="tribe-common-anchor-alt tribe-tickets__commerce-checkout-header-link-back-to-event"
 	href="http://wordpress.test/?post_type=tribe_events&#038;p={{ID}}"
 >back to event</a>
 </div>
 </header>
-
+					
 <div class="tribe-tickets__commerce-checkout-cart">
 
 	<header class="tribe-tickets__commerce-checkout-cart-header">
@@ -62,7 +62,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;10.00</span>
 </div>
@@ -112,7 +112,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;20.00</span>
 </div>
@@ -126,10 +126,14 @@
 </article>
 </div>
 
-
+	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"
@@ -181,7 +185,7 @@
 </div>
 		<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Something went wrong!	</div>
 </div>
@@ -199,7 +203,7 @@
 			autocomplete="off"
 			placeholder="First and last name"
 			 class="tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-name tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your first and last names are required		</div>
 	</div>
@@ -215,7 +219,7 @@
 			name="purchaser-email"
 			autocomplete="off"
 			 class="tribe-common-b2 tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-email tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your email address is required		</div>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description">
@@ -227,7 +231,7 @@
 				<footer class="tribe-tickets__commerce-checkout-footer">
 	<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-footer-notice-error--no-gateway" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Unavailable!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Checkout is not available at this time because a payment method has not been set up. Please notify the site administrator.	</div>
 </div>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
@@ -128,44 +128,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
@@ -193,44 +193,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
@@ -6,14 +6,14 @@
 	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
 	Purchase Tickets</h3>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
-
+	
 <a
 	class="tribe-common-anchor-alt tribe-tickets__commerce-checkout-header-link-back-to-event"
 	href="http://wordpress.test/?tribe_events=test-event"
 >back to event</a>
 </div>
 </header>
-
+					
 <div class="tribe-tickets__commerce-checkout-cart">
 
 	<header class="tribe-tickets__commerce-checkout-cart-header">
@@ -62,7 +62,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;5.00</span>
 </div>
@@ -112,7 +112,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;10.00</span>
 </div>
@@ -126,9 +126,9 @@
 </article>
 </div>
 
-
+	
 </div>
-
+					
 <div class="tribe-tickets__commerce-checkout-cart">
 
 	<header class="tribe-tickets__commerce-checkout-cart-header">
@@ -177,7 +177,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;20.00</span>
 </div>
@@ -191,10 +191,14 @@
 </article>
 </div>
 
-
+	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"
@@ -246,7 +250,7 @@
 </div>
 		<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Something went wrong!	</div>
 </div>
@@ -264,7 +268,7 @@
 			autocomplete="off"
 			placeholder="First and last name"
 			 class="tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-name tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your first and last names are required		</div>
 	</div>
@@ -280,7 +284,7 @@
 			name="purchaser-email"
 			autocomplete="off"
 			 class="tribe-common-b2 tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-email tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your email address is required		</div>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description">
@@ -292,7 +296,7 @@
 				<footer class="tribe-tickets__commerce-checkout-footer">
 	<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-footer-notice-error--no-gateway" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Unavailable!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Checkout is not available at this time because a payment method has not been set up. Please notify the site administrator.	</div>
 </div>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
@@ -78,44 +78,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
@@ -6,14 +6,14 @@
 	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
 	Purchase Tickets</h3>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
-
+	
 <a
 	class="tribe-common-anchor-alt tribe-tickets__commerce-checkout-header-link-back-to-event"
 	href="http://wordpress.test/?post_type=tribe_events&#038;p={{ID}}"
 >back to event</a>
 </div>
 </header>
-
+					
 <div class="tribe-tickets__commerce-checkout-cart">
 
 	<header class="tribe-tickets__commerce-checkout-cart-header">
@@ -62,7 +62,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;10.00</span>
 </div>
@@ -76,10 +76,14 @@
 </article>
 </div>
 
-
+	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"
@@ -131,7 +135,7 @@
 </div>
 		<div id=""  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Something went wrong!	</div>
 </div>
@@ -149,7 +153,7 @@
 			autocomplete="off"
 			placeholder="First and last name"
 			 class="tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-name tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your first and last names are required		</div>
 	</div>
@@ -165,7 +169,7 @@
 			name="purchaser-email"
 			autocomplete="off"
 			 class="tribe-common-b2 tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-email tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your email address is required		</div>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description">
@@ -177,7 +181,7 @@
 				<footer class="tribe-tickets__commerce-checkout-footer">
 	<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-footer-notice-error--no-gateway" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Unavailable!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Checkout is not available at this time because a payment method has not been set up. Please notify the site administrator.	</div>
 </div>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
@@ -6,14 +6,14 @@
 	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
 	Purchase Tickets</h3>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
-
+	
 <a
 	class="tribe-common-anchor-alt tribe-tickets__commerce-checkout-header-link-back-to-event"
 	href="http://wordpress.test/?tribe_events=test-event"
 >back to event</a>
 </div>
 </header>
-
+					
 <div class="tribe-tickets__commerce-checkout-cart">
 
 	<header class="tribe-tickets__commerce-checkout-cart-header">
@@ -62,7 +62,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;10.00</span>
 </div>
@@ -76,9 +76,9 @@
 </article>
 </div>
 
-
+	
 </div>
-
+					
 <div class="tribe-tickets__commerce-checkout-cart">
 
 	<header class="tribe-tickets__commerce-checkout-cart-header">
@@ -127,7 +127,7 @@
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
-
+	
 <span class="tec-tickets-price amount">
 	&#x24;20.00</span>
 </div>
@@ -141,10 +141,14 @@
 </article>
 </div>
 
-
+	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"
@@ -196,7 +200,7 @@
 </div>
 		<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Something went wrong!	</div>
 </div>
@@ -214,7 +218,7 @@
 			autocomplete="off"
 			placeholder="First and last name"
 			 class="tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-name tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your first and last names are required		</div>
 	</div>
@@ -230,7 +234,7 @@
 			name="purchaser-email"
 			autocomplete="off"
 			 class="tribe-common-b2 tribe-tickets__commerce-checkout-purchaser-info-form-field tribe-tickets__commerce-checkout-purchaser-info-form-field-email tribe-common-form-control-text__input tribe-tickets__form-field-input" 			required
-		/>
+					/>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description tribe-common-a11y-hidden error">
 			Your email address is required		</div>
 		<div class="tribe-common-b3 tribe-tickets__form-field-description">
@@ -242,7 +246,7 @@
 				<footer class="tribe-tickets__commerce-checkout-footer">
 	<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-footer-notice-error--no-gateway" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Unavailable!</h3>
-
+	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >
 		Checkout is not available at this time because a payment method has not been set up. Please notify the site administrator.	</div>
 </div>

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
@@ -143,44 +143,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="http://wordpress.test/wp-content/plugins/event-tickets/common/src/resources/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
@@ -279,6 +279,10 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link tribe-common-a11y-hidden" >
+		<button>
+			Add coupon code		</button>
+	</p>
 	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
@@ -278,44 +278,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link tribe-common-a11y-hidden" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link tribe-common-a11y-hidden" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value="test-coupon-4"
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 						test-coupon-4					</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 					- &#x24;70.00				</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -279,7 +279,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -278,44 +278,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -279,7 +279,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -278,44 +278,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -79,7 +79,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -78,44 +78,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -79,7 +79,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -78,44 +78,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -79,7 +79,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -78,44 +78,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -79,7 +79,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -78,44 +78,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
@@ -228,44 +228,45 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
-		<button>
-			Add coupon code		</button>
-	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
+	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
 		<input
-			class="tec-tickets__commerce-checkout-cart-coupons__input"
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
 			type="text"
-			id="coupon_input"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
 			name="coupons"
-			aria-describedby="coupon_error"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
 			aria-label="Enter coupon code"
 			placeholder="Enter coupon code"
 			value=""
 		/>
-		<button
-			id="coupon_apply"
-			 class="tec-tickets__commerce-checkout-cart-coupons__apply-button tribe-common-c-btn" 		>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
 			Apply		</button>
 	</div>
-	<p id="coupon_error" class="tec-tickets__commerce-checkout-cart-coupons__error" style="display: none; color: red;" aria-live="polite" role="alert">
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
 		Invalid coupon code	</p>
-	<div  class="tec-tickets__commerce-checkout-cart-coupons__applied tribe-common-a11y-hidden" >
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
 		<ul>
 			<li>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-text tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					<span class="tec-tickets__commerce-checkout-cart-coupons__applied-label">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
 											</span>
-					<button class="tec-tickets__commerce-checkout-cart-coupons__remove-button" type="button">
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
 						<img
 							src="https://example.com/images/icons/close.svg"
-							alt="Close icon"
+							alt="Icon to remove coupon"
 							title="Remove coupon"
 						>
 					</button>
 				</span>
-				<span class="tec-tickets__commerce-checkout-cart-coupons__applied-discount tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
 									</span>
 			</li>
 		</ul>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
@@ -1,12 +1,3 @@
-
-
-
-
-
-
-
-
-
 <div class="tribe-common event-tickets">
 	<section
 		class="tribe-tickets__commerce-checkout"
@@ -238,7 +229,11 @@
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
 	<div class="tec-tickets__commerce-checkout-coupons-wrapper tribe-tickets__form tribe-common-b2">
-	<div  class="tec-tickets__commerce-checkout-cart-coupons" >
+	<p  class="tec-tickets__commerce-checkout-cart-coupons__add-coupon-link" >
+		<button>
+			Add coupon code		</button>
+	</p>
+	<div  class="tec-tickets__commerce-checkout-cart-coupons tribe-common-a11y-hidden" >
 		<input
 			class="tec-tickets__commerce-checkout-cart-coupons__input"
 			type="text"


### PR DESCRIPTION
### 🎫 Ticket

QA spreadsheeet – issue `#012`

### 🗒️ Description

This changes the coupon input field to be hidden initially, and a new link "Add coupon code" is displayed instead. Clicking this link will then show the coupon input as before.

### 🎥 Artifacts <!-- if applicable-->

https://github.com/user-attachments/assets/7dd745b4-7bed-48c1-b1e3-0f7f87da6e66


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
