### PR TITLE
ET-2510 Add check for order items to be array

### DIFF
--- a/changelog/fix-ET-2510-add-check-for-non-array-items
+++ b/changelog/fix-ET-2510-add-check-for-non-array-items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add extra check that items added to an order should be an array. Props to @TomGroot! [ET-2510]

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Coupons.php
@@ -159,6 +159,7 @@ class Coupons extends Controller_Contract {
 	 * Filter the properties of the order object to add coupons.
 	 *
 	 * @since 5.21.0
+	 * @since TBD Added check that the items are an array.
 	 *
 	 * @param array $properties The properties of the order object.
 	 *
@@ -167,7 +168,7 @@ class Coupons extends Controller_Contract {
 	public function attach_coupons_to_order_object( array $properties ): array {
 		// We shouldn't have an order with no items, but let's just be safe.
 		$items = $properties['items'] ?? [];
-		if ( empty( $items ) ) {
+		if ( empty( $items ) || ! is_array( $items ) ) {
 			return $properties;
 		}
 

--- a/src/Tickets/Commerce/Order_Modifiers/Checkout/Fees.php
+++ b/src/Tickets/Commerce/Order_Modifiers/Checkout/Fees.php
@@ -96,6 +96,7 @@ class Fees extends Abstract_Fees {
 	 * Add fees to the order object properties.
 	 *
 	 * @since 5.21.0
+	 * @since TBD Added check that the items are an array.
 	 *
 	 * @param array $properties The properties of the order object.
 	 *
@@ -104,7 +105,7 @@ class Fees extends Abstract_Fees {
 	public function attach_fees_to_order_object( array $properties ): array {
 		// There shouldn't be an order with no items, but let's just be safe.
 		$items = $properties['items'] ?? [];
-		if ( empty( $items ) ) {
+		if ( empty( $items ) || ! is_array( $items ) ) {
 			return $properties;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ET-2510]

### 🗒️ Description

Props to @tomgroot ([original PR here](https://github.com/the-events-calendar/event-tickets/pull/3777)) for catching an issue where the items being added to an order for a coupon or fee needed a check making sure that the `items` are an array before trying to run `array_filter` on them. 

### 🎥 Artifacts 
Using a snippet, I could simulate this scenario. 
Before:
![ET-2510-Before](https://github.com/user-attachments/assets/7a443fe6-9073-4a66-bb41-8671035c57cf)

After:
![ET-2510-After](https://github.com/user-attachments/assets/be7a6c1b-d013-4d06-855d-72d90fd61c4d)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
