### PR TITLE
ET-2404 Glance Item Attendees Defensive Coding 

### DIFF
--- a/changelog/fix-ET-2404-glance-item-attendees
+++ b/changelog/fix-ET-2404-glance-item-attendees
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add defensive coding to custom_glance_items_attendees() to avoid a fatal. [ET-2404]

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -41,6 +41,8 @@ class Glance_Items {
 	 * @return array $items The maybe modified array of items to be displayed.
 	 */
 	public function custom_glance_items_attendees( $items = [] ): array {
+		$items = is_array( $items ) ? $items : [];
+		
 		$total = get_transient( static::$attendee_count_key );
 
 		if ( false === $total ) {


### PR DESCRIPTION
### 🎫 Ticket

[ET-2404]

### 🗒️ Description

We're declaring that the return type must be `array` but there are edge cases where `null` is being passed and returned from `custom_glance_items_attendees()` - this adds some defensive code to ensure that the param is converted to an array. 

### 🎥 Artifacts 

https://github.com/user-attachments/assets/703e91f2-b64e-4600-84c0-d7b424906ec7


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
