### PR TITLE
Fix various issues after tyson migration

### DIFF
--- a/src/Tickets/Blocks/Ticket/Block.php
+++ b/src/Tickets/Blocks/Ticket/Block.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Blocks\Ticket;
 
 use Tribe__Editor__Blocks__Abstract as Abstract_Block;
 use Tribe__Tickets__Main as Tickets_Main;
+use TEC\Common\Asset;
 
 /**
  * Class Block.
@@ -86,29 +87,36 @@ class Block extends Abstract_Block {
 	 * @return void
 	 */
 	public function register_editor_scripts() {
-		$plugin = Tickets_Main::instance();
-
-		// Using WordPress functions to register since we just need to register them.
-		wp_register_script(
+		Asset::add(
 			'tec-tickets-ticket-item-block-editor-script',
-			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/editor.js',
-			[ 'tribe-common-gutenberg-vendor', 'tribe-tickets-gutenberg-vendor', 'tec-common-php-date-formatter' ],
-			Tickets_Main::VERSION,
-			true
-		);
+			'Ticket/editor.js',
+			Tickets_Main::VERSION
+		)
+			->add_to_group_path( 'et-tickets-blocks' )
+			->set_dependencies(
+				'tribe-tickets-gutenberg-vendor',
+				'tec-common-php-date-formatter',
+				'tribe-common-gutenberg-vendor'
+			)
+			->in_footer()
+			->register();
 
-		wp_register_style(
+		Asset::add(
 			'tec-tickets-ticket-item-block-secondary-editor-style',
-			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/editor.css',
-			[ 'tribe-tickets-gutenberg-main-styles' ],
+			'Ticket/editor.css',
 			Tickets_Main::VERSION
-		);
+		)
+			->add_to_group_path( 'et-tickets-blocks' )
+			->set_dependencies( 'tribe-tickets-gutenberg-main-styles' )
+			->register();
 
-		wp_register_style(
+		Asset::add(
 			'tec-tickets-ticket-item-block-editor-style',
-			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/style-editor.css',
-			[ 'tec-tickets-ticket-item-block-secondary-editor-style' ],
+			'Ticket/style-editor.css',
 			Tickets_Main::VERSION
-		);
+		)
+			->add_to_group_path( 'et-tickets-blocks' )
+			->set_dependencies( 'tec-tickets-ticket-item-block-secondary-editor-style' )
+			->register();
 	}
 }

--- a/src/Tickets/Blocks/Ticket/Block.php
+++ b/src/Tickets/Blocks/Ticket/Block.php
@@ -99,14 +99,14 @@ class Block extends Abstract_Block {
 
 		wp_register_style(
 			'tec-tickets-ticket-item-block-secondary-editor-style',
-			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/style-editor.css',
+			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/editor.css',
 			[ 'tribe-tickets-gutenberg-main-styles' ],
 			Tickets_Main::VERSION
 		);
 
 		wp_register_style(
 			'tec-tickets-ticket-item-block-editor-style',
-			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/editor.css',
+			$plugin->plugin_url . 'build/tickets/Blocks/Ticket/style-editor.css',
 			[ 'tec-tickets-ticket-item-block-secondary-editor-style' ],
 			Tickets_Main::VERSION
 		);

--- a/src/Tickets/Commerce/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Admin/Order_Modifier_Fee_Metabox.php
@@ -107,7 +107,7 @@ class Order_Modifier_Fee_Metabox extends Controller_Contract {
 		parent::__construct( $container );
 		// Set up the modifier strategy and manager for handling fees.
 		$this->controller = $controller;
-		$this->manager           = $manager;
+		$this->manager    = $manager;
 
 		// Set up the order modifiers repository for accessing fee data.
 		$this->order_modifiers_relationship_repository = $order_modifier_relationship;
@@ -166,7 +166,7 @@ class Order_Modifier_Fee_Metabox extends Controller_Contract {
 			'admin/order-modifiers/fees.js',
 			Main::VERSION
 		)
-			->add_to_group_path( 'et-core' )
+			->add_to_group_path( Main::class )
 			->set_condition( [ $this, 'should_enqueue_assets' ] )
 			->set_dependencies( 'jquery', 'tribe-dropdowns', 'tribe-select2' )
 			->enqueue_on( 'admin_enqueue_scripts' )

--- a/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Modifier_Admin_Handler.php
@@ -135,7 +135,7 @@ class Modifier_Admin_Handler extends Controller_Contract {
 			'admin/order-modifiers/table.js',
 			Tickets_Plugin::VERSION
 		)
-			->add_to_group_path( 'et-core' )
+			->add_to_group_path( Tickets_Plugin::class )
 			->set_condition( fn() => $this->is_on_page() )
 			->set_dependencies( 'jquery', 'wp-util' )
 			->enqueue_on( 'admin_enqueue_scripts' )

--- a/src/Tickets/Seating/Assets.php
+++ b/src/Tickets/Seating/Assets.php
@@ -131,7 +131,7 @@ class Assets extends Controller_Contract {
 			ET::VERSION
 		)
 			->add_to_group_path( 'tec-seating' )
-			->add_localize_script( 'tec.tickets.seating.utils', [ $this, 'get_utils_data' ] )
+			->add_localize_script( 'tec.tickets.seating.utilsData', [ $this, 'get_utils_data' ] )
 			->add_to_group( 'tec-tickets-seating' )
 			->register();
 	}

--- a/src/Tickets/Seating/app/utils/index.js
+++ b/src/Tickets/Seating/app/utils/index.js
@@ -6,7 +6,7 @@
  * @return {string} The link URL, or an empty string if it does not exist.
  */
 export function getLink(link) {
-	return window?.tec?.tickets?.seating?.utils?.links?.[link] || '';
+	return window?.tec?.tickets?.seating?.utilsData?.links?.[link] || '';
 }
 
 /**
@@ -20,10 +20,10 @@ export function getLink(link) {
 export function getLocalizedString(slug, group) {
 	if (group) {
 		return (
-			window?.tec?.tickets?.seating?.utils?.localizedStrings?.[group]?.[slug] || ''
+			window?.tec?.tickets?.seating?.utilsData?.localizedStrings?.[group]?.[slug] || ''
 		);
 	}
-	return window?.tec?.tickets?.seating?.utils?.localizedStrings?.[slug] || '';
+	return window?.tec?.tickets?.seating?.utilsData?.localizedStrings?.[slug] || '';
 }
 
 /**

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -72,7 +72,7 @@ class Tribe__Tickets__Editor__Assets {
 		tec_asset(
 			$plugin,
 			'tribe-tickets-gutenberg-secondary-styles',
-			'app/style-main.css',
+			'app/main.css',
 			[],
 			null,
 			[
@@ -94,7 +94,7 @@ class Tribe__Tickets__Editor__Assets {
 		tec_asset(
 			$plugin,
 			'tribe-tickets-gutenberg-main-styles',
-			'app/main.css',
+			'app/style-main.css',
 			[ 'tribe-common-full-style', 'tribe-tickets-gutenberg-vendor-styles' ],
 			'enqueue_block_editor_assets',
 			[

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -440,9 +440,6 @@ class Tribe__Tickets__Main {
 	 * @since TBD Added Tyson group paths.
 	 */
 	public function bootstrap() {
-		// Add the group path for the ET core assets.
-		Assets_Config::add_group_path( 'et-core', $this->plugin_path, 'src/resources/', true );
-
 		/*
 		* Register the `/build` directory assets as a different group to ensure back-compatibility.
 		* This needs to happen early in the plugin bootstrap routine.

--- a/tests/order_modifiers_integration/Admin/Order_Modifier_Fee_Metabox_Test.php
+++ b/tests/order_modifiers_integration/Admin/Order_Modifier_Fee_Metabox_Test.php
@@ -26,7 +26,7 @@ class Order_Modifier_Fee_Metabox_Test extends Controller_Test_Case {
 
 	public function asset_data_provider() {
 		$assets = [
-			'order-modifiers-fees-js' => '/src/resources/js/admin/order-modifiers/fees.js',
+			'order-modifiers-fees-js' => '/build/js/admin/order-modifiers/fees.js',
 		];
 
 		foreach ( $assets as $slug => $path ) {

--- a/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
+++ b/tests/order_modifiers_integration/Modifier_Admin_Handler_Test.php
@@ -37,7 +37,7 @@ class Modifier_Admin_Handler_Test extends Controller_Test_Case {
 
 	public function asset_data_provider() {
 		$assets = [
-			'tec-tickets-order-modifiers-table' => 'src/resources/js/admin/order-modifiers/table.js',
+			'tec-tickets-order-modifiers-table' => 'build/js/admin/order-modifiers/table.js',
 		];
 
 		foreach ( $assets as $slug => $path ) {

--- a/tests/slr_jest/_bootstrap.js
+++ b/tests/slr_jest/_bootstrap.js
@@ -24,7 +24,8 @@ global.tec.tickets.seating = {
 		ACTION_GET_SEAT_TYPES_BY_LAYOUT_ID:
 			'tec_tickets_seating_get_seat_types_by_layout_id',
 	},
-	utils: {
+	utils: {},
+	utilsData: {
 		localizedStrings: {
 			layouts: {
 				'add-failed': 'Failed to add the layout.',


### PR DESCRIPTION
Fixes various asset issues after migation to Tyson.

Most important one was `tec.tickets.seating.utils` was being used as an object for webpack to expose AND
as a localized data entry from php.

One of the two was working only - so i changed the data that php was localizing data at.