### PR TITLE
Limit percent coupons to 100%

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -173,10 +173,15 @@ class Modifier_Admin_Handler extends Controller_Contract {
 				'etOrderModifiersAmountField',
 				function () {
 					$code = Currency::get_currency_code();
+					$percent_max = 'coupon' === $this->get_modifier_type_from_request()
+						? 100
+						: 999999999;
+
 					return [
 						'currencySymbol'     => Currency::get_currency_symbol( $code ),
 						'decimalSeparator'   => Currency::get_currency_separator_decimal( $code ),
 						'thousandsSeparator' => Currency::get_currency_separator_thousands( $code ),
+						'percentMax'         => $percent_max,
 						'placement'          => Currency::get_currency_symbol_position( $code ),
 						'precision'          => Currency::get_currency_precision( $code ),
 					];

--- a/src/admin-views/order_modifiers/coupon-edit.php
+++ b/src/admin-views/order_modifiers/coupon-edit.php
@@ -95,7 +95,7 @@ $limit_error_text = __( 'Coupon Limit must be a positive number. Use 0 or leave 
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="<?php esc_attr_e( 'Amount is required', 'event-tickets' ); ?>"
+						data-validation-error="<?php esc_attr_e( 'Amount is required. A Percentage amount cannot be more than 100%.', 'event-tickets' ); ?>"
 						value="<?php echo esc_attr( (string) $order_modifier_amount ); ?>" />
 				</div>
 

--- a/src/resources/js/admin/order-modifiers/amount-field.js
+++ b/src/resources/js/admin/order-modifiers/amount-field.js
@@ -11,6 +11,7 @@
  * @type {string} currencySymbol     The currency symbol
  * @type {string} decimalSeparator   The decimal separator character
  * @type {string} thousandsSeparator The thousands separator character
+ * @type {string} percentMax         The maximum value for a percentage
  * @type {string} placement          Can be "prefix" or "postfix"
  * @type {number} precision          The number of decimal places to display
  */
@@ -19,6 +20,7 @@ window.etOrderModifiersAmountField = window.etOrderModifiersAmountField || {
 	currencySymbol: '$',
 	decimalSeparator: '.',
 	thousandsSeparator: ',',
+	percentMax: 999999999,
 	placement: 'prefix',
 	precision: 2,
 };
@@ -90,7 +92,11 @@ window.etOrderModifiersAmountField = window.etOrderModifiersAmountField || {
 		const $input = $( selectors.amount );
 		const asFloat = parseFloat( mask.unmaskedValue );
 
-		if ( ! isNaN( asFloat ) && asFloat > 0 ) {
+		// Set up the conditions to check if the value is valid.
+		const isFloatValid = ! isNaN( asFloat ) && asFloat > 0;
+		const isPercentValid = 'percent' === getType() && asFloat <= parseFloat( i18n.percentMax );
+
+		if ( isFloatValid && isPercentValid ) {
 			$input.removeClass( validation.selectors.error.className() );
 			$input.val( asFloat );
 			return;

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Emojis in Name and Slug__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Emojis in Name and Slug__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="$15.00" />
 				</div>
 

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Excessively Large Amount__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Excessively Large Amount__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="$1,234,567.90" />
 				</div>
 

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Long Decimal Value__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Long Decimal Value__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="$1.01" />
 				</div>
 

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Special Characters__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Coupon - Special Characters__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="$5.00" />
 				</div>
 

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Flat Coupon__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Flat Coupon__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="$5.00" />
 				</div>
 

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Percent Coupon__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_correctly__Percent Coupon__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="10.00%" />
 				</div>
 

--- a/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_with_no_data__0.snapshot.html
+++ b/tests/order_modifiers_integration/Coupons/__snapshots__/Create_Coupon_Modifiers_Test__does_edit_screen_render_with_no_data__0.snapshot.html
@@ -53,7 +53,7 @@
 						name="order_modifier_amount"
 						id="order_modifier_amount"
 						class="tribe-field tec_order_modifier_amount_field"
-						data-validation-error="Amount is required"
+						data-validation-error="Amount is required. A Percentage amount cannot be more than 100%."
 						value="" />
 				</div>
 

--- a/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
+++ b/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
@@ -38,6 +38,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 	public function asset_data_provider() {
 		$assets = [
 			'tec-tickets-order-modifiers-table' => 'src/resources/js/admin/order-modifiers/table.js',
+			'tec-tickets-order-modifiers-amount-field-edit-js' => 'src/resources/js/admin/order-modifiers/amount-field.js',
 		];
 
 		foreach ( $assets as $slug => $path ) {
@@ -242,8 +243,8 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 				return [
 					'modifier_id'        => 99999,
 					'modifier_type'      => 'fee',
-					'expected_result'    => null, // No result expected.
-					'expected_exception' => Not_Found_Exception::class, // Exception expected.
+					'expected_result'    => null,
+					'expected_exception' => Not_Found_Exception::class,
 				];
 			},
 		];
@@ -262,8 +263,8 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 				return [
 					'modifier_id'        => $modifier->id,
 					'modifier_type'      => 'invalid-modifier',
-					'expected_result'    => null, // No result expected.
-					'expected_exception' => InvalidArgumentException::class, // Exception expected.
+					'expected_result'    => null,
+					'expected_exception' => InvalidArgumentException::class,
 				];
 			},
 		];
@@ -577,6 +578,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 				];
 			},
 		];
+
 		yield 'Missing display name' => [
 			function () {
 				return [
@@ -609,6 +611,25 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 					'nonce'          => 'valid_nonce',
 					'valid_nonce'    => true,
 					'expected_error' => 'The field "status" is required and cannot be empty.',
+				];
+			},
+		];
+
+		yield 'Invalid coupon percentage > 100' => [
+			function () {
+				return [
+					'post_data'      => [
+						'order_modifier_sub_type'     => 'percent',
+						'order_modifier_amount'       => '101',
+						'order_modifier_slug'         => 'test_slug_5',
+						'order_modifier_display_name' => 'Test 5 Coupon',
+						'order_modifier_status'       => 'active',
+						'order_modifier_form_save'    => true,
+						'modifier'                    => 'coupon',
+					],
+					'nonce'          => 'valid_nonce',
+					'valid_nonce'    => true,
+					'expected_error' => 'Percentage must be less than or equal to 100.',
 				];
 			},
 		];


### PR DESCRIPTION
### 🎫 Ticket

Related to QA item `#40`

### 🗒️ Description

This upates the validation logic for coupons. When a coupon is set to a percentage, it no longer allows for a value over 100%. This is handled both by JS validation and by PHP validation (in case the JS validation fails or is disabled somehow).

[skip-changelog] *No changelog needed; This is modifying an unreleased feature.*

### 🎥 Artifacts <!-- if applicable-->

#### Before

https://github.com/user-attachments/assets/149827a9-3a4c-42c9-a684-eff9f8465019

#### After

https://github.com/user-attachments/assets/2ed2d410-5f09-4a6c-afe3-04465163fec1

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
