### PR TITLE
Update the position of the coupon field in checkout

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
@@ -59,7 +59,7 @@ class Coupons extends Controller_Contract {
 		add_action(
 			'tec_tickets_commerce_checkout_cart_before_footer_quantity',
 			[ $this, 'display_coupon_section' ],
-			20,
+			40,
 			3
 		);
 

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
@@ -98,7 +98,7 @@ class Coupons extends Controller_Contract {
 		remove_action(
 			'tec_tickets_commerce_checkout_cart_before_footer_quantity',
 			[ $this, 'display_coupon_section' ],
-			20
+			40
 		);
 
 		remove_filter(

--- a/src/resources/postcss/tickets-commerce/_checkout.pcss
+++ b/src/resources/postcss/tickets-commerce/_checkout.pcss
@@ -397,6 +397,8 @@
 	}
 
 	.tec-tickets-commerce-checkout-cart__coupons {
+		padding-bottom: var(--tec-spacer-0);
+		padding-top: var(--tec-spacer-3);
 		text-align: right;
 
 		.tec-tickets-commerce-checkout-cart__coupons-input-error {

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -278,51 +278,7 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
-	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
-		Add coupon code	</button>
-	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
-		<input
-			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
-			type="text"
-			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
-			name="coupons"
-			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
-			aria-label="Enter coupon code"
-			placeholder="Enter coupon code"
-			value=""
-		/>
-		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
-			Apply		</button>
-	</div>
-	<p
-		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
-		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
-		aria-live="polite"
-		role="alert"
-	>
-		Invalid coupon code	</p>
-	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
-		<ul>
-			<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
-					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
-											</span>
-					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
-						<img
-							src="https://example.com/images/icons/close.svg"
-							alt="Icon to remove coupon"
-							title="Remove coupon"
-						>
-					</button>
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
-									</span>
-			</li>
-		</ul>
-	</div>
-</div>
-
+	
 <div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
 	<ul>
 					<li>
@@ -392,6 +348,50 @@
 					$4.68				</span>
 			</li>
 			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
+		<input
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
+			type="text"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
+			name="coupons"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
+			aria-label="Enter coupon code"
+			placeholder="Enter coupon code"
+			value=""
+		/>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
+			Apply		</button>
+	</div>
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
+		Invalid coupon code	</p>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
+		<ul>
+			<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
+											</span>
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
+						<img
+							src="https://example.com/images/icons/close.svg"
+							alt="Icon to remove coupon"
+							title="Remove coupon"
+						>
+					</button>
+				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
+									</span>
+			</li>
+		</ul>
+	</div>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">20</span></div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -278,51 +278,7 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
-	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
-		Add coupon code	</button>
-	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
-		<input
-			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
-			type="text"
-			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
-			name="coupons"
-			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
-			aria-label="Enter coupon code"
-			placeholder="Enter coupon code"
-			value=""
-		/>
-		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
-			Apply		</button>
-	</div>
-	<p
-		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
-		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
-		aria-live="polite"
-		role="alert"
-	>
-		Invalid coupon code	</p>
-	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
-		<ul>
-			<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
-					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
-											</span>
-					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
-						<img
-							src="https://example.com/images/icons/close.svg"
-							alt="Icon to remove coupon"
-							title="Remove coupon"
-						>
-					</button>
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
-									</span>
-			</li>
-		</ul>
-	</div>
-</div>
-
+	
 <div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
 	<ul>
 					<li>
@@ -392,6 +348,50 @@
 					$6.00				</span>
 			</li>
 			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
+		<input
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
+			type="text"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
+			name="coupons"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
+			aria-label="Enter coupon code"
+			placeholder="Enter coupon code"
+			value=""
+		/>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
+			Apply		</button>
+	</div>
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
+		Invalid coupon code	</p>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
+		<ul>
+			<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
+											</span>
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
+						<img
+							src="https://example.com/images/icons/close.svg"
+							alt="Icon to remove coupon"
+							title="Remove coupon"
+						>
+					</button>
+				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
+									</span>
+			</li>
+		</ul>
+	</div>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">20</span></div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -78,7 +78,18 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	
+<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
+	<ul>
+					<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
+					test fee 1 (3x):				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+					$15.00				</span>
+			</li>
+			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
 	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
 		Add coupon code	</button>
 	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
@@ -121,17 +132,6 @@
 			</li>
 		</ul>
 	</div>
-</div>
-
-<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
-	<ul>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1 (3x):				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$15.00				</span>
-			</li>
-			</ul>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">3</span></div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -78,7 +78,18 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	
+<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
+	<ul>
+					<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
+					test fee 1 (3x):				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+					$6.00				</span>
+			</li>
+			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
 	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
 		Add coupon code	</button>
 	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
@@ -121,17 +132,6 @@
 			</li>
 		</ul>
 	</div>
-</div>
-
-<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
-	<ul>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1 (3x):				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.00				</span>
-			</li>
-			</ul>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">3</span></div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -78,7 +78,18 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	
+<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
+	<ul>
+					<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
+					test fee 1 (2x):				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+					$6.00				</span>
+			</li>
+			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
 	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
 		Add coupon code	</button>
 	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
@@ -121,17 +132,6 @@
 			</li>
 		</ul>
 	</div>
-</div>
-
-<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
-	<ul>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1 (2x):				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$6.00				</span>
-			</li>
-			</ul>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">2</span></div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -78,7 +78,18 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	
+<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
+	<ul>
+					<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
+					test fee 1 (2x):				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
+					$20.00				</span>
+			</li>
+			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
 	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
 		Add coupon code	</button>
 	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
@@ -121,17 +132,6 @@
 			</li>
 		</ul>
 	</div>
-</div>
-
-<div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
-	<ul>
-					<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">
-					test fee 1 (2x):				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">
-					$20.00				</span>
-			</li>
-			</ul>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">2</span></div>

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
@@ -228,51 +228,7 @@
 
 	
 <footer  class="tribe-tickets__commerce-checkout-cart-footer tribe-common-b1" >
-	<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
-	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
-		Add coupon code	</button>
-	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
-		<input
-			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
-			type="text"
-			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
-			name="coupons"
-			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
-			aria-label="Enter coupon code"
-			placeholder="Enter coupon code"
-			value=""
-		/>
-		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
-			Apply		</button>
-	</div>
-	<p
-		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
-		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
-		aria-live="polite"
-		role="alert"
-	>
-		Invalid coupon code	</p>
-	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
-		<ul>
-			<li>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
-					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
-											</span>
-					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
-						<img
-							src="https://example.com/images/icons/close.svg"
-							alt="Icon to remove coupon"
-							title="Remove coupon"
-						>
-					</button>
-				</span>
-				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
-									</span>
-			</li>
-		</ul>
-	</div>
-</div>
-
+	
 <div class="tribe-tickets__commerce-checkout-cart-footer-order-modifier-fees">
 	<ul>
 					<li>
@@ -330,6 +286,50 @@
 					$6.00				</span>
 			</li>
 			</ul>
+</div>
+<div class="tribe-common-b2 tribe-tickets__form tec-tickets-commerce-checkout-cart__coupons">
+	<button  class="tec-tickets-commerce-checkout-cart__coupons-add-link" >
+		Add coupon code	</button>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-input-container tribe-common-a11y-hidden" >
+		<input
+			class="tec-tickets-commerce-checkout-cart__coupons-input-field"
+			type="text"
+			id="tec-tickets-commerce-checkout-cart__coupon-input-field"
+			name="coupons"
+			aria-describedby="tec-tickets-commerce-checkout-cart__coupons-error-text"
+			aria-label="Enter coupon code"
+			placeholder="Enter coupon code"
+			value=""
+		/>
+		<button  class="tribe-common-c-btn-border tec-tickets-commerce-checkout-cart__coupons-apply-button" >
+			Apply		</button>
+	</div>
+	<p
+		id="tec-tickets-commerce-checkout-cart__coupons-error-text"
+		class="tec-tickets-commerce-checkout-cart__coupons-input-error tribe-common-a11y-hidden"
+		aria-live="polite"
+		role="alert"
+	>
+		Invalid coupon code	</p>
+	<div  class="tec-tickets-commerce-checkout-cart__coupons-applied-container tribe-common-a11y-hidden" >
+		<ul>
+			<li>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label tec-tickets-commerce-checkout-cart__coupons-applied-text">
+					<span class="tec-tickets-commerce-checkout-cart__coupons-applied-label">
+											</span>
+					<button class="tec-tickets-commerce-checkout-cart__coupons-remove-button" type="button">
+						<img
+							src="https://example.com/images/icons/close.svg"
+							alt="Icon to remove coupon"
+							title="Remove coupon"
+						>
+					</button>
+				</span>
+				<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number tec-tickets-commerce-checkout-cart__coupons-discount-amount">
+									</span>
+			</li>
+		</ul>
+	</div>
 </div>
 <div class="tribe-tickets__commerce-checkout-cart-footer-quantity">
 	<span class="tribe-tickets__commerce-checkout-cart-footer-quantity-label">Quantity: </span><span class="tribe-tickets__commerce-checkout-cart-footer-quantity-number">14</span></div>


### PR DESCRIPTION
### 🎫 Ticket

Related to QA `40`

### 🗒️ Description

This PR moves the position of the coupon input field in the checkout, and tweaks the styling to give it some more padding.

[skip-changelog] *No changelog needed; This is adjusting an unreleased feature.*

### 🎥 Artifacts <!-- if applicable-->

#### Before

https://github.com/user-attachments/assets/fc8c8e0c-985f-46da-9b21-b09d8a3dd21d


#### After

https://github.com/user-attachments/assets/6c82aa21-4833-4964-b52d-dece16446d15


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
