### PR TITLE
Fix fatal error when remove a coupon from $0 cart

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -253,7 +253,7 @@ class Coupons extends Base_API {
 			$discount   = Currency_Value::create_from_float( $coupon->get_discount_amount( $original_total->get_raw_value()->get() ) );
 
 			// Update the payment intent with the new value.
-			if ( $this->is_using_stripe() ) {
+			if ( $this->is_using_stripe() && $request->has_param( 'payment_intent_id' ) ) {
 				$this->update_stripe_payment_intent(
 					$request->get_param( 'payment_intent_id' ),
 					$cart_total->get_raw_value()->get_as_integer()
@@ -325,7 +325,7 @@ class Coupons extends Base_API {
 			$cart_total = Currency_Value::create_from_float( $cart->get_cart_total() );
 
 			// Update the payment intent with the new value.
-			if ( $this->is_using_stripe() ) {
+			if ( $this->is_using_stripe() && $request->has_param( 'payment_intent_id' ) ) {
 				$this->update_stripe_payment_intent(
 					$request->get_param( 'payment_intent_id' ),
 					$cart_total->get_raw_value()->get_as_integer()
@@ -476,7 +476,6 @@ class Coupons extends Base_API {
 				'description' => esc_html__( 'The Stripe payment intent to apply the coupon to.', 'event-tickets' ),
 				'type'        => 'string',
 				'format'      => 'text-field',
-				'required'    => $this->is_using_stripe(),
 			],
 			'purchaser_data'    => [
 				'description'       => esc_html__( 'The purchaser data.', 'event-tickets' ),

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/Stripe/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/Stripe/Coupons.php
@@ -9,11 +9,16 @@ declare( strict_types=1 );
 
 namespace TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\Stripe;
 
+use Closure;
 use Exception;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\StellarWP\Assets\Asset;
 use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Checkout;
+use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
 use TEC\Tickets\Commerce\Order_Modifiers\Models\Coupon;
 use TEC\Tickets\Commerce\Utils\Value;
+use Tribe__Assets;
 use WP_Post;
 
 /**
@@ -44,6 +49,12 @@ class Coupons extends Controller_Contract {
 			10,
 			2
 		);
+
+		add_action(
+			'tec-tickets-commerce-checkout-shortcode-assets',
+			[ $this, 'adjust_stripe_asset_enqueue_condition' ],
+			1
+		);
 	}
 
 	/**
@@ -64,6 +75,12 @@ class Coupons extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_commerce_stripe_update_payment_intent_metadata',
 			[ $this, 'add_meta_data_to_stripe' ]
+		);
+
+		remove_action(
+			'tec-tickets-commerce-checkout-shortcode-assets',
+			[ $this, 'adjust_stripe_asset_enqueue_condition' ],
+			1
 		);
 	}
 
@@ -155,5 +172,74 @@ class Coupons extends Controller_Contract {
 		}
 
 		return $metadata;
+	}
+
+	/**
+	 * Adjusts the condition for enqueuing the Stripe checkout asset.
+	 *
+	 * This is necessary because the normal logic for enqueueing the asset is based (in part)
+	 * on the value of the cart. If the cart total is zero, the asset is not enqueued. However,
+	 * we still want to enqueue the asset if a coupon is present, even if the cart total is zero.
+	 * This is because the customer could need to remove the coupon, and we still rely on the
+	 * Payment Intent data from the Stripe checkout asset for that functionality.
+	 *
+	 * @see \TEC\Tickets\Commerce\Gateways\Stripe\Assets::should_enqueue_assets()
+	 * @since 5.21.0
+	 *
+	 * @return void
+	 */
+	public function adjust_stripe_asset_enqueue_condition() {
+		// Only change the enqueue condition if the cart has a coupon present.
+		$cart = tribe( Cart::class )->get_repository();
+		if ( empty( $cart->get_items_in_cart( false, 'coupon' ) ) ) {
+			return;
+		}
+
+		/** @var Asset $asset */
+		$asset = Tribe__Assets::instance()->get( 'tec-tickets-commerce-gateway-stripe-checkout' );
+
+		// If for some reason we didn't get an asset back, we can't do anything.
+		if ( ! $asset instanceof Asset ) {
+			return;
+		}
+
+		// If the original condition would return true, we don't need to change it.
+		$original_condition = $asset->get_condition();
+		if ( is_callable( $original_condition ) && $original_condition() ) {
+			return;
+		}
+
+		// Set the new condition for enqueuing the asset.
+		$asset->set_condition(
+			function(): bool {
+				// If it's not the checkout page, we don't need to enqueue the asset.
+				if ( ! tribe( Checkout::class )->is_current_page() ) {
+					return false;
+				}
+
+				// If the gateway is not enabled, we don't need to enqueue the asset.
+				if ( ! tribe_is_truthy( tribe_get_option( Gateway::get_enabled_option_key() ) ) ) {
+					return false;
+				}
+
+				/** @var Gateway $gateway */
+				$gateway = tribe( Gateway::class );
+
+				// Define our own "is_active()" method to avoid calling should_show().
+				$is_active = Closure::bind(
+					function() {
+						return tribe( static::$merchant )->is_active();
+					},
+					$gateway,
+					$gateway
+				);
+
+				if ( ! $is_active() ) {
+					return false;
+				}
+
+				return true;
+			}
+		);
 	}
 }

--- a/tests/order_modifiers_integration/API/Coupons_Test.php
+++ b/tests/order_modifiers_integration/API/Coupons_Test.php
@@ -4,6 +4,7 @@ namespace TEC\Tickets\Commerce\Order_Modifiers\API;
 
 use Closure;
 use Generator;
+use PHPUnit\Framework\Assert;
 use TEC\Common\Tests\Provider\Controller_Test_Case;
 use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Cart\Abstract_Cart;
@@ -35,8 +36,8 @@ class Coupons_Test extends Controller_Test_Case {
 	 */
 	public function it_should_provide_expected_responses( Closure $fixture, ?Closure $post_checks = null ) {
 		$this->make_controller()->register();
-		[ $path, $should_fail, $method, $data ] = $fixture();
-		$result = $this->assert_endpoint( $path, $method, $should_fail, $data, 401 );
+		[ $path, $should_fail, $method, $data, $code ] = $fixture();
+		$result = $this->assert_endpoint( $path, $method, $should_fail, $data, $code );
 
 		if ( null !== $post_checks ) {
 			$post_checks( $result );
@@ -46,13 +47,14 @@ class Coupons_Test extends Controller_Test_Case {
 	public function rest_endpoints_data_provider(): Generator {
 		yield 'coupons archive -> unauthorized' => [
 			function () {
-				$coupons = $this->create_data();
+				$this->create_data();
 
 				return [
 					'/coupons',
 					true,
 					'GET',
 					[],
+					401,
 				];
 			},
 		];
@@ -68,8 +70,9 @@ class Coupons_Test extends Controller_Test_Case {
 
 		yield 'apply coupon -> valid response' => [
 			function () use ( $coupon_15_percent ) {
+				$coupon_15_percent( true );
 				$cart = $this->set_up_cart_with_ticket();
-				$this->assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
+				Assert::assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
 
 				// Set up the fake payment intent update handler.
 				$this->set_class_fn_return( Payment_Intent::class, 'update', true );
@@ -83,6 +86,7 @@ class Coupons_Test extends Controller_Test_Case {
 						'cart_hash'         => $cart->get_hash(),
 						'payment_intent_id' => 'fake-payment-intent-id',
 					],
+					200,
 				];
 			},
 			function ( Response $response ) use ( $coupon_15_percent ) {
@@ -90,23 +94,23 @@ class Coupons_Test extends Controller_Test_Case {
 				/** @var Abstract_Cart $cart */
 				$cart = tribe( Cart::class )->get_repository();
 
-				$this->assertCount( 2, $cart->get_items_in_cart( false, 'all' ) );
-				$this->assertCount( 1, $cart->get_items_in_cart( false, 'coupon' ) );
+				Assert::assertCount( 2, $cart->get_items_in_cart( false, 'all' ) );
+				Assert::assertCount( 1, $cart->get_items_in_cart( false, 'coupon' ) );
 
 				// Check that the response has the correct data.
 				$data = $response->get_data();
-				$this->assertArrayHasKey( 'success', $data );
-				$this->assertArrayHasKey( 'discount', $data );
-				$this->assertArrayHasKey( 'label', $data );
-				$this->assertArrayHasKey( 'message', $data );
-				$this->assertArrayHasKey( 'cartAmount', $data );
-				$this->assertArrayHasKey( 'doReload', $data );
+				Assert::assertArrayHasKey( 'success', $data );
+				Assert::assertArrayHasKey( 'discount', $data );
+				Assert::assertArrayHasKey( 'label', $data );
+				Assert::assertArrayHasKey( 'message', $data );
+				Assert::assertArrayHasKey( 'cartAmount', $data );
+				Assert::assertArrayHasKey( 'doReload', $data );
 
 				// Check that the data has been generated correctly.
-				$this->assertTrue( $data['success'] );
-				$this->assertSame( '- $1.50', $data['discount'] );
-				$this->assertSame( $coupon_15_percent()->slug, $data['label'] );
-				$this->assertSame(
+				Assert::assertTrue( $data['success'] );
+				Assert::assertSame( '- $1.50', $data['discount'] );
+				Assert::assertSame( $coupon_15_percent()->slug, $data['label'] );
+				Assert::assertSame(
 					esc_html(
 						sprintf(
 							'Coupon "%s" applied successfully.',
@@ -115,7 +119,7 @@ class Coupons_Test extends Controller_Test_Case {
 					),
 					$data['message']
 				);
-				$this->assertSame(
+				Assert::assertSame(
 					Currency_Value::create_from_float( $cart->get_cart_total() )->get(),
 					$data['cartAmount']
 				);
@@ -124,9 +128,10 @@ class Coupons_Test extends Controller_Test_Case {
 
 		yield 'Remove coupon – valid response' => [
 			function () use ( $coupon_15_percent ) {
+				$coupon_15_percent( true );
 				$cart = $this->set_up_cart_with_ticket();
-				$coupon_15_percent( true )->add_to_cart( $cart );
-				$this->assertCount( 1, $cart->get_items_in_cart( false, 'coupon' ) );
+				$coupon_15_percent()->add_to_cart( $cart );
+				Assert::assertCount( 1, $cart->get_items_in_cart( false, 'coupon' ) );
 
 				// Set up the fake payment intent update handler.
 				$this->set_class_fn_return( Payment_Intent::class, 'update', true );
@@ -140,6 +145,7 @@ class Coupons_Test extends Controller_Test_Case {
 						'cart_hash'         => $cart->get_hash(),
 						'payment_intent_id' => 'fake-payment-intent-id',
 					],
+					200,
 				];
 			},
 			function ( Response $response ) use ( $coupon_15_percent ) {
@@ -147,19 +153,19 @@ class Coupons_Test extends Controller_Test_Case {
 				/** @var Abstract_Cart $cart */
 				$cart = tribe( Cart::class )->get_repository();
 
-				$this->assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
-				$this->assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
+				Assert::assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
+				Assert::assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
 
 				// Check that the response has the correct data.
 				$data = $response->get_data();
-				$this->assertArrayHasKey( 'success', $data );
-				$this->assertArrayHasKey( 'message', $data );
-				$this->assertArrayHasKey( 'cartAmount', $data );
-				$this->assertArrayHasKey( 'doReload', $data );
+				Assert::assertArrayHasKey( 'success', $data );
+				Assert::assertArrayHasKey( 'message', $data );
+				Assert::assertArrayHasKey( 'cartAmount', $data );
+				Assert::assertArrayHasKey( 'doReload', $data );
 
 				// Check that the data has been generated correctly.
-				$this->assertTrue( $data['success'] );
-				$this->assertSame(
+				Assert::assertTrue( $data['success'] );
+				Assert::assertSame(
 					esc_html(
 						sprintf(
 							'Coupon "%s" removed successfully.',
@@ -168,10 +174,32 @@ class Coupons_Test extends Controller_Test_Case {
 					),
 					$data['message']
 				);
-				$this->assertSame(
+				Assert::assertSame(
 					Currency_Value::create_from_float( $cart->get_cart_total() )->get(),
 					$data['cartAmount']
 				);
+			},
+		];
+
+		yield 'It should not error with no payment intent' => [
+			function () use ( $coupon_15_percent ) {
+				$coupon_15_percent( true );
+				$cart = $this->set_up_cart_with_ticket();
+				Assert::assertCount( 0, $cart->get_items_in_cart( false, 'coupon' ) );
+
+				$coupon_15_percent()->add_to_cart( $cart );
+				Assert::assertCount( 1, $cart->get_items_in_cart( false, 'coupon' ) );
+
+				return [
+					'/coupons/apply',
+					false,
+					'POST',
+					[
+						'coupon'    => $coupon_15_percent()->slug,
+						'cart_hash' => $cart->get_hash(),
+					],
+					200,
+				];
 			},
 		];
 	}
@@ -189,7 +217,7 @@ class Coupons_Test extends Controller_Test_Case {
 		// Create 10 more coupons that are percentage discounts.
 		$coupons = array_merge( $coupons, $this->create_coupons( 10 ) );
 
-		$this->assertSame( 20, count( $coupons ) );
+		Assert::assertSame( 20, count( $coupons ) );
 
 		// Sanity check: Ensure that querying the DB shows the same number.
 		$repo   = tribe( CouponsRepository::class );
@@ -200,7 +228,7 @@ class Coupons_Test extends Controller_Test_Case {
 			false
 		);
 
-		$this->assertSame( 20, count( $result ) );
+		Assert::assertSame( 20, count( $result ) );
 
 		return $coupons;
 	}
@@ -210,22 +238,22 @@ class Coupons_Test extends Controller_Test_Case {
 		string $method = Server::READABLE,
 		bool $should_fail = false,
 		array $data = [],
-		int $error_code = 400
+		int $response_code = 400
 	) {
 		$response = $this->do_rest_api_request( $path, $method, $data );
 
 		if ( $should_fail ) {
-			$this->assertTrue( $response->is_error(), "Expected an error response for path: {$path}" );
-			$this->assertInstanceof( WP_Error::class, $response->as_error() );
-			$this->assertSame( $error_code, $response->get_status() );
+			Assert::assertTrue( $response->is_error(), "Expected an error response for path: {$path}" );
+			Assert::assertInstanceof( WP_Error::class, $response->as_error() );
+			Assert::assertSame( $response_code, $response->get_status() );
 
 			return $response;
 		}
 
-		$this->assertGreaterThanOrEqual( 200, $response->get_status(), 'A response code should be returned >= 200' );
-		$this->assertLessThan( 300, $response->get_status(), 'A response code should be returned < 300' );
-		$this->assertFalse( $response->is_error(), "Expected a successful response for path: {$path}" );
-		$this->assertNull( $response->as_error() );
+		Assert::assertGreaterThanOrEqual( 200, $response->get_status(), 'A response code should be returned >= 200' );
+		Assert::assertSame( $response_code, $response->get_status(), "A {$response_code} response code should be returned" );
+		Assert::assertFalse( $response->is_error(), "Expected a successful response for path: {$path}" );
+		Assert::assertNull( $response->as_error() );
 
 		return $response;
 	}
@@ -261,7 +289,7 @@ class Coupons_Test extends Controller_Test_Case {
 		$cart = $commerce_cart->get_repository();
 		$cart->upsert_item( $ticket, 1 );
 
-		$this->assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
+		Assert::assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );
 
 		return $cart;
 	}


### PR DESCRIPTION
- **Update API to only trigger Payment Intent update when we have the ID**
- **Update tests to ensure no error is thrown when Payment Intent isn't provided**
- **Add custom conditional for the Stripe JS asset**
