### PR TITLE
Will now respect ticket order if provided

### DIFF
--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -550,7 +550,7 @@ class Ticket {
 				'post_author'  => get_current_user_id(),
 				'post_excerpt' => $ticket->description,
 				'post_title'   => $ticket->name,
-				'menu_order'   => tribe_get_request_var( 'menu_order', - 1 ),
+				'menu_order'   => (int) ( tribe_get_request_var( 'menu_order', $raw_data['ticket_menu_order'] ?? - 1 ) ),
 				'meta_input' => [
 					'_type' => $raw_data['ticket_type'] ?? 'default',
 				]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -4029,7 +4029,9 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$ticket->end_date = date( Tribe__Date_Utils::DBDATEFORMAT, strtotime( $end_datetime ) );
 			}
 
-			update_post_meta( $ticket->ID, '_type', $data['ticket_type'] ?? 'default' );
+			if ( $update ) {
+				update_post_meta( $ticket->ID, '_type', $data['ticket_type'] ?? 'default' );
+			}
 
 			// Pass the control to the child object.
 			$save_ticket = $this->save_ticket( $post_id, $ticket, $data );


### PR DESCRIPTION
### 🎫 Ticket

No ticket.
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fixing waitlist snapshot tests failing from time to time by respecting the ticket menu order being provided.

### 🎥 Artifacts <!-- if applicable-->

The ticket order is set after the change - before all the tickets had -1 as their menu order.

![image](https://github.com/user-attachments/assets/f252b84e-a908-4c4e-aad0-7f966e011416)


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
