### PR TITLE
Use is_active filter

### DIFF
--- a/src/Tickets/Admin/Onboarding/Controller.php
+++ b/src/Tickets/Admin/Onboarding/Controller.php
@@ -166,6 +166,12 @@ class Controller extends Controller_Contract {
 	 * @return void
 	 */
 	public function redirect_tec_pages_to_guided_setup(): void {
+
+		// Early bail if not active.
+		if ( ! $this->is_active() ) {
+			return;
+		}
+
 		// Early bail if already on guided setup page.
 		if ( Landing_Page::$slug === tec_get_request_var( 'page' ) ) {
 			return;


### PR DESCRIPTION
### 🎫 Ticket

[ET-2339]

### 🗒️ Description

We had a filter in our Controller `tec_tickets_onboarding_is_active` that wasn't applied anywhere.

[ET-2339]: https://stellarwp.atlassian.net/browse/ET-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ