### PR TITLE
Update JS validation to prevent submit when amount is invalid

### DIFF
--- a/src/resources/js/admin/order-modifiers/amount-field.js
+++ b/src/resources/js/admin/order-modifiers/amount-field.js
@@ -37,6 +37,7 @@ window.etOrderModifiersAmountField = window.etOrderModifiersAmountField || {
 
 	const selectors = {
 		amount: '#order_modifier_amount',
+		form: '.tec-settings-order_modifier',
 		type: '#order_modifier_sub_type',
 	};
 
@@ -85,6 +86,7 @@ window.etOrderModifiersAmountField = window.etOrderModifiersAmountField || {
 	};
 
 	const validateAmount = () => {
+		const $form = $( selectors.form );
 		const $input = $( selectors.amount );
 		const asFloat = parseFloat( mask.unmaskedValue );
 
@@ -94,6 +96,10 @@ window.etOrderModifiersAmountField = window.etOrderModifiersAmountField || {
 			return;
 		}
 
+		// Remove the valid class so the validation library won't allow submit.
+		$form.removeClass( validation.selectors.valid.className() );
+
+		// Mark the input as invalid and display the error.
 		$input.addClass( validation.selectors.error.className() );
 		$input.one( 'focusin', validation.onChangeFieldRemoveError );
 		$input.trigger( 'displayErrors.tribe' );


### PR DESCRIPTION
### 🎫 Ticket

QA Issue `#034`

### 🗒️ Description

This updates the custom validation attached to the `amount` field for coupons and fees. Since we're overriding the normal validation, we need to also remove the `.tribe-validation-valid` class from the `<form>` element. This will ensure that the validation library prevents the Submit button from working until all validation passes. By extension, this also ensures that data which has already been entered isn't lost on page refresh.

### 🎥 Artifacts <!-- if applicable-->

**Before:** Page reloads on submit, even with invalid data.

https://github.com/user-attachments/assets/c9c2c8a8-4f20-4c8b-a2f9-cef785b52bb6

**After:** Page is prevented from reloading.

https://github.com/user-attachments/assets/a36b71dc-631b-48bc-8fe5-8c99f3c07f7f



### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
