### PR TITLE
Fix PayPal errors when using coupons

### DIFF
--- a/src/Tickets/Commerce/Gateways/PayPal/Client.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Client.php
@@ -503,6 +503,14 @@ class Client {
 						'currency_code' => Arr::get( $unit, 'currency' ),
 					],
 				];
+
+				// If we have extra breakdown provided, merge into the item breakdown.
+				if ( array_key_exists( 'extra_breakdown', $unit ) ) {
+					$purchase_unit['amount']['breakdown'] = array_merge(
+						$purchase_unit['amount']['breakdown'],
+						$unit['extra_breakdown']
+					);
+				}
 			}
 
 			if ( ! empty( $unit['tax_id'] ) ) {

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -128,6 +128,16 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			$unit['items'][] = $this->get_unit_data( $item, $order );
 		}
 
+		/**
+		 * Filters the unit data for the order before sending it to PayPal.
+		 *
+		 * @since TBD
+		 *
+		 * @param array   $unit  The structured data for the order.
+		 * @param WP_Post $order The current order object.
+		 */
+		$unit = (array) apply_filters( 'tec_tickets_commerce_paypal_order_unit', $unit, $order );
+
 		$paypal_order = tribe( Client::class )->create_order( $unit );
 
 		if ( empty( $paypal_order['id'] ) || empty( $paypal_order['create_time'] ) ) {

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -13,6 +13,8 @@ use Exception;
 use TEC\Common\Contracts\Container;
 use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Cart\Abstract_Cart;
+use TEC\Tickets\Commerce\Gateways\Manager as Gateway_Manager;
+use TEC\Tickets\Commerce\Gateways\Stripe\Gateway as Stripe;
 use TEC\Tickets\Commerce\Gateways\Stripe\Payment_Intent;
 use TEC\Tickets\Commerce\Order_Modifiers\Models\Coupon;
 use TEC\Tickets\Commerce\Order_Modifiers\Models\Order_Modifier;
@@ -532,6 +534,24 @@ class Coupons extends Base_API {
 
 			default:
 				return [];
+		}
+	}
+
+	/**
+	 * Determine if the current gateway is Stripe.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the current gateway is Stripe.
+	 */
+	protected function is_using_stripe(): bool {
+		try {
+			/** @var Gateway_Manager $manager */
+			$manager = $this->container->get( Gateway_Manager::class );
+
+			return Stripe::get_key() === $manager->get_current_gateway();
+		} catch ( Exception $e ) {
+			return false;
 		}
 	}
 

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -556,29 +556,6 @@ class Coupons extends Base_API {
 	}
 
 	/**
-	 * Get the purchaser information.
-	 *
-	 * @since 5.18.0
-	 *
-	 * @param Request $request The request object.
-	 *
-	 * @return array
-	 */
-	protected function get_purchaser_information( Request $request ) {
-		$purchaser_data = $request->get_param( 'purchaser_data' );
-
-		[ $first_name, $last_name ] = explode( ' ', $purchaser_data['name'], 2 );
-
-		return [
-			'purchaser_user_id'    => 0,
-			'purchaser_full_name'  => $purchaser_data['name'],
-			'purchaser_first_name' => $first_name ?? $purchaser_data['name'],
-			'purchaser_last_name'  => $last_name ?? '',
-			'purchaser_email'      => sanitize_email( $purchaser_data['email'] ),
-		];
-	}
-
-	/**
 	 * Get the coupon slug from the request object and validate it.
 	 *
 	 * @since TBD

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -449,10 +449,10 @@ class Coupons extends Base_API {
 				'required'    => true,
 			],
 			'payment_intent_id' => [
-				'description' => esc_html__( 'The payment intent to apply the coupon to.', 'event-tickets' ),
+				'description' => esc_html__( 'The Stripe payment intent to apply the coupon to.', 'event-tickets' ),
 				'type'        => 'string',
 				'format'      => 'text-field',
-				'required'    => true,
+				'required'    => $this->is_using_stripe(),
 			],
 			'purchaser_data'    => [
 				'description'       => esc_html__( 'The purchaser data.', 'event-tickets' ),

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -349,6 +349,21 @@ class Coupons extends Base_API {
 	}
 
 	/**
+	 * Update the Stripe payment intent.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id     The payment intent ID.
+	 * @param int    $amount The new amount as an integer. This should be in the smallest currency
+	 *                       unit (e.g. cents for USD: $1 = 100 cents).
+	 *
+	 * @return void
+	 */
+	protected function update_stripe_payment_intent( string $id, int $amount ) {
+		Payment_Intent::update( $id, [ 'amount' => $amount ] );
+	}
+
+	/**
 	 * Prepare a coupon for the response.
 	 *
 	 * @since 5.18.0

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -252,11 +252,13 @@ class Coupons extends Base_API {
 			$cart_total = Currency_Value::create_from_float( $cart->get_cart_total() );
 			$discount   = Currency_Value::create_from_float( $coupon->get_discount_amount( $original_total->get_raw_value()->get() ) );
 
-			// Update the payment intent with the new value
-			Payment_Intent::update(
-				$request->get_param( 'payment_intent_id' ),
-				[ 'amount' => $cart_total->get_raw_value()->get_as_integer() ]
-			);
+			// Update the payment intent with the new value.
+			if ( $this->is_using_stripe() ) {
+				$this->update_stripe_payment_intent(
+					$request->get_param( 'payment_intent_id' ),
+					$cart_total->get_raw_value()->get_as_integer()
+				);
+			}
 
 			return rest_ensure_response(
 				[
@@ -319,10 +321,12 @@ class Coupons extends Base_API {
 			$cart_total = Currency_Value::create_from_float( $cart->get_cart_total() );
 
 			// Update the payment intent with the new value.
-			Payment_Intent::update(
-				$request->get_param( 'payment_intent_id' ),
-				[ 'amount' => $cart_total->get_raw_value()->get_as_integer() ]
-			);
+			if ( $this->is_using_stripe() ) {
+				$this->update_stripe_payment_intent(
+					$request->get_param( 'payment_intent_id' ),
+					$cart_total->get_raw_value()->get_as_integer()
+				);
+			}
 
 			return rest_ensure_response(
 				[

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/PayPal/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/PayPal/Coupons.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Coupons class for handling PayPal coupons.
+ *
+ * This class manages the addition and calculation of coupons within the PayPal gateway workflow.
+ *
+ * @since   TBD
+ * @package TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal
+ */
+
+namespace TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Tickets\Commerce\Traits\Type;
+use WP_Post;
+
+/**
+ * Class Coupons
+ *
+ * @since TBD
+ */
+class Coupons extends Controller_Contract {
+
+	use Type;
+
+	/**
+	 * Registers the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		add_filter(
+			'tec_tickets_commerce_paypal_order_unit',
+			[ $this, 'add_coupon_unit_data_to_paypal' ],
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Removes the filters and actions hooks added by the controller.
+	 *
+	 * Bound implementations should not be removed in this method!
+	 *
+	 * @since TBD
+	 *
+	 * @return void Filters and actions hooks added by the controller are be removed.
+	 */
+	public function unregister(): void {
+		remove_filter(
+			'tec_tickets_commerce_paypal_order_unit',
+			[ $this, 'add_coupon_unit_data_to_paypal' ],
+		);
+	}
+
+	/**
+	 * Adds coupon unit data to the PayPal order.
+	 *
+	 * @since TBD
+	 *
+	 * @param array   $unit  The unit data to be passed to PayPal.
+	 * @param WP_Post $order The order object.
+	 *
+	 * @return array
+	 */
+	public function add_coupon_unit_data_to_paypal( array $unit, WP_Post $order ) {
+		if ( empty ( $order->coupons ) ) {
+			return $unit;
+		}
+
+		foreach ( $order->coupons as $coupon ) {
+			if ( is_int( $coupon['id'] ) ) {
+				$sku = $this->get_unique_type_id( $coupon['id'], 'coupon' );
+			} else {
+				$sku = $coupon['id'];
+			}
+
+			$unit['items'][] = [
+				'name'        => $coupon['slug'],
+				'quantity'    => $coupon['quantity'] ?? 1,
+				'unit_amount' => [
+					'value'         => $coupon['sub_total'],
+					'currency_code' => $order->currency,
+				],
+				'item_total'  => [
+					'value'         => $coupon['sub_total'],
+					'currency_code' => $order->currency,
+				],
+				'sku'         => $sku,
+			];
+		}
+
+		return $unit;
+	}
+}

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/PayPal/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/PayPal/Coupons.php
@@ -12,6 +12,7 @@ namespace TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Tickets\Commerce\Traits\Type;
+use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
 use WP_Post;
 
 /**
@@ -71,21 +72,20 @@ class Coupons extends Controller_Contract {
 		}
 
 		foreach ( $order->coupons as $coupon ) {
-			if ( is_int( $coupon['id'] ) ) {
-				$sku = $this->get_unique_type_id( $coupon['id'], 'coupon' );
-			} else {
-				$sku = $coupon['id'];
-			}
+			// Get SKU and value.
+			$sku   = $this->get_unique_type_id( $coupon['id'], 'coupon' );
+			$value = Legacy_Value_Factory::to_precision_value( $coupon['sub_total'] );
 
+			// Build item data array.
 			$unit['items'][] = [
 				'name'        => $coupon['slug'],
 				'quantity'    => $coupon['quantity'] ?? 1,
 				'unit_amount' => [
-					'value'         => $coupon['sub_total'],
+					'value'         => (string) $value,
 					'currency_code' => $order->currency,
 				],
 				'item_total'  => [
-					'value'         => $coupon['sub_total'],
+					'value'         => (string) $value,
 					'currency_code' => $order->currency,
 				],
 				'sku'         => $sku,

--- a/src/Tickets/Commerce/Order_Modifiers/Controller.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Controller.php
@@ -21,6 +21,7 @@ use TEC\Tickets\Commerce\Order_Modifiers\Admin\Editor;
 use TEC\Tickets\Commerce\Order_Modifiers\Admin\Order_Modifier_Fee_Metabox;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Coupons as Coupons_Checkout;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Fees as Agnostic_Checkout_Fees;
+use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal\Coupons as PayPal_Checkout_Coupons;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal\Fees as Paypal_Checkout_Fees;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\Stripe\Fees as Stripe_Checkout_Fees;
 use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\Stripe\Coupons as Stripe_Checkout_Coupons;
@@ -73,6 +74,7 @@ final class Controller extends Controller_Contract {
 		$this->container->get( Editor::class )->unregister();
 		$this->container->get( Coupons_Checkout::class )->unregister();
 		$this->container->get( Stripe_Checkout_Coupons::class )->unregister();
+		$this->container->get( PayPal_Checkout_Coupons::class )->unregister();
 
 		// API classes.
 		$this->container->get( Coupons::class )->unregister();
@@ -104,6 +106,7 @@ final class Controller extends Controller_Contract {
 		$this->container->register( Editor::class );
 		$this->container->register( Coupons_Checkout::class );
 		$this->container->register( Stripe_Checkout_Coupons::class );
+		$this->container->register( PayPal_Checkout_Coupons::class );
 
 		// API classes.
 		$this->container->register( Coupons::class );

--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -314,7 +314,7 @@ tribe.tickets.commerce = {};
 			const hiddenName = obj.selectors.hiddenElement.className();
 			const $inputContainer = $( obj.selectors.couponInputContainer );
 			const nonce = $( obj.selectors.nonce ).val();
-			const intentId = window.tecTicketsCommerceGatewayStripeCheckout.paymentIntentData.id || '';
+			const stripeIntentId = window.tecTicketsCommerceGatewayStripeCheckout?.paymentIntentData?.id;
 
 			// Hide the error message initially.
 			$errorMessage.addClass( hiddenName );
@@ -336,10 +336,13 @@ tribe.tickets.commerce = {};
 			const requestData = {
 				coupon: couponValue,
 				nonce: nonce,
-				payment_intent_id: intentId,
 				purchaser_data: obj.getPurchaserData( $( obj.selectors.purchaserFormContainer ) ),
 				cart_hash: cartHash[ 1 ],
 			};
+
+			if ( undefined !== stripeIntentId ) {
+				requestData.payment_intent_id = stripeIntentId;
+			}
 
 			$.ajax( {
 				url: `${ tecTicketsCommerce.restUrl }coupons/apply`,

--- a/src/views/v2/commerce/order/details/coupons.php
+++ b/src/views/v2/commerce/order/details/coupons.php
@@ -26,7 +26,7 @@ if ( empty( $order->coupons ) ) {
 
 $discounts = array_map(
 	fn( Value $value ) => Legacy_Value_Factory::to_currency_value( $value ),
-	wp_list_pluck( $order->coupons, 'sub_total' )
+	wp_list_pluck( array_values( $order->coupons ), 'sub_total' )
 );
 
 $total_discount = Currency_Value::sum( ...$discounts );


### PR DESCRIPTION
### 🎫 Ticket

QA Issue `031`

### 🗒️ Description

This fixes the PayPal errors that are generated when using coupons. Notably:

1. Adds a custom controller to handle adding Coupons to the PayPal order data.
    1. PayPal doesn't accept negative values for items, so we have to handle this a different way. I'm using a solution that I [found here](https://www.paypal-community.com/t5/REST-APIs/Applying-Discounts-to-Payment-Orders/td-p/1761738).
    1. I added a filter and a bit of extra logic to the PayPal `Client` class. This facilitates the changes described above.
1. I updated the `tickets-commerce.js` script to not error when PayPal is in use. This was the cause of the console error where we tried to query a window object that didn't exist
1. I updated the Coupons API to only require the Stripe payment intent when stripe is being used
1. I also fixed a PHP 7.4 error in the template file where using array destructring triggered an error because the array had string keys instead of numeric keys.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
