### PR TITLE
Use Agnostic_Cart instead of Cart_Interface (for now)

### DIFF
--- a/changelog/fix-tickets-commerce-cart-binding
+++ b/changelog/fix-tickets-commerce-cart-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an error when using ETP and ET with Woo as commerce provider instead of TicketsCommerce. [ET-2336]

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -4,6 +4,7 @@
 namespace TEC\Tickets\Commerce;
 
 use TEC\Tickets\Commerce;
+use TEC\Tickets\Commerce\Cart\Agnostic_Cart;
 use TEC\Tickets\Commerce\Cart\Cart_Interface;
 use TEC\Tickets\Commerce\Traits\Cart as Cart_Trait;
 use Tribe__Tickets__Tickets as Tickets;
@@ -77,11 +78,12 @@ class Cart {
 	 *
 	 * @since 5.1.9
 	 * @since 5.21.0 Updated to use Cart_Interface instead of Unmanaged_Cart.
+	 * @since 5.21.1 Used Agnostic_Cart instead of Cart_Interface until we can fix ETP.
 	 *
-	 * @return Cart_Interface
+	 * @return Agnostic_Cart
 	 */
 	public function get_repository() {
-		$default_cart = tribe( Cart_Interface::class );
+		$default_cart = tribe( Agnostic_Cart::class );
 
 		/**
 		 * Filters the cart repository, by default we use Unmanaged Cart.

--- a/src/Tickets/Commerce/Provider.php
+++ b/src/Tickets/Commerce/Provider.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Commerce;
 use TEC\Common\Contracts\Service_Provider;
 use TEC\Tickets\Commerce\Cart\Agnostic_Cart;
 use TEC\Tickets\Commerce\Cart\Cart_Interface;
+use TEC\Tickets\Commerce\Cart\Unmanaged_Cart;
 use Tribe__Tickets__Main as Tickets_Plugin;
 
 /**
@@ -69,7 +70,8 @@ class Provider extends Service_Provider {
 		$this->container->singleton( Order::class );
 		$this->container->singleton( Ticket::class );
 		$this->container->singleton( Cart::class );
-		$this->container->singleton( Cart\Unmanaged_Cart::class );
+		$this->container->singleton( Unmanaged_Cart::class );
+		$this->container->singleton( Agnostic_Cart::class );
 		$this->container->singleton( Cart_Interface::class, Agnostic_Cart::class );
 
 		$this->container->singleton( Checkout::class );

--- a/tests/order_modifiers_integration/API/Coupons_Test.php
+++ b/tests/order_modifiers_integration/API/Coupons_Test.php
@@ -287,6 +287,10 @@ class Coupons_Test extends Controller_Test_Case {
 
 		/** @var Abstract_Cart $cart */
 		$cart = $commerce_cart->get_repository();
+
+		// Ensure we have the same cart object by checking the hash.
+		Assert::assertSame( 'fake-cart-hash', $cart->get_hash() );
+
 		$cart->upsert_item( $ticket, 1 );
 
 		Assert::assertCount( 1, $cart->get_items_in_cart( false, 'all' ) );


### PR DESCRIPTION
### 🎫 Ticket

[ET-2336]

### 🗒️ Description

The change to calling `tribe( Cart_Interface::class )` back in #3522 caused a fatal error in ETP when using Woo instead of TicketsCommerce.

This PR switches to using the `Agnostic_Cart` class as the reference instead of the `Cart_Interface` interface. It also registers the `Agnostic_Cart` class as a singleton within the TicketsCommerce `Provider` class.

In the future when we fix the ETP dependency, we will want to return to using `Cart_Interface`.

### 🎥 Artifacts <!-- if applicable-->

*n/a for this PR*

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2336]: https://stellarwp.atlassian.net/browse/ET-2336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ