### PR TITLE
Make the ticket type optional for PHP 8+ compatibility

### DIFF
--- a/src/Tribe/Metabox.php
+++ b/src/Tribe/Metabox.php
@@ -165,6 +165,7 @@ class Tribe__Tickets__Metabox {
 	 * Get the Panels for a given post.
 	 *
 	 * @since  4.6.2
+	 * @since  TBD Make the ticket type optional for PHP 8+ compatibility.
 	 *
 	 * @param int|WP_Post $post        The post object or ID the tickets are for.
 	 * @param int|null    $ticket_id   The ID of the ticket to render the panels for, or `null` if rendering for a new
@@ -173,7 +174,7 @@ class Tribe__Tickets__Metabox {
 	 *
 	 * @return array<string,string> A map from panel name to panel HTML content.
 	 */
-	public function get_panels( $post, $ticket_id = null, string $ticket_type = null ) {
+	public function get_panels( $post, $ticket_id = null, ?string $ticket_type = null ) {
 		if ( ! $post instanceof WP_Post ) {
 			$post = get_post( $post );
 		}


### PR DESCRIPTION
### 🎫 Ticket

[ETP-963]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

One of the tests failed with a "3 params needed, 2 submitted" error. The test does submit 2 params and the third should be defaulted to `null` but apparently that's not PHP 8+ compatible.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ETP-963]: https://stellarwp.atlassian.net/browse/ETP-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ