### PR TITLE
Deprecate the old landing page and redirect to the new one.

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -40,7 +40,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-
 define( 'EVENT_TICKETS_DIR', dirname( __FILE__ ) );
 define( 'EVENT_TICKETS_MAIN_PLUGIN_FILE', __FILE__ );
 

--- a/event-tickets.php
+++ b/event-tickets.php
@@ -40,6 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+
 define( 'EVENT_TICKETS_DIR', dirname( __FILE__ ) );
 define( 'EVENT_TICKETS_MAIN_PLUGIN_FILE', __FILE__ );
 

--- a/src/Tickets/Admin/Onboarding/Controller.php
+++ b/src/Tickets/Admin/Onboarding/Controller.php
@@ -85,8 +85,6 @@ class Controller extends Controller_Contract {
 		add_action( 'admin_post_' . Landing_Page::DISMISS_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
 		add_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
 		add_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
-		// Remove older deprecated actions
-		//remove_action( 'admin_init', [ 'Tribe__Admin__Activation_Page', 'maybe_redirect' ], 10 );
 	}
 
 	/**
@@ -133,8 +131,7 @@ class Controller extends Controller_Contract {
 	 */
 	public function redirect_tec_pages_to_guided_setup(): void {
 		// Do not redirect if they are already on the Guided Setup page. Also prevents an infinite loop if $force is true.
-		$page = tec_get_request_var( 'page' );
-		if ( Landing_Page::$slug === $page ) {
+		if ( Landing_Page::$slug === tec_get_request_var( 'page' ) ) {
 			return;
 		}
 
@@ -151,38 +148,43 @@ class Controller extends Controller_Contract {
 		$force = apply_filters( 'tec_tickets_onboarding_force_redirect_to_guided_setup', false );
 
 		if ( ! $force ) {
-			// For single plugin activation, check the activation redirect transient
+			// For single plugin activation, check the activation redirect transient.
 			$activation_redirect = get_transient( Landing_Page::ACTIVATION_REDIRECT_OPTION );
 
-			// For bulk activation, only redirect if they're on an ET admin page and have the wizard redirect transient
+			// For bulk activation, only redirect if they're on an ET admin page and have the wizard redirect transient.
 			$wizard_redirect = get_transient( Landing_Page::BULK_ACTIVATION_REDIRECT_OPTION );
 
-			// If neither transient is set, don't redirect
+			// If neither transient is set, don't redirect.
 			if ( ! $activation_redirect && ! $wizard_redirect ) {
 				return;
 			}
 
-			// If it's a bulk activation (wizard redirect), only proceed if we're on an ET admin page
+			// If it's a bulk activation (wizard redirect), only proceed if we're on an ET admin page.
 			if ( ! $activation_redirect && $wizard_redirect ) {
 				$requested_page = tec_get_request_var( 'page', '' );
-				$post_type = tec_get_request_var( 'post_type', '' );
+				$post_type      = tec_get_request_var( 'post_type', '' );
 				$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
-				// Check if we're on any ET admin page
+				// Check if we're on any ET admin page.
 				$is_et_page = false;
 
-				// Check main tec-tickets pages
+				// Check main tec-tickets pages.
 				if (
-					! empty( $requested_page )
-					&& (
-						strpos( $requested_page, 'tec-tickets' ) === 0
-						|| null !== $current_screen && strpos( $current_screen->base, 'tec-tickets' ) === 0
-						|| $requested_page === 'tickets-setup'
+					(
+						! empty( $requested_page )
+						&& (
+							strpos( $requested_page, 'tec-tickets' ) === 0
+							|| $requested_page === 'tickets-setup'
+						)
+					)
+					|| (
+						null !== $current_screen
+						&& strpos( $current_screen->base, 'tec-tickets' ) === 0
 					)
 				) {
 					$is_et_page = true;
-				} else if ( $post_type === 'ticket-meta-fieldset' ) {
-					// Check if we're on the ticket fieldsets page
+				} elseif ( $post_type === 'ticket-meta-fieldset' ) {
+					// Check if we're on the ticket fieldsets page.
 					$is_et_page = true;
 				}
 

--- a/src/Tickets/Admin/Onboarding/Tickets_Landing_Page.php
+++ b/src/Tickets/Admin/Onboarding/Tickets_Landing_Page.php
@@ -55,6 +55,24 @@ class Tickets_Landing_Page extends Abstract_Admin_Page {
 	const VISITED_GUIDED_SETUP_OPTION = 'tec_tickets_onboarding_wizard_visited_guided_setup';
 
 	/**
+	 * The option to redirect to the guided setup after bulk activation.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const BULK_ACTIVATION_REDIRECT_OPTION = '_tec_tickets_wizard_redirect';
+
+	/**
+	 * The option to redirect to the guided setup after single activation.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const ACTIVATION_REDIRECT_OPTION = '_tec_tickets_activation_redirect';
+
+	/**
 	 * The slug for the admin menu.
 	 *
 	 * @since TBD
@@ -222,6 +240,7 @@ class Tickets_Landing_Page extends Abstract_Admin_Page {
 
 		// Stop redirecting if the user has visited the Guided Setup page.
 		tribe_update_option( self::VISITED_GUIDED_SETUP_OPTION, true );
+		delete_transient( '_tribe_tickets_activation_redirect' );
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -235,13 +235,16 @@ class Tribe__Tickets__Main {
 		// Will be used to set up Stripe webhook on admin_init.
 		set_transient( 'tec_tickets_commerce_setup_stripe_webhook', true );
 
-		// Set a transient we can use when deciding whether or not to show update/welcome splash pages
+		// Set a transient we can use when deciding whether or not to show update/welcome splash pages.
 		if ( is_network_admin() ) {
 			// Never redirect on network admin.
 			return;
 		}
 
-		if ( isset( $_POST['checked'] ) && count( $_POST['checked'] ) > 1 ) {
+		// Get the checked plugins from the request. If there are more than one, we're doing a bulk activation.
+		$checked = tec_get_request_var( 'checked', [] );
+
+		if (  count( $checked ) > 1 ) {
 			// If multiple plugins are being activated, set the wizard redirect transient, this should only trigger redirection on a ET admin page visit.
 			set_transient( Landing_Page::BULK_ACTIVATION_REDIRECT_OPTION, 1, 30 );
 		} else {

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -8,6 +8,7 @@ use Tribe\Tickets\Events\Service_Provider as Events_Service_Provider;
 use Tribe\Tickets\Promoter\Service_Provider as Promoter_Service_Provider;
 use Tribe\Tickets\Admin\Settings;
 use TEC\Common\StellarWP\Assets\Config as Assets_Config;
+use TEC\Tickets\Admin\Onboarding\Landing_Page;
 
 /**
  * Class Tribe__Tickets__Main.
@@ -123,6 +124,8 @@ class Tribe__Tickets__Main {
 	protected $move_ticket_types;
 
 	/**
+	 * @deprecated TBD
+	 *
 	 * @var Tribe__Admin__Activation_Page
 	 */
 	protected $activation_page;
@@ -220,11 +223,6 @@ class Tribe__Tickets__Main {
 	 * Fires when the plugin is activated.
 	 */
 	public function on_activation() {
-		// Set a transient we can use when deciding whether or not to show update/welcome splash pages
-		if ( ! is_network_admin() && ! isset( $_GET['activate-multi'] ) ) {
-			set_transient( '_tribe_tickets_activation_redirect', 1, 30 );
-		}
-
 		// Set plugin activation time for all installs.
 		if ( is_admin() ) {
 			// Avoid a race condition and fatal by waiting until Common is loaded before we try to run this.
@@ -234,8 +232,22 @@ class Tribe__Tickets__Main {
 			);
 		}
 
-		// Will be used to set up Stripe webwook on admin_init.
+		// Will be used to set up Stripe webhook on admin_init.
 		set_transient( 'tec_tickets_commerce_setup_stripe_webhook', true );
+
+		// Set a transient we can use when deciding whether or not to show update/welcome splash pages
+		if ( is_network_admin() ) {
+			// Never redirect on network admin.
+			return;
+		}
+
+		if ( isset( $_POST['checked'] ) && count( $_POST['checked'] ) > 1 ) {
+			// If multiple plugins are being activated, set the wizard redirect transient, this should only trigger redirection on a ET admin page visit.
+			set_transient( Landing_Page::BULK_ACTIVATION_REDIRECT_OPTION, 1, 30 );
+		} else {
+			// If a single plugin is being activated, set the activation redirect transient for immediate redirection.
+			set_transient( Landing_Page::ACTIVATION_REDIRECT_OPTION, 1, 30 );
+		}
 	}
 
 	/**
@@ -471,7 +483,6 @@ class Tribe__Tickets__Main {
 		$this->user_event_confirmation_list_shortcode();
 		$this->move_tickets();
 		$this->move_ticket_types();
-		$this->activation_page();
 
 		Tribe__Tickets__JSON_LD__Order::hook();
 		Tribe__Tickets__JSON_LD__Type::hook();
@@ -964,9 +975,13 @@ class Tribe__Tickets__Main {
 	}
 
 	/**
+	 * @deprecated TBD
+	 *
 	 * @return Tribe__Admin__Activation_Page
 	 */
 	public function activation_page() {
+		_deprecated_function( __METHOD__, 'TBD', 'Now handled by TEC\Tickets\Admin\Onboarding\Controller' );
+
 		if ( empty( $this->activation_page ) ) {
 			$this->activation_page = new Tribe__Admin__Activation_Page( [
 				'slug'                  => 'event-tickets',

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -8,7 +8,7 @@ use Tribe\Tickets\Events\Service_Provider as Events_Service_Provider;
 use Tribe\Tickets\Promoter\Service_Provider as Promoter_Service_Provider;
 use Tribe\Tickets\Admin\Settings;
 use TEC\Common\StellarWP\Assets\Config as Assets_Config;
-use TEC\Tickets\Admin\Onboarding\Landing_Page;
+use TEC\Tickets\Admin\Onboarding\Tickets_Landing_Page;
 
 /**
  * Class Tribe__Tickets__Main.
@@ -246,10 +246,10 @@ class Tribe__Tickets__Main {
 
 		if ( count( $checked ) > 1 ) {
 			// If multiple plugins are being activated, set the wizard redirect transient, this should only trigger redirection on a ET admin page visit.
-			set_transient( Landing_Page::BULK_ACTIVATION_REDIRECT_OPTION, 1, 30 );
+			set_transient( Tickets_Landing_Page::BULK_ACTIVATION_REDIRECT_OPTION, 1, 30 );
 		} else {
 			// If a single plugin is being activated, set the activation redirect transient for immediate redirection.
-			set_transient( Landing_Page::ACTIVATION_REDIRECT_OPTION, 1, 30 );
+			set_transient( Tickets_Landing_Page::ACTIVATION_REDIRECT_OPTION, 1, 30 );
 		}
 	}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -244,7 +244,7 @@ class Tribe__Tickets__Main {
 		// Get the checked plugins from the request. If there are more than one, we're doing a bulk activation.
 		$checked = tec_get_request_var( 'checked', [] );
 
-		if (  count( $checked ) > 1 ) {
+		if ( count( $checked ) > 1 ) {
 			// If multiple plugins are being activated, set the wizard redirect transient, this should only trigger redirection on a ET admin page visit.
 			set_transient( Landing_Page::BULK_ACTIVATION_REDIRECT_OPTION, 1, 30 );
 		} else {

--- a/tests/ft_ct1_migration.suite.dist.yml
+++ b/tests/ft_ct1_migration.suite.dist.yml
@@ -27,7 +27,9 @@ modules:
         dbPassword: %WP_DB_PASSWORD%
         plugins:
           - the-events-calendar/the-events-calendar.php
+          - events-pro/events-calendar-pro.php
           - event-tickets/event-tickets.php
         activatePlugins:
           - the-events-calendar/the-events-calendar.php
+          - events-pro/events-calendar-pro.php
           - event-tickets/event-tickets.php

--- a/tests/ft_ct1_migration.suite.dist.yml
+++ b/tests/ft_ct1_migration.suite.dist.yml
@@ -25,3 +25,9 @@ modules:
         dbHost: %WP_DB_HOST%
         dbUser: %WP_DB_USER%
         dbPassword: %WP_DB_PASSWORD%
+        plugins:
+          - the-events-calendar/the-events-calendar.php
+          - event-tickets/event-tickets.php
+        activatePlugins:
+          - the-events-calendar/the-events-calendar.php
+          - event-tickets/event-tickets.php

--- a/tests/ft_ct1_migration/_bootstrap.php
+++ b/tests/ft_ct1_migration/_bootstrap.php
@@ -80,11 +80,9 @@ $clean_after_test = static function () {
 };
 addListener( Codeception\Events::TEST_AFTER, $clean_after_test );
 
-// Move the CT1 setup to plugins_loaded action
 addListener( Codeception\Events::SUITE_BEFORE, static function () {
 	putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 	$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
-
 	add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
 	tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
 	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );

--- a/tests/ft_ct1_migration/_bootstrap.php
+++ b/tests/ft_ct1_migration/_bootstrap.php
@@ -81,7 +81,6 @@ $clean_after_test = static function () {
 addListener( Codeception\Events::TEST_AFTER, $clean_after_test );
 
 addListener( Codeception\Events::SUITE_BEFORE, static function () {
-	require_once __DIR__ . '/../../common/src/Tribe/Container.php';
 	putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 	$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
 	add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );

--- a/tests/ft_ct1_migration/_bootstrap.php
+++ b/tests/ft_ct1_migration/_bootstrap.php
@@ -85,7 +85,6 @@ addListener( Codeception\Events::SUITE_BEFORE, static function () {
 	putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 	$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
 
-
 	add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
 	tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
 	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );

--- a/tests/ft_ct1_migration/_bootstrap.php
+++ b/tests/ft_ct1_migration/_bootstrap.php
@@ -81,12 +81,13 @@ $clean_after_test = static function () {
 addListener( Codeception\Events::TEST_AFTER, $clean_after_test );
 
 addListener( Codeception\Events::SUITE_BEFORE, static function () {
+	$container = \Tribe__Container::init();
 	putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 	$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
 	add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
-	tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
-	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
-	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Models\Provider::class );
+	$container->register( TEC\Events\Custom_Tables\V1\Provider::class );
+	$container->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
+	$container->register( TEC\Events_Pro\Custom_Tables\V1\Models\Provider::class );
 
 	delete_transient( 'tec_custom_tables_v1_initialized' );
 	wp_cache_delete( 'tec_custom_tables_v1_initialized' );

--- a/tests/ft_ct1_migration/_bootstrap.php
+++ b/tests/ft_ct1_migration/_bootstrap.php
@@ -80,25 +80,30 @@ $clean_after_test = static function () {
 };
 addListener( Codeception\Events::TEST_AFTER, $clean_after_test );
 
+// Set environment variables early
+putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
+$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
+
+// Move the CT1 setup to plugins_loaded action
 addListener( Codeception\Events::SUITE_BEFORE, static function () {
-	putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
-	$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
-	add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
-	tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
-	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
-	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Models\Provider::class );
+	add_action('plugins_loaded', static function() {
+		add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
+		tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
+		tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
+		tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Models\Provider::class );
 
-	delete_transient( 'tec_custom_tables_v1_initialized' );
-	wp_cache_delete( 'tec_custom_tables_v1_initialized' );
+		delete_transient( 'tec_custom_tables_v1_initialized' );
+		wp_cache_delete( 'tec_custom_tables_v1_initialized' );
 
-	// Run the activation routines to ensure the tables will be set up independently of the previous state.
-	TEC_Activation::init();
-	Activation::init();
-	do_action( 'tec_events_custom_tables_v1_load_action_scheduler' );
+		// Run the activation routines
+		TEC_Activation::init();
+		Activation::init();
+		do_action( 'tec_events_custom_tables_v1_load_action_scheduler' );
 
-	global $wpdb;
-	// Increase the posts table auto increment value to avoid conflicts with the test data.
-	if ( $wpdb->query( "ALTER TABLE $wpdb->posts AUTO_INCREMENT = 12389" ) === false ) {
-		throw new RuntimeException( 'Failed to set the posts table auto increment value.' );
-	}
-} );
+		global $wpdb;
+		// Increase the posts table auto increment value
+		if ( $wpdb->query( "ALTER TABLE $wpdb->posts AUTO_INCREMENT = 12389" ) === false ) {
+			throw new RuntimeException( 'Failed to set the posts table auto increment value.' );
+		}
+	}, 20); // Run after TEC and ET are loaded
+});

--- a/tests/ft_ct1_migration/_bootstrap.php
+++ b/tests/ft_ct1_migration/_bootstrap.php
@@ -81,13 +81,13 @@ $clean_after_test = static function () {
 addListener( Codeception\Events::TEST_AFTER, $clean_after_test );
 
 addListener( Codeception\Events::SUITE_BEFORE, static function () {
-	$container = \Tribe__Container::init();
+	require_once __DIR__ . '/../../common/src/Tribe/Container.php';
 	putenv( 'TEC_CUSTOM_TABLES_V1_DISABLED=0' );
 	$_ENV['TEC_CUSTOM_TABLES_V1_DISABLED'] = 0;
 	add_filter( 'tec_events_custom_tables_v1_enabled', '__return_true' );
-	$container->register( TEC\Events\Custom_Tables\V1\Provider::class );
-	$container->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
-	$container->register( TEC\Events_Pro\Custom_Tables\V1\Models\Provider::class );
+	tribe()->register( TEC\Events\Custom_Tables\V1\Provider::class );
+	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Provider::class );
+	tribe()->register( TEC\Events_Pro\Custom_Tables\V1\Models\Provider::class );
 
 	delete_transient( 'tec_custom_tables_v1_initialized' );
 	wp_cache_delete( 'tec_custom_tables_v1_initialized' );


### PR DESCRIPTION
### 🎫 Ticket(s)

[ET-2358] [ET-2359]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This deprecates the `Main.php` instance of `Tribe__Admin__Activation_Page` and the function that instantiates it. Instead, it leverages the new Onboarding Wizard's controller to handle the redirect.

The redirect happens immediately on a standalone ET install. 
After a bulk activation of ET and other plugins, it will happen on the next ET admin page load.

### 🎥 Artifacts <!-- if applicable-->

#### Bulk activation:
https://www.loom.com/share/f185abe7917a4337a253e53cad8061bd?sid=77600b72-7236-46aa-9f2a-69d5df4535f3

#### Standalone activation:
https://www.loom.com/share/698a93974d0a4dc7aa5b5124d96cf2e3?sid=4e8f82f0-6b57-43d9-a53a-b68a8d3e93d9

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2358]: https://stellarwp.atlassian.net/browse/ET-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-2359]: https://stellarwp.atlassian.net/browse/ET-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ