### PR TITLE
Fix - Add TicketsCommerce support for ETP seating assets conditionals.

### DIFF
--- a/changelog/fix-tc-support-for-etp-seating
+++ b/changelog/fix-tc-support-for-etp-seating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add TicketsCommerce support for ETP seating assets conditionals to avoid dependency. [ET-2336]

--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -614,7 +614,7 @@ class Controller extends Controller_Contract {
 	 *
 	 * @return bool Whether AR assets should be registered.
 	 */
-	public function filter_should_register_ar_assets( $should_register ) {
+	public function filter_should_register_ar_assets( bool $should_register ): bool {
 		// If other providers already registered the assets, we don't need to do it.
 		if ( $should_register ) {
 			return $should_register;

--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -17,6 +17,7 @@ use TEC\Tickets\Commerce\Checkout;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Ticket;
 use TEC\Tickets\Seating\Meta;
+use TEC\Tickets\Seating\Orders\Cart as Seating_Cart;
 use TEC\Tickets\Seating\Service\Service;
 use TEC\Tickets\Seating\Tables\Seat_Types as Seat_Types_Table;
 use Tribe__Cache_Listener as Cache_Listener;
@@ -28,7 +29,7 @@ use WP_Post;
 /**
  * Class Controller.
  *
- * @since   5.16.0
+ * @since 5.16.0
  *
  * @package TEC\Tickets\Seating\Commerce;
  */
@@ -106,6 +107,7 @@ class Controller extends Controller_Contract {
 		add_action( 'before_delete_post', [ $this, 'restock_ticket_on_attendee_deletion' ], 10, 2 );
 		add_action( 'wp_trash_post', [ $this, 'restock_ticket_on_attendee_trash' ] );
 		add_filter( 'tec_tickets_plus_seating_is_checkout_page', [ $this, 'filter_is_checkout_page' ] );
+		add_filter( 'tec_tickets_plus_seating_register_ar_assets', [ $this, 'filter_should_register_ar_assets' ] );
 	}
 
 	/**
@@ -127,6 +129,7 @@ class Controller extends Controller_Contract {
 		remove_action( 'before_delete_post', [ $this, 'restock_ticket_on_attendee_deletion' ] );
 		remove_action( 'wp_trash_post', [ $this, 'restock_ticket_on_attendee_trash' ] );
 		remove_filter( 'tec_tickets_plus_seating_is_checkout_page', [ $this, 'filter_is_checkout_page' ] );
+		remove_filter( 'tec_tickets_plus_seating_register_ar_assets', [ $this, 'filter_should_register_ar_assets' ] );
 	}
 
 	/**
@@ -600,5 +603,23 @@ class Controller extends Controller_Contract {
 		}
 		
 		return tribe( Checkout::class )->is_current_page();
+	}
+	
+	/**
+	 * Filters whether AR assets should be registered.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $should_register Whether AR assets should be registered.
+	 *
+	 * @return bool Whether AR assets should be registered.
+	 */
+	public function filter_should_register_ar_assets( $should_register ) {
+		// If other providers already registered the assets, we don't need to do it.
+		if ( $should_register ) {
+			return $should_register;
+		}
+		
+		return tribe( Seating_Cart::class )->cart_has_seating_tickets();
 	}
 }

--- a/src/Tickets/Seating/Commerce/Controller.php
+++ b/src/Tickets/Seating/Commerce/Controller.php
@@ -13,6 +13,7 @@ use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\lucatume\DI52\Container;
 use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Checkout;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Ticket;
 use TEC\Tickets\Seating\Meta;
@@ -104,6 +105,7 @@ class Controller extends Controller_Contract {
 		add_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10, 4 );
 		add_action( 'before_delete_post', [ $this, 'restock_ticket_on_attendee_deletion' ], 10, 2 );
 		add_action( 'wp_trash_post', [ $this, 'restock_ticket_on_attendee_trash' ] );
+		add_filter( 'tec_tickets_plus_seating_is_checkout_page', [ $this, 'filter_is_checkout_page' ] );
 	}
 
 	/**
@@ -124,6 +126,7 @@ class Controller extends Controller_Contract {
 		remove_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10 );
 		remove_action( 'before_delete_post', [ $this, 'restock_ticket_on_attendee_deletion' ] );
 		remove_action( 'wp_trash_post', [ $this, 'restock_ticket_on_attendee_trash' ] );
+		remove_filter( 'tec_tickets_plus_seating_is_checkout_page', [ $this, 'filter_is_checkout_page' ] );
 	}
 
 	/**
@@ -579,5 +582,23 @@ class Controller extends Controller_Contract {
 		$this->update_seated_ticket_stock( $ticket_id, $seat_type, 1 );
 
 		add_filter( 'update_post_metadata', [ $this, 'handle_ticket_meta_update' ], 10, 4 );
+	}
+	
+	/**
+	 * Filters whether the current page is the Tickets Commerce checkout page.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $is_checkout_page Whether the current page is the Tickets Commerce checkout page.
+	 *
+	 * @return bool Whether the current page is the Tickets Commerce checkout page.
+	 */
+	public function filter_is_checkout_page( bool $is_checkout_page ): bool {
+		// If already on checkout page, then no need to determine.
+		if ( $is_checkout_page ) {
+			return $is_checkout_page;
+		}
+		
+		return tribe( Checkout::class )->is_current_page();
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* TicketsCommerce conditionals were directly used inside ETP, which caused Fatal errors when Seating with Woo is enabled without TicketsCommerce.
* This PR utilizes the filters provided by ETP to provide the data as needed thus avoiding a direct dependency.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
🎥 screencast(s): https://share.cleanshot.com/JYB4ZK5f

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
