### PR TITLE
Ensure cart and order values cannot be less than zero

### DIFF
--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -207,11 +207,9 @@ abstract class Abstract_Cart implements Cart_Interface {
 		);
 
 		// Only update the stored total if it's greater than zero.
-		if ( $total->get() > 0.0 ) {
-			$this->cart_total = $total;
-		} else {
-			$this->cart_total = new Precision_Value( 0.0 );
-		}
+		$this->cart_total = $total->get() > 0.0
+			? $total
+			: new Precision_Value( 0.0 );
 
 		// Mark that the total has been calculated.
 		$this->total_calculated = true;

--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -209,6 +209,8 @@ abstract class Abstract_Cart implements Cart_Interface {
 		// Only update the stored total if it's greater than zero.
 		if ( $total->get() > 0.0 ) {
 			$this->cart_total = $total;
+		} else {
+			$this->cart_total = new Precision_Value( 0.0 );
 		}
 
 		// Mark that the total has been calculated.

--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -199,8 +199,19 @@ abstract class Abstract_Cart implements Cart_Interface {
 			$additional_values
 		);
 
-		// Set the total and mark it as calculated.
-		$this->cart_total       = Precision_Value::sum( $this->cart_subtotal, ...$additional_values, ...$callable_subtotals );
+		// Calculate the new value from all of the subtotals.
+		$total = Precision_Value::sum(
+			$this->cart_subtotal,
+			...$additional_values,
+			...$callable_subtotals
+		);
+
+		// Only update the stored total if it's greater than zero.
+		if ( $total->get() > 0.0 ) {
+			$this->cart_total = $total;
+		}
+
+		// Mark that the total has been calculated.
 		$this->total_calculated = true;
 
 		return $this->cart_total->get();

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -19,6 +19,7 @@ use TEC\Tickets\Commerce\Status\Reversed;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\Utils\Value;
 use Tribe__Date_Utils as Dates;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use WP_Post;
 
 /**
@@ -525,32 +526,44 @@ class Order extends Abstract_Order {
 	public function create_from_cart( Gateway_Interface $gateway, $purchaser = null ) {
 		$cart = tribe( Cart::class );
 
-		$items = $cart->get_items_in_cart();
+		// Prepare the items for the order.
 		$items = array_filter(
 			array_map(
 				static function ( $item ) {
-					/** @var Value $ticket_value */
-					$ticket_value         = tribe( Ticket::class )->get_price_value( $item['ticket_id'] );
-					$ticket_regular_value = tribe( Ticket::class )->get_price_value( $item['ticket_id'], true );
+					/** @var Ticket_Object $ticket */
+					$ticket = $item['obj'] ?? tribe( Ticket::class )->get_ticket( $item['ticket_id'] );
 
-					if ( null === $ticket_value ) {
+					// Ensure we have a valid ticket object to work with.
+					if ( null === $ticket ) {
 						return null;
 					}
 
-					$item['price']     = $ticket_value->get_decimal();
-					$item['sub_total'] = $ticket_value->sub_total( $item['quantity'] )->get_decimal();
-					$item['event_id']  = tribe( Ticket::class )->get_related_event_id( $item['ticket_id'] );
+					// Ensure we have the properties we need on the ticket object.
+					if ( ! isset( $ticket->price, $ticket->regular_price ) ) {
+						return null;
+					}
 
-					$item['regular_price']     = $ticket_regular_value->get_decimal();
-					$item['regular_sub_total'] = $ticket_regular_value->sub_total( $item['quantity'] )->get_decimal();
+					$ticket_value         = Value::create( $ticket->price );
+					$ticket_regular_value = Value::create( $ticket->regular_price );
 
-					return $item;
+					return [
+						'event_id'          => $item['event_id'] ?? tribe( Ticket::class )->get_related_event_id( $item['ticket_id'] ),
+						'extra'             => $item['extra'] ?? [],
+						'price'             => $ticket_value->get_decimal(),
+						'quantity'          => $item['quantity'],
+						'regular_price'     => $ticket_regular_value->get_decimal(),
+						'regular_sub_total' => $item['regular_sub_total'] ?? $ticket_regular_value->sub_total( $item['quantity'] )->get_decimal(),
+						'sub_total'         => $item['sub_total'] ?? $ticket_value->sub_total( $item['quantity'] )->get_decimal(),
+						'ticket_id'         => $item['ticket_id'],
+						'type'              => $item['type'] ?? 'ticket',
+					];
 				},
-				$items
+				$cart->get_items_in_cart( true )
 			)
 		);
 
-		$subtotal = $this->get_value_total( $items );
+		// Get the subtotal calculation from the cart.
+		$cart_subtotal = Value::create( $cart->get_cart_subtotal() );
 
 		$original_cart_items = $items;
 
@@ -576,20 +589,41 @@ class Order extends Abstract_Order {
 		$items = apply_filters(
 			'tec_tickets_commerce_create_order_from_cart_items',
 			$items,
-			$subtotal,
+			$cart_subtotal,
 			$gateway,
 			$purchaser
 		);
 
-		$total = $this->get_value_total( array_filter( $items ) );
+		// Get the total calculation from the cart.
+		$cart_total = Value::create( $cart->get_cart_total() );
+
+		/**
+		 * Filter the cart total before creating an order.
+		 *
+		 * @since 5.21.0
+		 *
+		 * @param Value             $cart_total    The cart total.
+		 * @param array             $items         The items in the cart.
+		 * @param Value             $cart_subtotal The calculated subtotal of the cart items.
+		 * @param Gateway_Interface $gateway       The payment gateway used for the order.
+		 * @param ?array            $purchaser     Purchaser details.
+		 */
+		$cart_total = apply_filters(
+			'tec_tickets_commerce_create_order_from_cart_total',
+			$cart_total,
+			$items,
+			$cart_subtotal,
+			$gateway,
+			$purchaser
+		);
 
 		$hash              = $cart->get_cart_hash();
 		$existing_order_id = null;
 
 		$order_args = [
 			'title'                => $this->generate_order_title( $original_cart_items, $hash ),
-			'total_value'          => $total->get_decimal(),
-			'subtotal'             => $subtotal->get_decimal(),
+			'total_value'          => $cart_total->get_decimal(),
+			'subtotal'             => $cart_subtotal->get_decimal(),
 			'items'                => $items,
 			'gateway'              => $gateway::get_key(),
 			'hash'                 => $hash,

--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -545,6 +545,7 @@ class Order extends Abstract_Order {
 
 					$ticket_value         = Value::create( $ticket->price );
 					$ticket_regular_value = Value::create( $ticket->regular_price );
+					$subtotal_value       = $item['sub_total'] ?? $ticket_value->sub_total( $item['quantity'] );
 
 					return [
 						'event_id'          => $item['event_id'] ?? tribe( Ticket::class )->get_related_event_id( $item['ticket_id'] ),
@@ -552,8 +553,8 @@ class Order extends Abstract_Order {
 						'price'             => $ticket_value->get_decimal(),
 						'quantity'          => $item['quantity'],
 						'regular_price'     => $ticket_regular_value->get_decimal(),
-						'regular_sub_total' => $item['regular_sub_total'] ?? $ticket_regular_value->sub_total( $item['quantity'] )->get_decimal(),
-						'sub_total'         => $item['sub_total'] ?? $ticket_value->sub_total( $item['quantity'] )->get_decimal(),
+						'regular_sub_total' => $ticket_regular_value->sub_total( $item['quantity'] )->get_decimal(),
+						'sub_total'         => $subtotal_value->get_decimal(),
 						'ticket_id'         => $item['ticket_id'],
 						'type'              => $item['type'] ?? 'ticket',
 					];

--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -294,7 +294,7 @@ tribe.tickets.commerce = {};
 	 */
 	obj.getStripeIntentId = function() {
 		return window.tecTicketsCommerceGatewayStripeCheckout?.paymentIntentData?.id;
-	}
+	};
 
 	obj.bindCouponApply = function() {
 		let ajaxInProgress = false;

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_render_fees__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_render_fees__0.snapshot.html
@@ -53,7 +53,7 @@
 					<strong>Total</strong>
 				</td>
 				<td style="padding-left:0;">
-					<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;10.00</span></ins></div>				</td>
+					<div class="tec-tickets-commerce-price-container"><ins><span class="tec-tickets-commerce-price">&#x24;15.00</span></ins></div>				</td>
 				<td></td>
 			</tr>
 		</tfoot>


### PR DESCRIPTION
### 🎫 Ticket

QA Issue `#036`

### 🗒️ Description

This ensures that orders and the cart value cannot be less than zero. 

[skip-changelog] *Skipping the changelog as this is fixing a bug in a new feature.*

The cause of this issue was the work done in #3612. In that PR, the coupon calculation was moved to the `get_cart_total()` method out of the `get_cart_subtotal()` method. At that point, I didn't include a check after the dynamic calculations to ensure the total wasn't less than zero.

While fixing that particular issue, I found that the Order creation process also has the wrong values set for new orders. Upon digging into the `Order` class, I found that it is doing its own calculations of totals entirely separate from the cart. So, this PR does the following:

1. Updates the `Abstract_Cart::get_cart_total()` method to ensure we don't end up with a negative total for the cart contents.
1. Updates the `Order::create_from_cart()` method with these changes:
    1. It uses the subtotal and total from the cart instead of manually calculating these values. This allows the cart to handle all of the advanced logic.
    1. It updates the item preparation to use more of the data that is already provided when calling `$cart->get_items_in_cart()`. 
    1. Because technically we're changing the total calculation, I added a filter to allow for changing the order total after additional items have been added, and before the order is created
1. I added unit tests that cover the cart having a greater than zero value, and tests that cover the resulting order having a greater than zero value
1. One of the snapshots had an error in the Fee calculation that I didn't notice previously. The fixes above revealed this error. It should be `$15` (`$10` ticket plus `$5` fee), so the snapshot has now been updated.
1. When testing these changes, I noticed that the Checkout page doesn't adjust to handle an order that costs $0 due to a coupon. For that reason, I updated the Coupons API and the frontend JS to trigger a page reload if needed. The reason for the reload is to ensure the correct page template is displayed after a coupon is applied/removed.

### 🎥 Artifacts <!-- if applicable-->

**Before:**

https://github.com/user-attachments/assets/b8934be9-c231-4fba-9b57-f04b96aa16c8

**After:**

https://github.com/user-attachments/assets/8fe9fea5-b07a-45cf-95b6-5e1c8ea9a69f


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
