### PR TITLE
ET-2513 Allow unlimited tickets to track tickets sold

### DIFF
--- a/changelog/fix-ET-2513-unlimited-ticket-quantity
+++ b/changelog/fix-ET-2513-unlimited-ticket-quantity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Allow unlimited capacity tickets to have the number of sales tracked. [ET-2513]


### PR DESCRIPTION
### 🎫 Ticket

[ET-2513]

### 🗒️ Description

We had logic in place to exclude unlimited capacity tickets from all stock calculations, but this resulted in the total ticket sales not being calculated and accurately shown in the Attendees Summar, All Tickets Summary, and block editor ticket blocks for unlimited tickets (they would always show as 0). This PR tweaks this logic a little bit to include the unlimited tickets in tracking the total sales, but still keeps them excluded from managing stock. 

This PR is also realigning the `bucket/commerce-maintenance` branches in `event-tickets` and `event-tickets/common`

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
