### PR TITLE
Modify coupon discount calculations

### DIFF
--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -264,7 +264,14 @@ abstract class Abstract_Cart implements Cart_Interface {
 		// Calculate the items that are dynamic. These items are not included in the subtotal calculation.
 		$callable_items = $this->update_items_with_subtotal( $callable_items, $subtotal->get() );
 
-		// Get the subtotals for the callable items as Precision_Value objects.
+		/*
+		 * With each item, we need to see if it is a positive value or a negative value.
+		 * If it is a positive, we can just add it and move on. But if it is negative, then
+		 * we need to ensure that it does not take the cart value less than zero.
+		 *
+		 * If the item would take the cart value below zero, calculate the amount that
+		 * would take it exactly to zero, and set that as the item's value.
+		 */
 		foreach ( $callable_items as $id => $item ) {
 			$this->calculated_items[ $id ] = $item;
 			$callable_subtotals[]          = Factory::to_precision_value( $item['sub_total'] );

--- a/src/Tickets/Commerce/Cart/Abstract_Cart.php
+++ b/src/Tickets/Commerce/Cart/Abstract_Cart.php
@@ -253,29 +253,7 @@ abstract class Abstract_Cart implements Cart_Interface {
 			return $this->cart_total->get();
 		}
 
-		$callable_subtotals = [];
-
-		// Get the items that have a dynamic subtotal.
-		$callable_items = array_filter(
-			$all_items,
-			static fn( $item ) => is_callable( $item['sub_total'] )
-		);
-
-		// Calculate the items that are dynamic. These items are not included in the subtotal calculation.
-		$callable_items = $this->update_items_with_subtotal( $callable_items, $subtotal->get() );
-
-		/*
-		 * With each item, we need to see if it is a positive value or a negative value.
-		 * If it is a positive, we can just add it and move on. But if it is negative, then
-		 * we need to ensure that it does not take the cart value less than zero.
-		 *
-		 * If the item would take the cart value below zero, calculate the amount that
-		 * would take it exactly to zero, and set that as the item's value.
-		 */
-		foreach ( $callable_items as $id => $item ) {
-			$this->calculated_items[ $id ] = $item;
-			$callable_subtotals[]          = Factory::to_precision_value( $item['sub_total'] );
-		}
+		$callable_subtotals = $this->calculate_dynamic_items( $all_items, $subtotal );
 
 		// Calculate the new value from all of the subtotals.
 		$total = Precision_Value::sum(
@@ -584,5 +562,18 @@ abstract class Abstract_Cart implements Cart_Interface {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Handle the calculation of dynamic items.
+	 *
+	 * @since 5.21.0
+	 *
+	 * @param array           $items    Array of items to calculate.
+	 * @param Precision_Value $subtotal The subtotal to use for the calculation.
+	 *
+	 * @return Precision_Value[] The calculated subtotals as Precision_Value objects.
+	 */
+	protected function calculate_dynamic_items( array $items, Precision_Value $subtotal ): array {
 	}
 }

--- a/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/API/Coupons.php
@@ -22,7 +22,6 @@ use TEC\Tickets\Commerce\Order_Modifiers\Repositories\Coupons as Coupons_Reposit
 use TEC\Tickets\Commerce\Order_Modifiers\Traits\Coupons as CouponsTrait;
 use TEC\Tickets\Commerce\Values\Currency_Value;
 use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
-use TEC\Tickets\Commerce\Values\Precision_Value;
 use WP_Error;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/Stripe/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Gateway/Stripe/Coupons.php
@@ -10,13 +10,11 @@ declare( strict_types=1 );
 namespace TEC\Tickets\Commerce\Order_Modifiers\Checkout\Gateway\Stripe;
 
 use Closure;
-use Exception;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\StellarWP\Assets\Asset;
 use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Checkout;
 use TEC\Tickets\Commerce\Gateways\Stripe\Gateway;
-use TEC\Tickets\Commerce\Order_Modifiers\Models\Coupon;
 use TEC\Tickets\Commerce\Utils\Value;
 use Tribe__Assets;
 use WP_Post;


### PR DESCRIPTION
- **Remove unused imports**
- **Add comment explaining the logic that needs to happen**
- **Create a separate method to handle dynamic calculations**
- **Set the logic for calculating dynamic items**

### 🎫 Ticket

Related to QA Item `40`

### 🗒️ Description

This updates the way that coupon discounts are calculated, with the goal of ensuring 2 main things:

1. No coupon will take the cart less than zero.
2. If a coupon *would* take the cart less than zero, the coupon's discount amount is updated to be the amount that takes the cart to *exactly* zero.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
