### PR TITLE
Replace TBD with correct version

### DIFF
--- a/tests/_support/Commerce/OrderModifiers/Coupon_Creator.php
+++ b/tests/_support/Commerce/OrderModifiers/Coupon_Creator.php
@@ -20,7 +20,7 @@ trait Coupon_Creator {
 	/**
 	 * Create a coupon.
 	 *
-	 * @since TBD
+	 * @since 5.21.0
 	 *
 	 * @param array $args The coupon arguments.
 	 *
@@ -51,7 +51,7 @@ trait Coupon_Creator {
 	/**
 	 * Create multiple coupons.
 	 *
-	 * @since TBD
+	 * @since 5.21.0
 	 *
 	 * @param int   $how_many The number of coupons to create.
 	 * @param array $args     The coupon arguments.

--- a/tests/_support/Traits/Tribe_URL.php
+++ b/tests/_support/Traits/Tribe_URL.php
@@ -9,7 +9,7 @@ use Tribe\Tests\Traits\With_Uopz;
 /**
  * Trait Tribe_URL
  *
- * @since TBD
+ * @since 5.21.0
  */
 trait Tribe_URL {
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Cart/Agnostic_CartTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Cart/Agnostic_CartTest.php
@@ -10,7 +10,7 @@ use TEC\Tickets\Commerce\Cart;
 /**
  * Class Agnostic_CartTest
  *
- * @since TBD
+ * @since 5.21.0
  */
 class Agnostic_CartTest extends WPTestCase {
 

--- a/tests/order_modifiers_integration/Checkout/Gateway/PayPal/Coupons_Test.php
+++ b/tests/order_modifiers_integration/Checkout/Gateway/PayPal/Coupons_Test.php
@@ -20,7 +20,7 @@ use Tribe\Tickets\Test\Traits\PayPal_REST_Override;
 /**
  * Class Coupons_Test
  *
- * @since TBD
+ * @since 5.21.0
  */
 class Coupons_Test extends Controller_Test_Case {
 


### PR DESCRIPTION
This replaces `TBD` with the correct version `5.21.0` for the Colossus release.

[skip-changelog]
