### PR TITLE
Fix translations called too early

### DIFF
--- a/src/Tickets/Assets.php
+++ b/src/Tickets/Assets.php
@@ -39,9 +39,11 @@ class Assets extends Service_Provider {
 			[
 				'localize' => [
 					'name' => 'tecTicketsSettings',
-					'data' => [
-						'debug' => defined( 'WP_DEBUG' ) && WP_DEBUG
-					],
+					'data' => static function() {
+						return [
+							'debug' => defined( 'WP_DEBUG' ) && WP_DEBUG
+						];
+					},
 				],
 			]
 		);

--- a/src/Tickets/Commerce/Gateways/PayPal/Assets.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Assets.php
@@ -40,12 +40,13 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 				'localize' => [
 					[
 						'name' => 'tribeTicketsCommercePayPaCommerce',
-						'data' => [
-							'translations' => [
-								'confirmPaypalAccountDisconnection' => esc_html__( 'Disconnect PayPal Account', 'event-tickets' ),
-								'disconnectPayPalAccount'           => esc_html__( 'Are you sure you want to disconnect your PayPal account?', 'event-tickets' ),
-								'connectSuccessTitle'               => esc_html__( 'You’re connected to PayPal! Here’s what’s next...', 'event-tickets' ),
-								'pciWarning'                        => sprintf(
+						'data' => static function() {
+							return [
+								'translations'              => [
+									'confirmPaypalAccountDisconnection' => esc_html__( 'Disconnect PayPal Account', 'event-tickets' ),
+									'disconnectPayPalAccount'          => esc_html__( 'Are you sure you want to disconnect your PayPal account?', 'event-tickets' ),
+								'connectSuccessTitle'       => esc_html__( 'You’re connected to PayPal! Here’s what’s next...', 'event-tickets' ),
+								'pciWarning'                => sprintf(
 									__(
 										'PayPal allows you to accept credit or debit cards directly on your website. Because of
 										this, your site needs to maintain <a href="%1$s" target="_blank">PCI-DDS compliance</a>.
@@ -55,20 +56,21 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 									// @todo Replace this URL.
 									'https://www.theeventscalendar.com/documentation/resources/pci-compliance/'
 								),
-								'pciComplianceInstructions'         => [
+								'pciComplianceInstructions' => [
 									esc_html__( 'Using a trusted, secure hosting provider – preferably one which claims and actively promotes PCI compliance.', 'event-tickets' ),
 									esc_html__( 'Maintain security best practices when setting passwords and limit access to your server.', 'event-tickets' ),
 									esc_html__( 'Implement an SSL certificate to keep your payments secure.', 'event-tickets' ),
 									esc_html__( 'Keep plugins up to date to ensure latest security fixes are present.', 'event-tickets' ),
 								],
-								'liveWarning'                       => tec_tickets_commerce_is_sandbox_mode()
+								'liveWarning'               => tec_tickets_commerce_is_sandbox_mode()
 									? esc_html__( 'You have connected your account for test mode. You will need to connect again once you are in live mode.', 'event-tickets' )
 									: '',
-							],
-						],
+								],
+							];
+						},
 					],
 				],
-			]
+			],
 		);
 
 		/**
@@ -108,10 +110,10 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 							'orderEndpoint' => tribe( Order_Endpoint::class )->get_route_url(),
 							'advancedPayments' => [
 								'fieldPlaceholders' => [
-									'cvv' => esc_html__( 'E.g.: 123', 'event-tickets' ),
+									'cvv'            => esc_html__( 'E.g.: 123', 'event-tickets' ),
 									'expirationDate' => esc_html__( 'E.g.: 03/26', 'event-tickets' ),
-									'number' => esc_html__( 'E.g.: 4111 1111 1111 1111', 'event-tickets' ),
-									'zipCode' => esc_html__( 'E.g.: 01020', 'event-tickets' ),
+									'number'         => esc_html__( 'E.g.: 4111 1111 1111 1111', 'event-tickets' ),
+									'zipCode'        => esc_html__( 'E.g.: 01020', 'event-tickets' ),
 								]
 							],
 						];

--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -17,6 +17,14 @@ use TEC\Tickets\Commerce\Reports\Attendees as Attendees_Reports;
 class Module extends \Tribe__Tickets__Tickets {
 
 	public function __construct() {
+		if( did_action( 'init' ) ) {
+			$this->init();
+		} else {
+			add_action( 'init', [ $this, 'init' ] );
+		}
+	}
+
+	public function init() {
 		// This needs to happen before parent construct.
 		$this->plugin_name = __( 'Tickets Commerce', 'event-tickets' );
 

--- a/src/Tickets/Commerce/Order_Modifiers/Controller.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Controller.php
@@ -124,7 +124,10 @@ final class Controller extends Controller_Contract {
 		$this->container->singleton( Coupon::class );
 
 		$this->register_flag_actions();
-		$this->run_deprecated_coupon_filter();
+
+		add_action( 'init', function() {
+			$this->run_deprecated_coupon_filter();
+		} );
 
 		add_action( 'init', [ $this, 'set_currency_defaults' ] );
 	}

--- a/src/Tickets/Provider.php
+++ b/src/Tickets/Provider.php
@@ -43,7 +43,6 @@ class Provider extends Service_Provider {
 	 */
 	public function register() {
 		if ( $this->has_registered ) {
-
 			return false;
 		}
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -130,12 +130,14 @@ class Tribe__Tickets__Assets {
 						'tribe-tickets-rsvp',
 						'tribe-tickets-registration-page',
 					],
-					'localize' => [
-						[
+					'localize' => static function() {
+						return [
+							[
 							'name' => 'TribeCurrency',
-							'data' => [ 'Tribe__Tickets__Tickets', 'get_asset_localize_data_for_currencies' ],
-						],
-					],
+								'data' => [ 'Tribe__Tickets__Tickets', 'get_asset_localize_data_for_currencies' ],
+							],
+						];
+					},
 				]
 			);
 

--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -214,12 +214,14 @@ class Tribe__Tickets__Editor__Blocks__Rsvp extends Tribe__Editor__Blocks__Abstra
 			[
 				'localize' => [
 					'name' => 'TribeRsvp',
-					'data' => [
-						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
-						'nonces'  => [
-							'rsvpHandle' => wp_create_nonce( 'tribe_tickets_rsvp_handle' )
-						],
-					],
+					'data' => static function() {
+						return [
+							'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
+							'nonces'  => [
+								'rsvpHandle' => wp_create_nonce( 'tribe_tickets_rsvp_handle' )
+							],
+						];
+					},
 				],
 			]
 		);
@@ -246,12 +248,14 @@ class Tribe__Tickets__Editor__Blocks__Rsvp extends Tribe__Editor__Blocks__Abstra
 				'conditionals' => [ $this, 'should_enqueue_ari' ],
 				'localize' => [
 					'name' => 'TribeRsvp',
-					'data' => [
-						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
-						'nonces'  => [
-							'rsvpHandle' => wp_create_nonce( 'tribe_tickets_rsvp_handle' )
-						],
-					],
+					'data' => static function() {
+						return [
+							'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
+							'nonces'  => [
+								'rsvpHandle' => wp_create_nonce( 'tribe_tickets_rsvp_handle' )
+							],
+						];
+					},
 				],
 			]
 		);
@@ -271,10 +275,12 @@ class Tribe__Tickets__Editor__Blocks__Rsvp extends Tribe__Editor__Blocks__Abstra
 			[
 				'localize' => [
 					'name' => 'TribeRsvp',
-					'data' => [
-						'ajaxurl'    => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
-						'cancelText' => __( 'Are you sure you want to cancel?', 'event-tickets' ),
-					],
+					'data' => static function() {
+						return [
+							'ajaxurl'    => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
+							'cancelText' => __( 'Are you sure you want to cancel?', 'event-tickets' ),
+						];
+					},
 				],
 				'groups'   => 'tribe-tickets-rsvp',
 			]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1245,7 +1245,9 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$this->parent_url  = $this->parentUrl  = trailingslashit( plugins_url( '', $this->parent_path ) );
 
 			// Register all Tribe__Tickets__Tickets api consumers
-			self::$active_modules[ $this->class_name ] = $this->plugin_name;
+			add_action( 'init', function() {
+				self::$active_modules[ $this->class_name ] = $this->plugin_name;
+			} );
 
 			add_action( 'wp', [ $this, 'hook' ] );
 


### PR DESCRIPTION
All of these changes address `Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the event-tickets domain was triggered too early.` issues I have encountered while trying to style an admin page.