### PR TITLE
Alternate build mode: development

### DIFF
--- a/bin/action-before-zip.sh
+++ b/bin/action-before-zip.sh
@@ -1,3 +1,16 @@
+#!/bin/bash
+
+# Default to production mode if not specified
+BUILD_MODE=${1:-production}
+
+# If 'dev' is passed, set to development mode
+if [ "$1" = "dev" ]; then
+    BUILD_MODE="development"
+    DEVTOOL="--devtool=source-map"
+else
+    DEVTOOL=""
+fi
+
 echo "Moving the Webpack 4 directory out of the way to prevent conflicts."
 mv node_modules/webpack /tmp/_webpack
 mv node_modules/webpack-cli /tmp/_webpack-cli
@@ -6,12 +19,12 @@ echo "Moving configuration files out of the way."
 mv webpack.config.js _webpack.config.js
 mv babel.config.json _babel.config.json
 
-echo "Building the JS with the correct Webpack version."
+echo "Building the JS with the correct Webpack version in $BUILD_MODE mode."
 npx \
 	--package="@tanstack/react-query" \
 	--package="@wordpress/scripts@27.9.0" \
 	--yes -- \
-	wp-scripts build --webpack-src-dir=src/resources/packages/wizard/ --output-path=build/wizard
+	wp-scripts build --webpack-src-dir=src/resources/packages/wizard/ --output-path=build/wizard --mode=$BUILD_MODE $DEVTOOL
 
 echo "Moving the Webpack 4 directory back to node_modules."
 mv /tmp/_webpack node_modules/webpack

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "scripts": {
     "analyze": "webpack-bundle-analyzer -m static stats.json",
     "before-zip": "bash bin/action-before-zip.sh",
+    "before-zip:dev": "bash bin/action-before-zip.sh dev",
     "bootstrap": "./scripts/linkDependencies",
     "build:webpack": "export NODE_OPTIONS=--openssl-legacy-provider && cross-env NODE_ENV=production webpack -p",
     "build:webpack:inspect": "export NODE_OPTIONS=--openssl-legacy-provider && cross-env NODE_ENV=production node --inspect node_modules/webpack/bin/webpack.js -p",


### PR DESCRIPTION
Till we have Tyson, this is needed to be able to inspect React components.

Usage:

`npm run before-zip`
or
`npm run before-zip:dev`