### PR TITLE
Don't allow sorting by used and remaining columns

### DIFF
--- a/src/Tickets/Commerce/Order_Modifiers/Table_Views/Coupon_Table.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Table_Views/Coupon_Table.php
@@ -166,8 +166,6 @@ class Coupon_Table extends Order_Modifier_Table {
 			'display_name' => [ 'display_name', true ],
 			'slug'         => [ 'slug', false ],
 			'raw_amount'   => [ 'raw_amount', false ],
-			'used'         => [ 'used', false ],
-			'remaining'    => [ 'remaining', false ],
 			'status'       => [ 'status', false ],
 		];
 	}


### PR DESCRIPTION
### 🎫 Ticket

QA Issue `#46`

### 🗒️ Description

Trying to sort Coupons by Used or Remaining triggers fatal errors. This PR removes the ability to sort by those columns. We can add this back at a later date when we can look into the sorting logic more deeply.

[skip-changelog] *Fixing a bug for a new feature*

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [xz] Add your PR to the project board for the release.
