### PR TITLE
Adjust how coupons are applied to include fees

### DIFF
--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -156,15 +156,20 @@ abstract class Abstract_Cart implements Cart_Interface {
 	 * @return array<string, mixed> List of items.
 	 */
 	public function get_items_in_cart( $full_item_params = false, string $type = 'ticket' ): array {
-		$items = $this->filter_items_by_type( $type );
+		// Get all of the items.
+		$items = $this->get_items();
+
+		// If we want the full params, add them.
+		if ( $full_item_params ) {
+			$items = $this->add_full_item_params( $items );
+		}
+
+		// Filter the items by type.
+		$items = $this->filter_items_by_type( $type, $items );
 
 		// When Items is empty in any capacity return an empty array.
 		if ( empty( $items ) ) {
 			return [];
-		}
-
-		if ( $full_item_params ) {
-			$items = $this->add_full_item_params( $items );
 		}
 
 		return array_filter( $items );

--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -120,7 +120,7 @@ abstract class Abstract_Cart implements Cart_Interface {
 	 * @return array<string, mixed> List of items.
 	 */
 	public function get_items_in_cart( $full_item_params = false, string $type = 'ticket' ): array {
-		$items = $this->get_items_by_type( $type );
+		$items = $this->filter_items_by_type( $type );
 
 		// When Items is empty in any capacity return an empty array.
 		if ( empty( $items ) ) {
@@ -412,24 +412,29 @@ abstract class Abstract_Cart implements Cart_Interface {
 	 *
 	 * @since 5.21.0
 	 *
-	 * @param string $type The type of item to get from the cart. Use 'all' to get all items.
+	 * @param string $type  The type of item to get from the item array. Use 'all' to get all items.
+	 * @param ?array $items The items to filter. If omitted, items will be retrieved from the cart.
 	 *
-	 * @return array The items in the cart.
+	 * @return array The filtered items.
 	 */
-	protected function get_items_by_type( string $type ): array {
-		$items = $this->get_items();
-
-		// Filter the items if we have something other than 'all' as the type.
-		if ( 'all' !== $type ) {
-			$items = array_filter(
-				$items,
-				static function ( $item ) use ( $type ) {
-					return $type === ( $item['type'] ?? 'ticket' );
-				}
-			);
+	protected function filter_items_by_type( string $type, ?array $items = null ): array {
+		// Get the items from the cart if they aren't provided.
+		if ( null === $items ) {
+			$items = $this->get_items();
 		}
 
-		return $items;
+		// If the type is 'all', then no filtering is needed.
+		if ( 'all' === $type ) {
+			return $items;
+		}
+
+		// Filter the items if we have something other than 'all' as the type.
+		return array_filter(
+			$items,
+			static function ( $item ) use ( $type ) {
+				return $type === ( $item['type'] ?? 'ticket' );
+			}
+		);
 	}
 
 	/**

--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -59,6 +59,24 @@ abstract class Abstract_Cart implements Cart_Interface {
 	protected $cart_hash;
 
 	/**
+	 * Array of items with full parameters available.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @var array
+	 */
+	protected array $full_param_items = [];
+
+	/**
+	 * Whether the items in the cart have full parameters.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @var bool
+	 */
+	protected bool $items_have_full_params = false;
+
+	/**
 	 * Whether the cart subtotal has been calculated.
 	 *
 	 * @since 5.21.0
@@ -331,7 +349,11 @@ abstract class Abstract_Cart implements Cart_Interface {
 	 * @return array The items in the cart with the full set of parameters.
 	 */
 	protected function add_full_item_params( array $items ): array {
-		return array_map(
+		if ( $this->items_have_full_params ) {
+			return $this->full_param_items;
+		}
+
+		$this->full_param_items = array_map(
 			static function ( $item ) {
 				// Try to get the ticket object, and if it's not valid, remove it from the cart.
 				$item['obj'] = Tickets::load_ticket_object( $item['ticket_id'] );
@@ -350,6 +372,10 @@ abstract class Abstract_Cart implements Cart_Interface {
 			},
 			$items
 		);
+
+		$this->items_have_full_params = true;
+
+		return $this->full_param_items;
 	}
 
 	/**
@@ -466,8 +492,9 @@ abstract class Abstract_Cart implements Cart_Interface {
 	 * @return void
 	 */
 	protected function reset_calculations() {
-		$this->subtotal_calculated = false;
-		$this->total_calculated    = false;
+		$this->items_have_full_params = false;
+		$this->subtotal_calculated    = false;
+		$this->total_calculated       = false;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -153,7 +153,8 @@ abstract class Abstract_Cart implements Cart_Interface {
 			return $this->cart_total->get();
 		}
 
-		$subtotal = new Precision_Value( $this->get_cart_subtotal() );
+		$subtotal  = new Precision_Value( $this->get_cart_subtotal() );
+		$all_items = $this->get_items_in_cart( true, 'all' );
 
 		/**
 		 * Filters the additional values in the cart in order to add additional fees or discounts.
@@ -171,7 +172,7 @@ abstract class Abstract_Cart implements Cart_Interface {
 		$additional_values = apply_filters(
 			'tec_tickets_commerce_get_cart_additional_values_total',
 			[],
-			$this->get_items_in_cart( true, 'all' ),
+			$all_items,
 			$subtotal
 		);
 
@@ -188,7 +189,7 @@ abstract class Abstract_Cart implements Cart_Interface {
 
 		// Get the items that have a dynamic subtotal.
 		$callable_items = array_filter(
-			$this->get_items_in_cart( true, 'all' ),
+			$all_items,
 			static fn( $item ) => is_callable( $item['sub_total'] )
 		);
 
@@ -269,7 +270,7 @@ abstract class Abstract_Cart implements Cart_Interface {
 		$additional_values = apply_filters(
 			'tec_tickets_commerce_get_cart_additional_values_subtotal',
 			[],
-			$this->get_items_in_cart( true, 'all' ),
+			$all_items,
 			$subtotal
 		);
 

--- a/src/Tickets/Commerce/Cart/Agnostic_Cart.php
+++ b/src/Tickets/Commerce/Cart/Agnostic_Cart.php
@@ -425,7 +425,11 @@ class Agnostic_Cart extends Abstract_Cart {
 	 * @return array The items in the cart with the full set of parameters.
 	 */
 	protected function add_full_item_params( array $items ): array {
-		return array_map(
+		if ( $this->items_have_full_params ) {
+			return $this->full_param_items;
+		}
+
+		$this->full_param_items = array_map(
 			function ( $item ) {
 				$type = $item['type'] ?? 'ticket';
 				switch ( $type ) {
@@ -452,6 +456,10 @@ class Agnostic_Cart extends Abstract_Cart {
 			},
 			$items
 		);
+
+		$this->items_have_full_params = true;
+
+		return $this->full_param_items;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Cart/Agnostic_Cart.php
+++ b/src/Tickets/Commerce/Cart/Agnostic_Cart.php
@@ -80,6 +80,11 @@ class Agnostic_Cart extends Abstract_Cart {
 	 * @param string $hash The hash to set.
 	 */
 	public function set_hash( $hash ) {
+		// If the cart hash matches what we already have, don't set it again.
+		if ( $this->get_hash() === $hash ) {
+			return;
+		}
+
 		parent::set_hash( $hash );
 		$this->load_items_from_transient();
 	}

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -405,9 +405,7 @@ abstract class Abstract_Fees extends Controller_Contract {
 		}
 
 		// Add the fee items to the other cart items.
-		$items = array_merge( $items, $fee_items );
-
-		return $items;
+		return array_merge( $items, $fee_items );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Abstract_Fees.php
@@ -147,23 +147,20 @@ abstract class Abstract_Fees extends Controller_Contract {
 	 * Calculates the fees and modifies the total value in the checkout process.
 	 *
 	 * @since 5.18.0
+	 * @since 5.21.0 Removed the $subtotal parameter.
 	 *
-	 * @param array $values   The existing values being passed through the filter.
-	 * @param array $items    The items in the cart.
-	 * @param Value $subtotal The list of subtotals from the items.
+	 * @param array $values The existing values being passed through the filter.
+	 * @param array $items  The items in the cart.
 	 *
-	 * @return array The updated total values, including the fees.
+	 * @return Precision_Value[] The updated total values, including the fees.
 	 */
-	public function calculate_fees( array $values, array $items, Value $subtotal ): array {
+	public function calculate_fees( array $values, array $items ): array {
 		$cache_key = 'calculate_fees_' . md5( wp_json_encode( $items ) );
 		$cache     = tribe_cache();
 
 		if ( ! empty( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) ) {
 			return $cache[ $cache_key ];
 		}
-
-		// Store the subtotal as a class property for later use, encapsulated as a Value object.
-
 
 		// Fetch the combined fees for the items in the cart.
 		$combined_fees = $this->get_combined_fees_for_items( $items );
@@ -173,10 +170,10 @@ abstract class Abstract_Fees extends Controller_Contract {
 		}
 
 		// Calculate the total fees based on each individual fee.
-		$sum_of_fees = $this->manager->calculate_total_fees( $combined_fees );
+		$fee_values = $this->manager->combine_total_fees( $combined_fees );
 
 		// Add the calculated fees to the total value.
-		$values[] = $sum_of_fees;
+		$values = array_merge( $values, $fee_values );
 
 		$cache[ $cache_key ] = $values;
 
@@ -345,13 +342,13 @@ abstract class Abstract_Fees extends Controller_Contract {
 	 * Adds fees as separate items in the cart.
 	 *
 	 * @since 5.18.0
+	 * @sicne 5.21.0 Removed the $subtotal parameter.
 	 *
-	 * @param array $items    The current items in the cart.
-	 * @param Value $subtotal The calculated subtotal of the cart items.
+	 * @param array $items The current items in the cart.
 	 *
 	 * @return array Updated list of items with fees added.
 	 */
-	public function append_fees_to_cart( array $items, Value $subtotal ) {
+	public function append_fees_to_cart( array $items ) {
 		if ( empty( $items ) ) {
 			return $items;
 		}

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
@@ -266,7 +266,7 @@ class Coupons extends Controller_Contract {
 
 		// Update the coupon values with the correct subtotals.
 		$coupons = $cart->update_items_with_subtotal(
-			$cart->get_items_in_cart( true, 'coupon' ),
+			$coupons,
 			Precision_Value::sum( ...$subtotals )->get(),
 		);
 

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Fees.php
@@ -35,10 +35,10 @@ class Fees extends Abstract_Fees {
 	public function do_register(): void {
 		// Hook for calculating total values, setting subtotal, and modifying the total value.
 		add_filter(
-			'tec_tickets_commerce_get_cart_additional_values',
+			'tec_tickets_commerce_get_cart_additional_values_total',
 			[ $this, 'calculate_fees' ],
 			10,
-			3
+			2
 		);
 
 		// Hook for displaying fees in the checkout.
@@ -58,9 +58,7 @@ class Fees extends Abstract_Fees {
 		// Append fee data to the cart.
 		add_filter(
 			'tec_tickets_commerce_create_order_from_cart_items',
-			[ $this, 'append_fees_to_cart' ],
-			10,
-			2
+			[ $this, 'append_fees_to_cart' ]
 		);
 	}
 
@@ -73,7 +71,7 @@ class Fees extends Abstract_Fees {
 	 */
 	public function unregister(): void {
 		remove_filter(
-			'tec_tickets_commerce_get_cart_additional_values',
+			'tec_tickets_commerce_get_cart_additional_values_total',
 			[ $this, 'calculate_fees' ]
 		);
 
@@ -90,7 +88,7 @@ class Fees extends Abstract_Fees {
 
 		remove_filter(
 			'tec_tickets_commerce_create_order_from_cart_items',
-			[ $this, 'append_fees_to_cart' ],
+			[ $this, 'append_fees_to_cart' ]
 		);
 	}
 

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/Stripe/Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/Stripe/Fees.php
@@ -87,9 +87,6 @@ class Fees extends Abstract_Fees {
 	 * @return Value Updated value including fees, or the original value if no fees exist.
 	 */
 	public function append_fees_to_cart_stripe( Value $value, array $items ): Value {
-		// Set the class-level subtotal to the current cart value.
-		$this->subtotal = $value;
-
 		// If no items exist in the cart, return the original value.
 		if ( empty( $items ) ) {
 			return $value;

--- a/src/Tickets/Commerce/Order_Modifiers/Models/Coupon.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Models/Coupon.php
@@ -62,7 +62,7 @@ class Coupon extends Order_Modifier {
 	 */
 	public function add_to_cart( Cart_Interface $cart, int $quantity = 1 ) {
 		$cart->upsert_item(
-			$this->get_unique_type_id( $this->id, 'coupon' ),
+			$this->get_type_id(),
 			$quantity,
 			[ 'type' => 'coupon' ]
 		);
@@ -78,6 +78,17 @@ class Coupon extends Order_Modifier {
 	 * @return void
 	 */
 	public function remove_from_cart( Cart_Interface $cart ) {
-		$cart->remove_item( $this->get_unique_type_id( $this->id, 'coupon' ) );
+		$cart->remove_item( $this->get_type_id() );
+	}
+
+	/**
+	 * Get the unique type ID for the coupon.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @return string The unique type ID.
+	 */
+	public function get_type_id(): string {
+		return $this->get_unique_type_id( $this->id, 'coupon' );
 	}
 }

--- a/src/Tickets/Commerce/Order_Modifiers/Models/Coupon.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Models/Coupon.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Commerce\Order_Modifiers\Models;
 
 use TEC\Tickets\Commerce\Cart\Cart_Interface;
 use TEC\Tickets\Commerce\Traits\Type;
+use TEC\Tickets\Commerce\Values\Float_Value;
 use TEC\Tickets\Commerce\Values\Precision_Value;
 
 /**
@@ -40,13 +41,15 @@ class Coupon extends Order_Modifier {
 	 */
 	public function get_discount_amount( float $subtotal ): float {
 		if ( 'flat' === $this->sub_type ) {
-			return -1 * $this->raw_amount;
+			/** @var Float_Value $amount */
+			$amount = $this->attributes['raw_amount'];
+			return $amount->invert_sign()->get();
 		}
 
 		$base_price = new Precision_Value( $subtotal );
 		$discount   = $base_price->multiply( $this->attributes['raw_amount'] );
 
-		return -1 * $discount->get();
+		return $discount->invert_sign()->get();
 	}
 
 	/**

--- a/src/Tickets/Commerce/Order_Modifiers/Modifiers/Modifier_Manager.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifiers/Modifier_Manager.php
@@ -166,14 +166,25 @@ class Modifier_Manager {
 	 * @return Value The total amount after fees are applied.
 	 */
 	public function calculate_total_fees( array $items ): Value {
-		$total_fees = new Precision_Value( 0.0 );
+		return Legacy_Value_Factory::to_legacy_value(
+			( new Precision_Value( 0.0 ) )->sum( ...$this->combine_total_fees( $items ) )
+		);
+	}
 
-		$all_fees = [];
-		foreach ( $items as $item ) {
-			$all_fees[] = $item['fee_amount'];
-		}
-
-		return Legacy_Value_Factory::to_legacy_value( $total_fees->sum( ...$all_fees ) );
+	/**
+	 * Get the combined fees for an array of items.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @param array $items The items in the cart.
+	 *
+	 * @return Precision_Value[] The combined fees for the items.
+	 */
+	public function combine_total_fees( array $items ): array {
+		return array_map(
+			static fn( $item ) => $item['fee_amount'],
+			$items
+		);
 	}
 
 	/**

--- a/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
+++ b/src/Tickets/Commerce/Shortcodes/Checkout_Shortcode.php
@@ -44,7 +44,7 @@ class Checkout_Shortcode extends Shortcode_Abstract {
 		$cart          = tribe( Cart::class );
 		$cart_subtotal = Value::create( $cart->get_cart_subtotal() ?? 0 );
 		$cart_total    = Value::create( $cart->get_cart_total() ?? 0 );
-		$items         = $cart->get_repository()->update_items_with_subtotal( $cart->get_items_in_cart( true, 'all' ) );
+		$items         = $cart->get_repository()->get_calculated_items( 'all' );
 		$sections      = array_unique( array_filter( wp_list_pluck( $items, 'event_id' ) ) );
 		$gateways      = tribe( Manager::class )->get_gateways();
 

--- a/src/Tickets/Commerce/Values/Float_Value.php
+++ b/src/Tickets/Commerce/Values/Float_Value.php
@@ -33,6 +33,17 @@ class Float_Value extends Base_Value {
 	}
 
 	/**
+	 * Invert the sign of the value.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @return Float_Value
+	 */
+	public function invert_sign(): Float_Value {
+		return new static( -1 * $this->value );
+	}
+
+	/**
 	 * Create a new instance from a numeric value.
 	 *
 	 * @param float|int|string $value The value to store. Can be a float, int, or numeric string.

--- a/tests/commerce_integration/TEC/Tickets/Commerce/CartTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/CartTest.php
@@ -6,7 +6,6 @@ use Codeception\TestCase\WPTestCase;
 use TEC\Tickets\Commerce;
 use TEC\Tickets\Commerce\Cart\Agnostic_Cart;
 use TEC\Tickets\Commerce\Cart\Cart_Interface;
-use TEC\Tickets\Commerce\Cart\Unmanaged_Cart;
 use TEC\Tickets\Commerce\Traits\Cart as Cart_Trait;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 

--- a/tests/order_modifiers_integration/API/Coupons_Test.php
+++ b/tests/order_modifiers_integration/API/Coupons_Test.php
@@ -108,7 +108,7 @@ class Coupons_Test extends Controller_Test_Case {
 
 				// Check that the data has been generated correctly.
 				Assert::assertTrue( $data['success'] );
-				Assert::assertSame( '- $1.50', $data['discount'] );
+				Assert::assertSame( '- &#x24;1.50', $data['discount'] );
 				Assert::assertSame( $coupon_15_percent()->slug, $data['label'] );
 				Assert::assertSame(
 					esc_html(

--- a/tests/order_modifiers_integration/Checkout/Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Fees_Test.php
@@ -10,10 +10,10 @@ use TEC\Tickets\Commerce\Admin\Singular_Order_Page;
 use TEC\Tickets\Commerce\Cart as Commerce_Cart;
 use TEC\Tickets\Commerce\Cart\Cart_Interface as Cart;
 use TEC\Tickets\Commerce\Order_Modifiers\API\Fees as ApiFees;
-use TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\PayPal\Fees as PayPalFees;
-use TEC\Tickets\Commerce\Values\Float_Value;
 use TEC\Tickets\Commerce\Shortcodes\Checkout_Shortcode;
+use TEC\Tickets\Commerce\Values\Float_Value;
 use TEC\Tickets\Flexible_Tickets\Test\Traits\Series_Pass_Factory;
+use Tribe\Tests\Tickets\Traits\Tribe_URL;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\OrderModifiers\Fee_Creator;
@@ -24,7 +24,6 @@ use Tribe\Tickets\Test\Traits\With_No_Object_Storage;
 use Tribe\Tickets\Test\Traits\With_Test_Orders;
 use Tribe\Tickets\Test\Traits\With_Tickets_Commerce;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
-use Tribe\Tests\Tickets\Traits\Tribe_URL;
 
 class Fees_Test extends Controller_Test_Case {
 
@@ -708,9 +707,9 @@ class Fees_Test extends Controller_Test_Case {
 	/**
 	 * Data provider for testing order totals with various inputs.
 	 *
-	 * @return \Generator
+	 * @return Generator
 	 */
-	public function cart_totals_data_provider(): \Generator {
+	public function cart_totals_data_provider(): Generator {
 		yield 'Ticket $10, Fee $5, Application All' => [
 			'ticket_price'      => Float_Value::from_number( 10 ),
 			'fee_raw_amount'    => Float_Value::from_number( 5 ),

--- a/tests/order_modifiers_integration/Checkout/Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Fees_Test.php
@@ -1042,12 +1042,4 @@ class Fees_Test extends Controller_Test_Case {
 
 		$this->assertMatchesHtmlSnapshot( $html );
 	}
-
-	/**
-	 * @before
-	 * @after
-	 */
-	public function reset_fees() {
-		$this->test_services->get( PayPalFees::class )->reset_fees_and_subtotal();
-	}
 }

--- a/tests/order_modifiers_integration/Checkout/Gateway/PayPal/Coupons_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Gateway/PayPal/Coupons_Test.php
@@ -178,11 +178,11 @@ class Coupons_Test extends Controller_Test_Case {
 		// The item total should be 22.56 + 2.26 + .46 = 25.28 (as a string).
 		Assert::assertEquals( '25.28', $purchase_unit['amount']['breakdown']['item_total']['value'] );
 
-		// The discount should be 17.3% * 2 * 11.28 = 3.90 (as a string).
-		Assert::assertEquals( '3.90', $purchase_unit['amount']['breakdown']['discount']['value'] );
+		// The discount should be 17.3% * 22.56 = 4.37 (as a string).
+		Assert::assertEquals( '4.37', $purchase_unit['amount']['breakdown']['discount']['value'] );
 
-		// The total value should match the item total minus the discount. 25.28 - 3.90 = 21.38 (as a string).
-		Assert::assertEquals( '21.38', $purchase_unit['amount']['value'], 'The total value should equal item_total minus discount' );
+		// The total value should match the item total minus the discount. 25.28 - 4.37 = 20.91 (as a string).
+		Assert::assertEquals( '20.91', $purchase_unit['amount']['value'], 'The total value should equal item_total minus discount' );
 	}
 
 	protected function create_the_things(): array {

--- a/tests/order_modifiers_integration/Checkout/Gateway/PayPal/PayPal_Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Gateway/PayPal/PayPal_Fees_Test.php
@@ -39,13 +39,6 @@ class PayPal_Fees_Test extends Controller_Test_Case {
 	protected string $gateway_class = PayPalGateway::class;
 
 	/**
-	 * @after
-	 */
-	public function breakdown() {
-		$this->test_services->get( $this->controller_class )->reset_fees_and_subtotal();
-	}
-
-	/**
 	 * @test
 	 */
 	public function it_should_not_store_objects() {

--- a/tests/order_modifiers_integration/Checkout/Gateway/Stripe/Stripe_Fees_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Gateway/Stripe/Stripe_Fees_Test.php
@@ -366,13 +366,6 @@ class Stripe_Fees_Test extends Controller_Test_Case {
 	}
 
 	/**
-	 * @after
-	 */
-	public function breakdown() {
-		$this->make_controller()->reset_fees_and_subtotal();
-	}
-
-	/**
 	 * @test
 	 * @dataProvider order_totals_data_provider
 	 * Ensures the order totals are calculated correctly for tickets and fees using the Stripe gateway.


### PR DESCRIPTION
### 🎫 Ticket

Related to QA Item `#40`

### 🗒️ Description

This PR updates the logic for cart items. The end goal is to ensure that Coupons are applied to Fees in addition to other cart items.

Notable changes:

1. The `Abstrat_Cart` class has changes to how the subtotal and total are calculated:
    1. There are 2 new filters:
        1. `tec_tickets_commerce_get_cart_additional_values_total` – Fired inside `get_cart_total()`, this allows for adding items to the cart total calculations. These items are excluded from the cart subtotal.
        1. `tec_tickets_commerce_get_cart_additional_values_subtotal` – Same as above, except it is fired within `get_cart_subtotal()`. It allows for items that should be included in the subtotal calculations.
    1. Both of the filters utilize `Precision_Value` objects instead of `Value` objects.
    1. Inside `get_cart_total()`, there's a point where we check whether the subtotal is `0`, and if so we skip any further processing. This check was moved later, to allow for the aforementioned filter to run.
1. Fee calculations were updated:
    1. The Fee classes no longer store the `$subtotal` value.
    1. The Fee classes no longer rely on a static value to determine whether fees need to be added to the cart
    1. The calculations use `Precision_Value` objects instead of `Value` objects
    1. The fees were hooked into the new filter
1. Coupons:
    1. A duplicate hook was removed from the Stripe class
    1. When coupons are added to cart items, they use the items they are passed to determine their discount rather than the reported cart subtotal.
1. The `Float_Value` class has a new method: `invert_sign()`. It functions to convert from positive to negative and vice versa.
1. The tests were updated to reflect the new calculation logic.
1. The Abstract Cart class was updated to add `get_calculated_items()`, which allows for retrieving the cart items with the same data that will be used to generate an order
1. The Checkout page shortcode and the Coupon API were updated to use the new method for retrieving items
1. The Coupon object was updated to make getting a type ID more easy and consistent.

[skip-changelog] *These changes are related to unreleased features.*

### 🎥 Artifacts <!-- if applicable-->

https://github.com/user-attachments/assets/dd9715d2-f1d0-4bcc-b5bb-c0a2dbedf33b


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
