### PR TITLE
Fix/idempotent event processing

### DIFF
--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -10,6 +10,7 @@
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_Merchant;
+use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 use Exception;
 
 /**
@@ -54,7 +55,7 @@ class Merchant extends Abstract_Merchant {
 	 *
 	 * @var string
 	 */
-	public static string $merchant_default_currency_option_key = 'tickets-commerce-merchant-currency';
+	public static string $merchant_default_currency_option_key = 'tickets-commerce-merchant-currency-%s';
 
 	/**
 	 * Option key to save the PKCE code verifier for OAuth authentication.
@@ -375,7 +376,7 @@ class Merchant extends Abstract_Merchant {
 	 * @return string
 	 */
 	public function get_merchant_currency(): string {
-		return get_option( static::$merchant_default_currency_option_key, 'USD' );
+		return (string) Commerce_Settings::get_option( static::$merchant_default_currency_option_key, [], 'USD' );
 	}
 
 	/**
@@ -528,7 +529,7 @@ class Merchant extends Abstract_Merchant {
 			if ( isset( $merchant['currency'] ) ) {
 				$update_data['merchant_currency'] = $merchant['currency'];
 				// Also update the option.
-				update_option( static::$merchant_default_currency_option_key, $merchant['currency'] );
+				Commerce_Settings::update_option( static::$merchant_default_currency_option_key, $merchant['currency'] );
 			}
 
 			if ( isset( $merchant['email_address'] ) ) {
@@ -703,6 +704,17 @@ class Merchant extends Abstract_Merchant {
 	 * @return bool
 	 */
 	public function is_ready_to_sell(): bool {
-		return (bool) $this->get_location_id();
+		return (bool) $this->get_location_id() && $this->is_currency_matching();
+	}
+
+	/**
+	 * Whether the merchant's currency matches the gateway's currency.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_currency_matching(): bool {
+		return $this->get_merchant_currency() === tribe_get_option( Commerce_Settings::$option_currency_code, 'USD' );
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
@@ -39,6 +39,15 @@ class Notices_Controller extends Controller_Contract {
 	public const NOT_READY_TO_SELL_NOTICE_SLUG = 'tec-tickets-commerce-square-not-ready-to-sell-notice';
 
 	/**
+	 * Currency mismatch notice slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const CURRENCY_MISMATCH_NOTICE_SLUG = 'tec-tickets-commerce-square-currency-mismatch-notice';
+
+	/**
 	 * Webhooks instance.
 	 *
 	 * @since TBD
@@ -111,6 +120,17 @@ class Notices_Controller extends Controller_Contract {
 			],
 			[ $this, 'should_display_not_ready_to_sell_notice' ]
 		);
+
+		tribe_notice(
+			self::CURRENCY_MISMATCH_NOTICE_SLUG,
+			[ $this, 'render_currency_mismatch_notice' ],
+			[
+				'type'     => 'error',
+				'dismiss'  => false,
+				'priority' => 10,
+			],
+			[ $this, 'should_display_currency_mismatch_notice' ]
+		);
 	}
 
 	/**
@@ -178,7 +198,30 @@ class Notices_Controller extends Controller_Contract {
 			return false;
 		}
 
-		return ! $this->merchant->is_ready_to_sell();
+		return ! (bool) $this->merchant->get_location_id();
+	}
+
+	/**
+	 * Determines if the not ready to sell notice should be displayed.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_display_currency_mismatch_notice() {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		if ( ! $this->gateway->is_enabled() ) {
+			return false;
+		}
+
+		if ( ! $this->gateway->is_active() ) {
+			return false;
+		}
+
+		return ! $this->merchant->is_currency_matching();
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\Contracts\Container;
+use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 
 /**
  * Class Controller
@@ -149,7 +150,7 @@ class Notices_Controller extends Controller_Contract {
 	 *
 	 * @return bool
 	 */
-	public function should_display_webhook_notice() {
+	public function should_display_webhook_notice(): bool {
 		// Only show on admin pages.
 		if ( ! is_admin() ) {
 			return false;
@@ -185,7 +186,7 @@ class Notices_Controller extends Controller_Contract {
 	 *
 	 * @return bool
 	 */
-	public function should_display_not_ready_to_sell_notice() {
+	public function should_display_not_ready_to_sell_notice(): bool {
 		if ( ! is_admin() ) {
 			return false;
 		}
@@ -208,7 +209,7 @@ class Notices_Controller extends Controller_Contract {
 	 *
 	 * @return bool
 	 */
-	public function should_display_currency_mismatch_notice() {
+	public function should_display_currency_mismatch_notice(): bool {
 		if ( ! is_admin() ) {
 			return false;
 		}
@@ -231,7 +232,7 @@ class Notices_Controller extends Controller_Contract {
 	 *
 	 * @return string
 	 */
-	public function render_webhook_notice() {
+	public function render_webhook_notice(): string {
 		$webhook_id = $this->webhooks->get_webhook_id();
 
 		$issues = [];
@@ -279,13 +280,38 @@ class Notices_Controller extends Controller_Contract {
 	 *
 	 * @return string
 	 */
-	public function render_not_ready_to_sell_notice() {
+	public function render_not_ready_to_sell_notice(): string {
 		return sprintf(
 			'<p><strong>%1$s</strong></p><p>%2$s</p><p><a href="%3$s" class="button button-primary">%4$s</a></p>',
 			esc_html__( 'Square Location not configured', 'event-tickets' ),
 			esc_html__( 'The Square payment gateway is not ready to sell until you configure a Business Location. .', 'event-tickets' ),
 			esc_url( admin_url( 'admin.php?page=tec-tickets-settings&tab=square' ) ),
 			esc_html__( 'Configure Business Location', 'event-tickets' )
+		);
+	}
+
+	/**
+	 * Render the not ready to sell notice.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function render_currency_mismatch_notice(): string {
+		$square_currency           = $this->merchant->get_merchant_currency();
+		$tickets_commerce_currency = tribe_get_option( Commerce_Settings::$option_currency_code, 'USD' );
+
+		return sprintf(
+			'<p><strong>%1$s</strong></p><p>%2$s</p><p><a href="%3$s" class="button button-primary">%4$s</a></p>',
+			esc_html__( 'Square Currency Mismatch', 'event-tickets' ),
+			sprintf(
+				/* translators: %1$s: Square currency. %2$s: TicketsCommerce currency. */
+				esc_html__( 'The Square payment gateway is accepting payments in %1$s but your TicketsCommerce Currency is set to %2$s.', 'event-tickets' ),
+				$square_currency,
+				$tickets_commerce_currency
+			),
+			esc_url( admin_url( 'admin.php?page=tec-tickets-settings&tab=payments' ) ),
+			esc_html__( 'Configure TicketsCommerce Currency', 'event-tickets' )
 		);
 	}
 
@@ -298,7 +324,7 @@ class Notices_Controller extends Controller_Contract {
 	 *
 	 * @return bool Whether this is a Tickets admin page.
 	 */
-	protected function is_tickets_admin_page( $screen_id ) {
+	protected function is_tickets_admin_page( $screen_id ): bool {
 		$valid_screens = [
 			'tickets_page_tec-tickets-settings',
 			'tickets_page_tec-tickets-commerce-orders',

--- a/src/Tickets/Commerce/Gateways/Square/Order.php
+++ b/src/Tickets/Commerce/Gateways/Square/Order.php
@@ -778,7 +778,7 @@ class Order extends Abstract_Order {
 		// Our booking fees are supports as service charges.
 		$booking_fees = $square_order['service_charges'] ?? [];
 
-		foreach ( $booking_fees as $offset => $fee ) {
+		foreach ( $booking_fees as $fee ) {
 			$items[] = [
 				'id'           => $fee['metadata']['local_id'] ?? 0,
 				'type'         => 'fee',
@@ -786,6 +786,26 @@ class Order extends Abstract_Order {
 				'sub_total'    => ( new Precision_Value( $fee['applied_money']['amount'] / 100 ) )->get(),
 				'fee_id'       => $fee['metadata']['local_id'] ?? 0,
 				'display_name' => $fee['name'],
+				'ticket_id'    => 0,
+				'event_id'     => 0,
+				'quantity'     => 1,
+			];
+		}
+
+		$taxes = $square_order['taxes'] ?? [];
+
+		foreach ( $taxes as $tax ) {
+			if ( $tax['type'] !== 'ADDITIVE' ) {
+				continue;
+			}
+
+			$items[] = [
+				'id'           => $tax['uid'],
+				'type'         => 'fee',
+				'price'        => ( new Precision_Value( $tax['applied_money']['amount'] / 100 ) )->get(),
+				'sub_total'    => ( new Precision_Value( $tax['applied_money']['amount'] / 100 ) )->get(),
+				'fee_id'       => $tax['uid'],
+				'display_name' => $tax['name'],
 				'ticket_id'    => 0,
 				'event_id'     => 0,
 				'quantity'     => 1,

--- a/src/Tickets/Commerce/Gateways/Square/Order.php
+++ b/src/Tickets/Commerce/Gateways/Square/Order.php
@@ -800,11 +800,11 @@ class Order extends Abstract_Order {
 			}
 
 			$items[] = [
-				'id'           => $tax['uid'],
+				'id'           => 'square-tax-' . $tax['uid'],
 				'type'         => 'fee',
 				'price'        => ( new Precision_Value( $tax['applied_money']['amount'] / 100 ) )->get(),
 				'sub_total'    => ( new Precision_Value( $tax['applied_money']['amount'] / 100 ) )->get(),
-				'fee_id'       => $tax['uid'],
+				'fee_id'       => 'square-tax-' . $tax['uid'],
 				'display_name' => $tax['name'],
 				'ticket_id'    => 0,
 				'event_id'     => 0,

--- a/src/Tickets/Commerce/Gateways/Square/Order.php
+++ b/src/Tickets/Commerce/Gateways/Square/Order.php
@@ -385,6 +385,12 @@ class Order extends Abstract_Order {
 			return null;
 		}
 
+		$event_id = $event_data['id'] ?? '';
+
+		if ( $event_id ) {
+			Commerce_Meta::add( $order->ID, REST\Webhook_Endpoint::KEY_ORDER_WEBHOOK_IDS, $event_id, [], 'post', false );
+		}
+
 		$payments = $square_order['tenders'] ?? [];
 
 		if ( ! empty( $payments ) ) {

--- a/src/Tickets/Commerce/Gateways/Square/Order.php
+++ b/src/Tickets/Commerce/Gateways/Square/Order.php
@@ -794,6 +794,8 @@ class Order extends Abstract_Order {
 
 		$taxes = $square_order['taxes'] ?? [];
 
+		// We don's support taxes yet in TC, but ADDITIVE taxes need to be added as a separate item to the
+		// order so that the total is reflecting reality. We add them as prefixed booking fees for now.
 		foreach ( $taxes as $tax ) {
 			if ( $tax['type'] !== 'ADDITIVE' ) {
 				continue;

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Objects/Item.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Objects/Item.php
@@ -181,7 +181,11 @@ abstract class Item implements JsonSerializable {
 			$this->data['version'] = $version;
 		}
 		$this->data['present_at_location_ids'] = [ tribe( Merchant::class )->get_location_id() ];
-		$this->set_image_ids();
+		/**
+		 * We don't sync any image until Square resolves its issue,
+		 * where not setting the image_ids removes all the images from the catalog object.
+		 */
+		// $this->set_image_ids();
 
 		return $this->set_object_values();
 	}
@@ -393,8 +397,26 @@ abstract class Item implements JsonSerializable {
 				],
 			];
 
+			/**
+			 * Filter the image path for the item.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $image_path   The image path.
+			 * @param string $product_type The product type.
+			 * @param Item   $item         The item object.
+			 *
+			 * @return string The image path.
+			 */
+			$image_path = apply_filters(
+				'tec_tickets_commerce_square_image_path',
+				ET::instance()->plugin_path . "src/resources/images/square-sync/{$product_type}.png",
+				$product_type,
+				$this
+			);
+
 			$arguments = [
-				'filepath' => ET::instance()->plugin_path . "src/resources/images/square-sync/{$product_type}.png",
+				'filepath' => $image_path,
 				'body'     => [
 					'request' => wp_json_encode( $data ),
 				],


### PR DESCRIPTION
Improve idempotency.
Prevent syncing of images until square bug is fixed.
Adding currency match as a check to the is_ready_to_sell method for Square. Also displaying a notice when that is not the case.