### PR TITLE
Fix input display for pecent to use correct thousand/decimal settings

### DIFF
--- a/changelog/fix-percent-input-display
+++ b/changelog/fix-percent-input-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the input field for Fees (and Coupons) when the type is Percent and the thousands/decimal separators are set to "." and ","

--- a/src/Tickets/Commerce/Order_Modifiers/Controller.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Controller.php
@@ -34,6 +34,7 @@ use TEC\Tickets\Commerce\Order_Modifiers\Table_Views\Coupon_Table;
 use TEC\Tickets\Commerce\Order_Modifiers\Table_Views\Fee_Table;
 use TEC\Tickets\Commerce\Order_Modifiers\Traits\Valid_Types;
 use TEC\Tickets\Commerce\Values\Currency_Value;
+use TEC\Tickets\Commerce\Values\Percent_Value;
 use TEC\Tickets\Commerce\Values\Precision_Value;
 use TEC\Tickets\Commerce\Utils\Currency;
 use Tribe__Tickets__Main as Tickets_Plugin;
@@ -149,11 +150,19 @@ final class Controller extends Controller_Contract {
 				break;
 		}
 
+		$thousands_separator = Currency::get_currency_separator_thousands( $currency_code );
+		$decimal_separator   = Currency::get_currency_separator_decimal( $currency_code );
+
 		Currency_Value::set_defaults(
 			Currency::get_currency_symbol( $currency_code ),
-			Currency::get_currency_separator_thousands( $currency_code ),
-			Currency::get_currency_separator_decimal( $currency_code ),
+			$thousands_separator,
+			$decimal_separator,
 			$currency_symbol_position
+		);
+
+		Percent_Value::set_defaults(
+			$thousands_separator,
+			$decimal_separator
 		);
 
 		Precision_Value::set_default_precision( (int) Currency::get_currency_precision( $currency_code ) );

--- a/src/Tickets/Commerce/Values/Currency_Value.php
+++ b/src/Tickets/Commerce/Values/Currency_Value.php
@@ -16,6 +16,8 @@ namespace TEC\Tickets\Commerce\Values;
  */
 class Currency_Value extends Base_Value {
 
+	use Digit_Separators;
+
 	/**
 	 * The currency symbol.
 	 *
@@ -31,20 +33,6 @@ class Currency_Value extends Base_Value {
 	protected $currency_symbol_position;
 
 	/**
-	 * The decimal separator.
-	 *
-	 * @var string
-	 */
-	protected $decimal_separator;
-
-	/**
-	 * The thousands separator.
-	 *
-	 * @var string
-	 */
-	protected $thousands_separator;
-
-	/**
 	 * The value.
 	 *
 	 * @var Precision_Value
@@ -58,8 +46,6 @@ class Currency_Value extends Base_Value {
 	 */
 	protected static array $defaults = [
 		'currency_symbol'          => '$',
-		'thousands_separator'      => ',',
-		'decimal_separator'        => '.',
 		'currency_symbol_position' => 'before',
 	];
 
@@ -105,12 +91,7 @@ class Currency_Value extends Base_Value {
 			$prefix = '';
 		}
 
-		$formatted = number_format(
-			$value->get(),
-			$value->get_precision(),
-			$this->decimal_separator,
-			$this->thousands_separator
-		);
+		$formatted = $this->get_formatted_number( $value->get(), $value->get_precision() );
 
 		switch ( $this->currency_symbol_position ) {
 			case 'after':
@@ -160,8 +141,8 @@ class Currency_Value extends Base_Value {
 		return new self(
 			$value,
 			$currency_symbol ?? self::$defaults['currency_symbol'],
-			$thousands_separator ?? self::$defaults['thousands_separator'],
-			$decimal_separator ?? self::$defaults['decimal_separator'],
+			$thousands_separator ?? self::$separator_defaults['thousands_separator'],
+			$decimal_separator ?? self::$separator_defaults['decimal_separator'],
 			$currency_symbol_position ?? self::$defaults['currency_symbol_position']
 		);
 	}
@@ -201,11 +182,11 @@ class Currency_Value extends Base_Value {
 		?string $currency_symbol_position = null
 	) {
 		self::$defaults = [
-			'currency_symbol'          => $currency_symbol ?? '$',
-			'thousands_separator'      => $thousands_separator ?? ',',
-			'decimal_separator'        => $decimal_separator ?? '.',
-			'currency_symbol_position' => $currency_symbol_position ?? 'before',
+			'currency_symbol'          => $currency_symbol ?? self::$defaults['currency_symbol'],
+			'currency_symbol_position' => $currency_symbol_position ?? self::$defaults['currency_symbol_position'],
 		];
+
+		self::set_separator_defaults( $decimal_separator, $thousands_separator );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Values/Digit_Separators.php
+++ b/src/Tickets/Commerce/Values/Digit_Separators.php
@@ -63,7 +63,7 @@ trait Digit_Separators {
 	 *
 	 * @return void
 	 */
-	static function set_separator_defaults(
+	protected static function set_separator_defaults(
 		?string $decimal_separator = null,
 		?string $thousands_separator = null
 	) {

--- a/src/Tickets/Commerce/Values/Digit_Separators.php
+++ b/src/Tickets/Commerce/Values/Digit_Separators.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Digit Separators trait.
+ *
+ * @since 5.21.0
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Tickets\Commerce\Values;
+
+/**
+ * Trait Digit_Separators
+ *
+ * @since 5.21.0
+ */
+trait Digit_Separators {
+
+	/**
+	 * The decimal separator.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @var string
+	 */
+	protected $decimal_separator;
+
+	/**
+	 * The thousands separator.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @var string
+	 */
+	protected $thousands_separator;
+
+	/**
+	 * The value.
+	 *
+	 * @var Precision_Value
+	 */
+	protected $value;
+
+	/**
+	 * Default values.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @var array
+	 */
+	protected static array $separator_defaults = [
+		'decimal_separator'   => '.',
+		'thousands_separator' => ',',
+	];
+
+	/**
+	 * Set the default decimal and thousands separators.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @param ?string $decimal_separator   The decimal separator.
+	 * @param ?string $thousands_separator The thousands separator.
+	 *
+	 * @return void
+	 */
+	static function set_separator_defaults(
+		?string $decimal_separator = null,
+		?string $thousands_separator = null
+	) {
+		self::$separator_defaults = [
+			'decimal_separator'   => $decimal_separator ?? self::$separator_defaults['decimal_separator'],
+			'thousands_separator' => $thousands_separator ?? self::$separator_defaults['thousands_separator'],
+		];
+	}
+
+	/**
+	 * Get a number formatted with the decimal and thousands separators.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @param float $number    The number to format.
+	 * @param int   $precision The number of decimal places to include.
+	 *
+	 * @return string
+	 */
+	protected function get_formatted_number( float $number, int $precision ): string {
+		return number_format( $number, $precision, $this->decimal_separator, $this->thousands_separator );
+	}
+}

--- a/src/Tickets/Commerce/Values/Percent_Value.php
+++ b/src/Tickets/Commerce/Values/Percent_Value.php
@@ -18,6 +18,8 @@ use InvalidArgumentException;
  */
 class Percent_Value extends Precision_Value {
 
+	use Digit_Separators;
+
 	/**
 	 * Minimum number a percentage can be.
 	 *
@@ -33,15 +35,24 @@ class Percent_Value extends Precision_Value {
 	 *
 	 * @since 5.18.0
 	 *
-	 * @param float|int|string $value The value to store. Can be a float, int, or numeric string. The
-	 *                                value will be divided by 100 to convert it to a percentage.
+	 * @param float|int|string $value               The value to store. Can be a float, int, or numeric string. The
+	 *                                              value will be divided by 100 to convert it to a percentage.
+	 * @param ?string          $thousands_separator The thousands separator.
+	 * @param ?string          $decimal_separator   The decimal separator.
 	 *
 	 * @throws InvalidArgumentException When the value is not numeric, or it is too small.
 	 */
-	public function __construct( $value ) {
+	public function __construct(
+		$value,
+		?string $thousands_separator = null,
+		?string $decimal_separator = null
+	) {
 		$value = Float_Value::from_number( $value )->get() / 100;
 		parent::__construct( $value, 4 );
 		$this->validate_minimum_value();
+
+		$this->thousands_separator = $thousands_separator ?? self::$separator_defaults['thousands_separator'];
+		$this->decimal_separator   = $decimal_separator ?? self::$separator_defaults['decimal_separator'];
 	}
 
 	/**
@@ -107,5 +118,22 @@ class Percent_Value extends Precision_Value {
 				sprintf( 'Percent value cannot be smaller than %.4f (%.2f%%).', $this->min_threshold, $this->min_threshold * 100 )
 			);
 		}
+	}
+
+	/**
+	 * Set the default decimal and thousands separators.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @param ?string $thousands_separator The thousands separator.
+	 * @param ?string $decimal_separator   The decimal separator.
+	 *
+	 * @return void
+	 */
+	public static function set_defaults(
+		?string $thousands_separator = null,
+		?string $decimal_separator = null
+	) {
+		self::set_separator_defaults( $decimal_separator, $thousands_separator );
 	}
 }

--- a/src/Tickets/Commerce/Values/Percent_Value.php
+++ b/src/Tickets/Commerce/Values/Percent_Value.php
@@ -95,8 +95,6 @@ class Percent_Value extends Precision_Value {
 	/**
 	 * The __toString method allows a class to decide how it will react when it is converted to a string.
 	 *
-	 * @todo: Allow for locale-specific formatting.
-	 *
 	 * @since 5.18.0
 	 *
 	 * @return string The value as a string.

--- a/src/Tickets/Commerce/Values/Percent_Value.php
+++ b/src/Tickets/Commerce/Values/Percent_Value.php
@@ -89,7 +89,7 @@ class Percent_Value extends Precision_Value {
 	 * @return string
 	 */
 	public function get_as_string(): string {
-		return sprintf( '%02.2F%%', $this->get_as_percent() );
+		return "{$this->get_formatted_number( $this->get_as_percent(), 2 )}%";
 	}
 
 	/**

--- a/tests/wpunit/TEC/Tickets/Order_Modifiers/Values/Currency_Value_Test.php
+++ b/tests/wpunit/TEC/Tickets/Order_Modifiers/Values/Currency_Value_Test.php
@@ -29,7 +29,12 @@ class Currency_Value_Test extends WPTestCase {
 		$this->assertEquals( '1.000,00¢', $currency_value->get() );
 		$this->assertEquals( '1.000,00¢', (string) $currency_value );
 
-		Currency_Value::set_defaults();
+		Currency_Value::set_defaults(
+			'$',
+			',',
+			'.',
+			'before'
+		);
 
 		$currency_value = Currency_Value::create( new Precision_Value( 100 ) );
 		$this->assertEquals( '$100.00', $currency_value->get() );


### PR DESCRIPTION
### 🎫 Ticket

QA issue `041`

### 🗒️ Description

This fixes the display and handling of Percent values in the "Amount" input field for Coupons and Fees. Previously, if the site settings use `,` for the decimal separator instead of `.`, the amount will not render correctly. For example, a `10%` value entered would be converted to `1000%` after saving.

The reason for this behavior is because the `Percent_Value` class wasn't handling number formats correctly, and was instead *always* using a `.` for the decimal separator (and `,` for the thousands separator).

This PR does the following to fix this issue:

1. Adds a new `Digit_Separators` trait that can be used across value classes
1. Applies the `Digit_Separators` trait to both `Currency_Value` and `Percent_Value`
1. Updates the `get_as_string()` method in `Percent_Value` to use the corrected format.
1. Updates the controller that sets the default values for thousands and decimal separators.
1. Adds new unit tests that cover the changes

### 🎥 Artifacts <!-- if applicable-->

#### Before

https://github.com/user-attachments/assets/19f0064f-f094-43a6-84e6-fdc2f97086ff

#### After

https://github.com/user-attachments/assets/39306bac-a6f4-4815-96fd-21911cafb987


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
