### PR TITLE
ET-2450 orders quicklink for pages

### DIFF
--- a/changelog/fix-ET-2450-orders-quicklink-for-pages
+++ b/changelog/fix-ET-2450-orders-quicklink-for-pages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add "Orders" link in the admin page row actions menu for pages with Tickets Commerce tickets. [ET-2450]

--- a/src/Tickets/Commerce/Reports/Orders.php
+++ b/src/Tickets/Commerce/Reports/Orders.php
@@ -189,6 +189,7 @@ class Orders extends Report_Abstract {
 	 */
 	public function hook() {
 		add_filter( 'post_row_actions', [ $this, 'add_orders_row_action' ], 10, 2 );
+		add_filter( 'page_row_actions', [ $this, 'add_orders_row_action' ], 10, 2 );
 		// Register before the default priority of 10 to avoid submenu hook issues.
 		add_action( 'admin_menu', [ $this, 'register_orders_page' ], 5 );
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-2450]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

When looking at the page list in the back-end, pages with Tickets Commerce tickets were missing the quicklink to the "Orders" page. This PR adds the filter that solves it, mimicking how it's done for the Attendees quicklinks.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot](https://dl.dropboxusercontent.com/scl/fi/zqp2aethigiw2lj0a1ami/shot_250513_144843.png?rlkey=mls1lnsawv3cccx1xe0ffrov8&dl=0)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
