### PR TITLE
Account for square miscalculations

### DIFF
--- a/src/Tickets/Commerce/Gateways/Square/Order.php
+++ b/src/Tickets/Commerce/Gateways/Square/Order.php
@@ -197,9 +197,59 @@ class Order extends Abstract_Order {
 		}
 
 		$body = [
-			'idempotency_key' => uniqid( $square_order_id ? 'tec-square-update-' : 'tec-square-create-', true ),
+			'idempotency_key' => uniqid( 'tec-square-calculate-', true ),
 			'order'           => $square_order,
 		];
+
+		$calculated_order = Requests::post(
+			'orders/calculate'
+			[],
+			[
+				'body' => $body,
+			]
+		);
+
+		if ( empty( $calculated_order['order']['total_money']['amount'] ) ) {
+			do_action( 'tribe_log', 'error', 'Square order calculate failed', [ $calculated_order['errors'] ?? $calculated_order, $square_order, $square_order_id ] );
+			throw new RuntimeException( __( 'Failed to calculate the Square order.', 'event-tickets' ), 1 );
+		}
+
+		$calculated_total = (int) $calculated_order['order']['total_money']['amount'];
+		$local_total      = (int) ( 100 * (float) $order->total );
+
+		$diff = $calculated_total - $local_total;
+
+		if ( 0 !== $diff ) {
+			if ( $diff > 0 ) {
+				if ( ! ( isset( $body['order']['discounts'] ) && is_array( $body['order']['discounts'] ) ) ) {
+					$body['order']['discounts'] = [];
+				}
+
+				$body['order']['discounts'][] = [
+					'name'         => __( 'Rounding difference discount', 'event-tickets' ),
+					'type'         => 'FIXED_AMOUNT',
+					'amount_money' => [
+						'amount'   => absint( $diff ),
+						'currency' => $order->currency,
+					],
+				];
+			} else {
+				if ( ! ( isset( $body['order']['service_charges'] ) && is_array( $body['order']['service_charges'] ) ) ) {
+					$body['order']['service_charges'] = [];
+				}
+
+				$body['order']['service_charges'][] = [
+					'name'              => __( 'Rounding difference service charge', 'event-tickets' ),
+					'calculation_phase' => 'SUBTOTAL_PHASE',
+					'amount_money'      => [
+						'amount'   => absint( $diff ),
+						'currency' => $order->currency,
+					],
+				];
+			}
+		}
+
+		$body['idempotency_key'] = uniqid( $square_order_id ? 'tec-square-update-' : 'tec-square-create-', true );
 
 		/**
 		 * Fires before the Square order is upserted.

--- a/src/Tickets/Commerce/Gateways/Square/Order.php
+++ b/src/Tickets/Commerce/Gateways/Square/Order.php
@@ -202,7 +202,7 @@ class Order extends Abstract_Order {
 		];
 
 		$calculated_order = Requests::post(
-			'orders/calculate'
+			'orders/calculate',
 			[],
 			[
 				'body' => $body,

--- a/src/Tickets/Commerce/Tables/Webhooks.php
+++ b/src/Tickets/Commerce/Tables/Webhooks.php
@@ -131,6 +131,18 @@ class Webhooks extends Table {
 			return $results;
 		}
 
+		$db_name = DB::get_var( 'SELECT DATABASE()' );
+
+		$inno_db_has_foreign_key = DB::table( DB::raw( 'information_schema.INNODB_SYS_FOREIGN' ) )
+			->where( 'ID', $db_name . '/order_id_fk' )
+			->where( 'FOR_NAME', $db_name . '/' . self::table_name( true ) )
+			->where( 'REF_NAME', $db_name . '/' . DB::prefix( 'posts' ) )
+			->count() > 0;
+
+		if ( $inno_db_has_foreign_key ) {
+			return $results;
+		}
+
 		DB::query(
 			DB::prepare(
 				'ALTER TABLE %i ADD CONSTRAINT `order_id_fk` FOREIGN KEY (`order_id`) REFERENCES %i (`ID`) ON DELETE CASCADE ON UPDATE NO ACTION',


### PR DESCRIPTION
This PR aims to fix possible differences between our local calculation and square calculation during the rounding phase.

For example lets assume we buy a ticket priced at 10$ with a fee of 1% and then we apply a coupon of 25%.

The math are: 10$ + 0.1$ = 10.1$

Coupon: 25% of 10.1 is 2.525 exactly.

Since USD/EUR has a precision of 2 decimals we need to adjust.

Our TC transform the 2.525 to 2.52, but Square transformst it to 2.53 which creates the issue.

We proactively use the calculate order endpoint in order to be able to adjust, with a discount or a fee based on the `square - local` total.