### PR TITLE
Ensure the telemetry modal is not shown on the onboarding landing page.

### DIFF
--- a/src/Tickets/Admin/Onboarding/Controller.php
+++ b/src/Tickets/Admin/Onboarding/Controller.php
@@ -100,6 +100,7 @@ class Controller extends Controller_Contract {
 		add_filter( 'tec_tickets_onboarding_wizard_handle', [ $this->steps['payments'], 'handle' ], 12, 2 );
 		add_filter( 'tec_tickets_onboarding_wizard_handle', [ $this->steps['communication'], 'handle' ], 13, 2 );
 		add_filter( 'tec_tickets_onboarding_wizard_handle', [ $this->steps['events'], 'handle' ], 14, 2 );
+		add_filter( 'tec_telemetry_is_et_admin_page', [ $this, 'hide_telemetry_on_onboarding_page' ], 10, 1 );
 	}
 
 	/**
@@ -128,6 +129,7 @@ class Controller extends Controller_Contract {
 		remove_filter( 'tec_tickets_onboarding_wizard_handle', [ $this->steps['payments'], 'handle' ], 12 );
 		remove_filter( 'tec_tickets_onboarding_wizard_handle', [ $this->steps['communication'], 'handle' ], 13 );
 		remove_filter( 'tec_tickets_onboarding_wizard_handle', [ $this->steps['events'], 'handle' ], 14 );
+		remove_filter( 'tec_telemetry_is_et_admin_page', [ $this, 'hide_telemetry_on_onboarding_page' ], 10 );
 	}
 
 	/**
@@ -301,5 +303,22 @@ class Controller extends Controller_Contract {
 	 */
 	public function register_rest_endpoints(): void {
 		$this->container->make( API::class )->register();
+	}
+
+	/**
+	 * Hide telemetry on the onboarding page by returning false when the page is detected.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $is_et_admin_page Whether the current page is an ET admin page.
+	 *
+	 * @return bool
+	 */
+	public function hide_telemetry_on_onboarding_page( $is_et_admin_page ): bool {
+		if ( Landing_Page::is_on_page() ) {
+			return false;
+		}
+
+		return $is_et_admin_page;
 	}
 }

--- a/src/Tickets/Telemetry/Telemetry.php
+++ b/src/Tickets/Telemetry/Telemetry.php
@@ -188,13 +188,42 @@ class Telemetry {
 			return;
 		}
 
+		if ( ! static::is_et_admin_page() ) {
+			return;
+		}
+
+		$show = Common_Telemetry::calculate_modal_status();
+
+		if ( ! $show ) {
+			return;
+		}
+
+		// 'event-tickets'
+		$telemetry_slug = substr( basename( EVENT_TICKETS_MAIN_PLUGIN_FILE ), 0, -4 );
+
+		/**
+		 * Fires to trigger the modal content on admin pages.
+		 *
+		 * @since 5.6.0.1
+		 */
+		do_action( 'tec_telemetry_modal', $telemetry_slug );
+	}
+
+	/**
+	 * Determines if the current page is an ET admin page.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the current page is an ET admin page.
+	 */
+	public static function is_et_admin_page(): bool {
 		$current_screen = get_current_screen();
 		$admin_helpers = Tribe__Admin__Helpers::instance();
 		$admin_pages   = tribe( 'admin.pages' );
 		$admin_page    = $admin_pages->get_current_page();
 
 		if ( ! $admin_helpers->is_screen() ) {
-			return;
+			return false;
 		}
 
 		if (
@@ -225,21 +254,7 @@ class Telemetry {
 			return false;
 		}
 
-		$show = Common_Telemetry::calculate_modal_status();
-
-		if ( ! $show ) {
-			return;
-		}
-
-		// 'event-tickets'
-		$telemetry_slug = substr( basename( EVENT_TICKETS_MAIN_PLUGIN_FILE ), 0, -4 );
-
-		/**
-		 * Fires to trigger the modal content on admin pages.
-		 *
-		 * @since 5.6.0.1
-		 */
-		do_action( 'tec_telemetry_modal', $telemetry_slug );
+		return (bool) apply_filters( 'tec_telemetry_is_et_admin_page', true );
 	}
 
 	/**


### PR DESCRIPTION
[ET-2380]

<img width="1113" alt="Screenshot 2025-05-05 at 5 44 31 PM" src="https://github.com/user-attachments/assets/f19c4cf2-b2dc-45a5-bceb-e70b65f193cf" />


[ET-2380]: https://stellarwp.atlassian.net/browse/ET-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ