### PR TITLE
Add access token to seller status API and fix merchant active check

### DIFF
--- a/src/Tickets/Commerce/Gateways/PayPal/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/WhoDat.php
@@ -89,8 +89,9 @@ class WhoDat extends Abstract_WhoDat {
 		}
 
 		$query_args = [
-			'mode'        => tribe( Merchant::class )->get_mode(),
-			'merchant_id' => $saved_merchant_id,
+			'mode'         => tribe( Merchant::class )->get_mode(),
+			'merchant_id'  => $saved_merchant_id,
+			'access_token' => tribe( Merchant::class )->get_access_token(),
 		];
 
 		$cache[ $cache_key ] = $this->post( 'seller/status', $query_args );

--- a/src/admin-views/settings/tickets-commerce/paypal/connect/active/paypal-status.php
+++ b/src/admin-views/settings/tickets-commerce/paypal/connect/active/paypal-status.php
@@ -15,7 +15,9 @@
  * @var bool                                          $is_merchant_connected [Global] Whether the merchant is connected or not.
  */
 
-if ( ! empty( $is_merchant_connected ) ) {
+defined( 'ABSPATH' ) || exit;
+
+if ( $is_merchant_active ?? false ) {
 	return;
 }
 


### PR DESCRIPTION
- Add access_token parameter to PayPal seller status query args for proper authentication
- Fix merchant status condition to check is_merchant_active instead of is_merchant_connected
- Add ABSPATH security check to PayPal status template
- Improve array formatting consistency in WhoDat query args
