### PR TITLE
Gracefully handle error messages

### DIFF
--- a/src/Tickets/Admin/Onboarding/Steps/Communication.php
+++ b/src/Tickets/Admin/Onboarding/Steps/Communication.php
@@ -45,7 +45,7 @@ class Communication extends Abstract_Step {
 		$settings = $request->get_json_params();
 
 		if ( empty( $settings['currentTab'] ) ) {
-			return $this->add_fail_message( $response, __( 'No communication settings provided.', 'event-tickets' ) );
+			return $this->add_message( $response, __( 'No communication settings provided.', 'event-tickets' ) );
 		}
 
 		$email = $settings['userEmail'] ?? '';

--- a/src/Tickets/Admin/Onboarding/Steps/Events.php
+++ b/src/Tickets/Admin/Onboarding/Steps/Events.php
@@ -79,7 +79,7 @@ class Events extends Abstract_Step {
 			$install = $plugin->install();
 
 			if ( ! $install ) {
-				return $this->add_fail_message( $response, __( 'Failed to install plugin.', 'event-tickets' ) );
+				return $this->add_message( $response, __( 'Failed to install plugin.', 'event-tickets' ) );
 			}
 		}
 
@@ -87,7 +87,7 @@ class Events extends Abstract_Step {
 			$active = $plugin->activate();
 
 			if ( ! $active ) {
-				return $this->add_fail_message( $response, __( 'Failed to activate plugin.', 'event-tickets' ) );
+				return $this->add_message( $response, __( 'Failed to activate plugin.', 'event-tickets' ) );
 			}
 		}
 

--- a/src/Tickets/Admin/Onboarding/Steps/Settings.php
+++ b/src/Tickets/Admin/Onboarding/Steps/Settings.php
@@ -49,7 +49,7 @@ class Settings extends Abstract_Step {
 		$settings = $request->get_json_params();
 
 		if ( empty( $settings['currentTab'] ) ) {
-			return $this->add_fail_message( $response, __( 'No settings provided.', 'event-tickets' ) );
+			return $this->add_message( $response, __( 'No settings provided.', 'event-tickets' ) );
 		}
 
 		tribe_update_option( Tickets_Settings::$tickets_commerce_enabled, (bool) $settings['paymentOption'] );

--- a/src/Tickets/Admin/Onboarding/Steps/Welcome.php
+++ b/src/Tickets/Admin/Onboarding/Steps/Welcome.php
@@ -57,7 +57,7 @@ class Welcome extends Abstract_Step {
 		$commerce_optin = tribe_update_option( Settings::$tickets_commerce_enabled, $optin );
 
 		if ( ! $option ) {
-			return $this->add_fail_message( $response, __( 'Failed to save opt-in status.', 'event-tickets' ) );
+			return $this->add_message( $response, __( 'Failed to save opt-in status.', 'event-tickets' ) );
 		}
 
 		// Tell Telemetry to update.


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

In our Ajax callback functions we returned errors with [add_fail_message()](https://github.com/the-events-calendar/tribe-common/blob/master/src/Common/Admin/Onboarding/Steps/Abstract_Step.php#L117C18-L117C34). That sent the `500` status code with the response, causing the flow to break without a way for the user to continue. Replacing it with the more general [add_message()](https://github.com/the-events-calendar/tribe-common/blob/master/src/Common/Admin/Onboarding/Steps/Abstract_Step.php#L95C18-L95C29) would allow user to complete the Wizard even if a step failed.

### Artifacts

![Screenshot_1](https://github.com/user-attachments/assets/1ae69df8-5ba3-47ba-96d9-3e8f7818f9f0)


