### PR TITLE
Validate coupon usage to be positive or empty

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Modifiers/Coupon.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifiers/Coupon.php
@@ -79,17 +79,8 @@ class Coupon extends Modifier_Abstract {
 	 * @return Model The newly inserted modifier or an empty array if no changes were made.
 	 */
 	public function insert_modifier( array $data ): Model {
-		// Save the modifier.
 		$modifier = parent::insert_modifier( $data );
-
-		// Handle metadata (e.g., coupons_available).
-		$this->handle_meta_data(
-			$modifier->id,
-			[
-				'meta_key'   => 'coupons_available',
-				'meta_value' => tec_get_request_var( 'order_modifier_coupon_limit', '' ),
-			]
-		);
+		$this->set_usage_limit( $modifier->id, tec_get_request_var( 'order_modifier_coupon_limit', '' ) );
 
 		return $modifier;
 	}
@@ -104,17 +95,8 @@ class Coupon extends Modifier_Abstract {
 	 * @return Model The updated modifier or an empty array if no changes were made.
 	 */
 	public function update_modifier( array $data ): Model {
-		// Save the modifier.
 		$modifier = parent::update_modifier( $data );
-
-		// Handle metadata (e.g., coupons_available).
-		$this->handle_meta_data(
-			$modifier->id,
-			[
-				'meta_key'   => 'coupons_available',
-				'meta_value' => tec_get_request_var( 'order_modifier_coupon_limit', '' ),
-			]
-		);
+		$this->set_usage_limit( $modifier->id, tec_get_request_var( 'order_modifier_coupon_limit', '' ) );
 
 		return $modifier;
 	}
@@ -204,5 +186,30 @@ class Coupon extends Modifier_Abstract {
 	 * @return void
 	 */
 	public function handle_relationship_update( array $modifier_ids, array $new_post_ids ): void {
+	}
+
+	/**
+	 * Set the usage limit for a coupon.
+	 *
+	 * @since TBD
+	 *
+	 * @param int        $modifier_id The modifier ID.
+	 * @param string|int $limit       The limit to set. Pass an empty string or 0 for no limit.
+	 *
+	 * @return Model
+	 */
+	public function set_usage_limit( int $modifier_id, $limit ) {
+		// Allow passing zero to set an empty limit.
+		if ( 0 === (int) $limit ) {
+			$limit = '';
+		}
+
+		return $this->handle_meta_data(
+			$modifier_id,
+			[
+				'meta_key'   => 'coupons_available',
+				'meta_value' => $limit,
+			]
+		);
 	}
 }

--- a/src/admin-views/order_modifiers/coupon-edit.php
+++ b/src/admin-views/order_modifiers/coupon-edit.php
@@ -29,7 +29,7 @@ if ( ! empty( $order_modifier_display_name ) ) {
 	$heading = __( 'New Coupon', 'event-tickets' );
 }
 
-$limit_error_text = __( 'If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit.', 'event-tickets' );
+$limit_error_text = __( 'Coupon Limit must be a positive number. Use 0 or leave empty for no limit.', 'event-tickets' );
 
 ?>
 <div class="wrap">

--- a/src/admin-views/order_modifiers/coupon-edit.php
+++ b/src/admin-views/order_modifiers/coupon-edit.php
@@ -29,6 +29,8 @@ if ( ! empty( $order_modifier_display_name ) ) {
 	$heading = __( 'New Coupon', 'event-tickets' );
 }
 
+$limit_error_text = __( 'If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit.', 'event-tickets' );
+
 ?>
 <div class="wrap">
 	<h1><?php echo esc_html( $heading ); ?></h1>
@@ -109,6 +111,8 @@ if ( ! empty( $order_modifier_display_name ) ) {
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="<?php echo esc_attr( $limit_error_text ); ?>"
 						value="<?php echo esc_attr( $order_modifier_coupon_limit ?? '' ); ?>" />
 					<p>
 						<?php esc_html_e( 'Leave field blank to allow for unlimited coupon redemption.', 'event-tickets' ); ?>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Emojis in Name and Slug__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Emojis in Name and Slug__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Emojis in Name and Slug__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Emojis in Name and Slug__0.snapshot.html
@@ -57,18 +57,19 @@
 						value="$15.00" />
 				</div>
 
-				<div class="form-field form-required">
-					<label for="order_modifier_status">
-						Status					</label>
-					<select name="order_modifier_status" id="order_modifier_status">
-													<option value="active"  selected='selected'>
-								Active							</option>
-													<option value="inactive" >
-								Inactive							</option>
-													<option value="draft" >
-								Draft							</option>
-											</select>
-				</div>
+				
+<div class="form-field form-required">
+	<label for="order_modifier_status">
+		Status	</label>
+	<select name="order_modifier_status" id="order_modifier_status">
+					<option value="active"  selected='selected'>
+				Active			</option>
+					<option value="inactive" >
+				Inactive			</option>
+					<option value="draft" >
+				Draft			</option>
+			</select>
+</div>
 
 				<div class="form-field form-required">
 					<label for="order_modifier_coupon_limit">
@@ -79,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Excessively Large Amount__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Excessively Large Amount__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Excessively Large Amount__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Excessively Large Amount__0.snapshot.html
@@ -57,18 +57,19 @@
 						value="$1,234,567.90" />
 				</div>
 
-				<div class="form-field form-required">
-					<label for="order_modifier_status">
-						Status					</label>
-					<select name="order_modifier_status" id="order_modifier_status">
-													<option value="active"  selected='selected'>
-								Active							</option>
-													<option value="inactive" >
-								Inactive							</option>
-													<option value="draft" >
-								Draft							</option>
-											</select>
-				</div>
+				
+<div class="form-field form-required">
+	<label for="order_modifier_status">
+		Status	</label>
+	<select name="order_modifier_status" id="order_modifier_status">
+					<option value="active"  selected='selected'>
+				Active			</option>
+					<option value="inactive" >
+				Inactive			</option>
+					<option value="draft" >
+				Draft			</option>
+			</select>
+</div>
 
 				<div class="form-field form-required">
 					<label for="order_modifier_coupon_limit">
@@ -79,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Long Decimal Value__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Long Decimal Value__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Long Decimal Value__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Long Decimal Value__0.snapshot.html
@@ -57,18 +57,19 @@
 						value="$1.01" />
 				</div>
 
-				<div class="form-field form-required">
-					<label for="order_modifier_status">
-						Status					</label>
-					<select name="order_modifier_status" id="order_modifier_status">
-													<option value="active"  selected='selected'>
-								Active							</option>
-													<option value="inactive" >
-								Inactive							</option>
-													<option value="draft" >
-								Draft							</option>
-											</select>
-				</div>
+				
+<div class="form-field form-required">
+	<label for="order_modifier_status">
+		Status	</label>
+	<select name="order_modifier_status" id="order_modifier_status">
+					<option value="active"  selected='selected'>
+				Active			</option>
+					<option value="inactive" >
+				Inactive			</option>
+					<option value="draft" >
+				Draft			</option>
+			</select>
+</div>
 
 				<div class="form-field form-required">
 					<label for="order_modifier_coupon_limit">
@@ -79,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Special Characters__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Special Characters__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Special Characters__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Special Characters__0.snapshot.html
@@ -57,18 +57,19 @@
 						value="$5.00" />
 				</div>
 
-				<div class="form-field form-required">
-					<label for="order_modifier_status">
-						Status					</label>
-					<select name="order_modifier_status" id="order_modifier_status">
-													<option value="active"  selected='selected'>
-								Active							</option>
-													<option value="inactive" >
-								Inactive							</option>
-													<option value="draft" >
-								Draft							</option>
-											</select>
-				</div>
+				
+<div class="form-field form-required">
+	<label for="order_modifier_status">
+		Status	</label>
+	<select name="order_modifier_status" id="order_modifier_status">
+					<option value="active"  selected='selected'>
+				Active			</option>
+					<option value="inactive" >
+				Inactive			</option>
+					<option value="draft" >
+				Draft			</option>
+			</select>
+</div>
 
 				<div class="form-field form-required">
 					<label for="order_modifier_coupon_limit">
@@ -79,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Flat Coupon__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Flat Coupon__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Flat Coupon__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Flat Coupon__0.snapshot.html
@@ -57,18 +57,19 @@
 						value="$5.00" />
 				</div>
 
-				<div class="form-field form-required">
-					<label for="order_modifier_status">
-						Status					</label>
-					<select name="order_modifier_status" id="order_modifier_status">
-													<option value="active"  selected='selected'>
-								Active							</option>
-													<option value="inactive" >
-								Inactive							</option>
-													<option value="draft" >
-								Draft							</option>
-											</select>
-				</div>
+				
+<div class="form-field form-required">
+	<label for="order_modifier_status">
+		Status	</label>
+	<select name="order_modifier_status" id="order_modifier_status">
+					<option value="active"  selected='selected'>
+				Active			</option>
+					<option value="inactive" >
+				Inactive			</option>
+					<option value="draft" >
+				Draft			</option>
+			</select>
+</div>
 
 				<div class="form-field form-required">
 					<label for="order_modifier_coupon_limit">
@@ -79,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Percent Coupon__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Percent Coupon__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Percent Coupon__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Percent Coupon__0.snapshot.html
@@ -57,18 +57,19 @@
 						value="10.00%" />
 				</div>
 
-				<div class="form-field form-required">
-					<label for="order_modifier_status">
-						Status					</label>
-					<select name="order_modifier_status" id="order_modifier_status">
-													<option value="active"  selected='selected'>
-								Active							</option>
-													<option value="inactive" >
-								Inactive							</option>
-													<option value="draft" >
-								Draft							</option>
-											</select>
-				</div>
+				
+<div class="form-field form-required">
+	<label for="order_modifier_status">
+		Status	</label>
+	<select name="order_modifier_status" id="order_modifier_status">
+					<option value="active"  selected='selected'>
+				Active			</option>
+					<option value="inactive" >
+				Inactive			</option>
+					<option value="draft" >
+				Draft			</option>
+			</select>
+</div>
 
 				<div class="form-field form-required">
 					<label for="order_modifier_coupon_limit">
@@ -79,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_with_no_data__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_with_no_data__0.snapshot.html
@@ -80,6 +80,8 @@
 						id="order_modifier_coupon_limit"
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
+						data-validation-is-greater-or-equal-to="0"
+						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_with_no_data__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_with_no_data__0.snapshot.html
@@ -81,7 +81,7 @@
 						maxlength="15"
 						class="tribe-field tec_order_modifier_amount_field"
 						data-validation-is-greater-or-equal-to="0"
-						data-validation-error="If setting a limit for a Coupon, it must be a positive number. Use 0 or leave empty for no limit."
+						data-validation-error="Coupon Limit must be a positive number. Use 0 or leave empty for no limit."
 						value="" />
 					<p>
 						Leave field blank to allow for unlimited coupon redemption.					</p>


### PR DESCRIPTION
### 🎫 Ticket

QA Issue `#033`

### 🗒️ Description

Update the coupon usage input field to error on negative numbers. It will also convert 0 to be an empty field, meaning no limit.

### 🎥 Artifacts <!-- if applicable-->

**Before:**

https://github.com/user-attachments/assets/b783c2cc-d3bd-47de-97a4-139ae88bbeff

**After:**

https://github.com/user-attachments/assets/e149805e-bb45-4cd4-ba3d-e9d05363fdd1

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
