### PR TITLE
Oauth remote revoke and Connection success message

### DIFF
--- a/src/Tickets/Commerce/Gateways/Square/Ajax.php
+++ b/src/Tickets/Commerce/Gateways/Square/Ajax.php
@@ -13,6 +13,7 @@ use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\Contracts\Container;
 use TEC\Tickets\Commerce\Gateways\Square\WhoDat;
 use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 
 /**
  * Square AJAX Hooks.
@@ -98,6 +99,7 @@ class Ajax extends Controller_Contract {
 			$connect_url = $this->who_dat->connect_account();
 
 			if ( ! empty( $connect_url ) ) {
+				Commerce_Settings::delete( 'tickets_commerce_gateways_square_remotely_disconnected_%s' );
 				wp_send_json_success( [ 'url' => $connect_url ] );
 				return;
 			}
@@ -129,13 +131,6 @@ class Ajax extends Controller_Contract {
 
 			// Delete local merchant data.
 			$this->merchant->delete_signup_data();
-
-			/**
-			 * Fires when a Square account is disconnected.
-			 *
-			 * @since TBD
-			 */
-			do_action( 'tec_tickets_commerce_square_merchant_disconnected' );
 
 			wp_send_json_success( [ 'message' => __( 'Successfully disconnected from Square.', 'event-tickets' ) ] );
 		} catch ( \Exception $e ) {

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -295,7 +295,16 @@ class Merchant extends Abstract_Merchant {
 		// Also delete any stored merchant data.
 		$this->delete_merchant_data();
 
-		return delete_option( $this->get_signup_data_key() );
+		$result = delete_option( $this->get_signup_data_key() );
+
+		/**
+		 * Fires when merchant data is deleted.
+		 *
+		 * @since TBD
+		 */
+		do_action( 'tec_tickets_commerce_square_merchant_disconnected' );
+
+		return $result;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/REST/Events.php
+++ b/src/Tickets/Commerce/Gateways/Square/REST/Events.php
@@ -158,6 +158,15 @@ class Events {
 	const TERMINAL_ACTION_UPDATED = 'terminal.action.updated';
 
 	/**
+	 * Square Webhook Event Types
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const OAUTH_AUTHORIZATION_REVOKED = 'oauth.authorization.revoked';
+
+	/**
 	 * Webhook event types supported.
 	 *
 	 * @since TBD
@@ -173,6 +182,7 @@ class Events {
 		self::ORDER_UPDATED,
 		self::CUSTOMER_DELETED,
 		self::INVENTORY_COUNT_UPDATED,
+		self::OAUTH_AUTHORIZATION_REVOKED,
 	];
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/REST/On_Boarding_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/Square/REST/On_Boarding_Endpoint.php
@@ -15,6 +15,7 @@ use TEC\Tickets\Commerce\Gateways\Square\Merchant;
 use TEC\Tickets\Commerce\Gateways\Square\Webhooks;
 use TEC\Tickets\Commerce\Gateways\Square\WhoDat;
 use TEC\Tickets\Settings as Tickets_Commerce_Settings;
+use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 use TEC\Tickets\Commerce\Payments_Tab;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -278,17 +279,7 @@ class On_Boarding_Endpoint extends Abstract_REST_Endpoint {
 		$merchant_data = $merchant->fetch_merchant_data( true );
 
 		// Log the retrieval attempt.
-		if ( $merchant_data ) {
-			do_action(
-				'tribe_log',
-				'info',
-				'Square Merchant Data Retrieved',
-				[
-					'source'      => 'tickets-commerce',
-					'merchant_id' => $params['merchant_id'],
-				]
-			);
-		} else {
+		if ( ! $merchant_data ) {
 			do_action(
 				'tribe_log',
 				'warning',
@@ -306,6 +297,8 @@ class On_Boarding_Endpoint extends Abstract_REST_Endpoint {
 		// Enable the gateway.
 		tribe_update_option( Tickets_Commerce_Settings::$tickets_commerce_enabled, true );
 		tribe_update_option( Gateway::get_enabled_option_key(), true );
+
+		Commerce_Settings::set( 'tickets_commerce_gateways_square_just_onboarded_%s', time() );
 
 		wp_safe_redirect( $square_tab_url );
 		tribe_exit();


### PR DESCRIPTION
Listen for the oauth revoke access event, and delete any merchant data from local even when that occurs.

DIsplay's a success notice when the connection with Square is established.

Display's an error notice when Square was disconnected and the disconnect was initiated remotely.