### PR TITLE
Remove ${CARET} from docblocks.

### DIFF
--- a/src/Tickets/Flexible_Tickets/Custom_Tables/Posts_And_Ticket_Groups.php
+++ b/src/Tickets/Flexible_Tickets/Custom_Tables/Posts_And_Ticket_Groups.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ${CARET}
+ * This class is used to store the relationship between posts and ticket groups.
  *
  * @since 5.8.0
  *

--- a/src/Tickets/Flexible_Tickets/Series_Passes/Base.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Base.php
@@ -34,7 +34,7 @@ use WP_Post;
  */
 class Base extends Controller {
 	/**
-	 * ${CARET}
+	 * A reference to the Admin Views handler for Flexible Tickets.
 	 *
 	 * @since 5.8.0
 	 *

--- a/src/Tickets/Seating/Service/Ephemeral_Token.php
+++ b/src/Tickets/Seating/Service/Ephemeral_Token.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ${CARET}
+ * This class is used to fetch an ephemeral token from the service.
  *
  * @since 5.16.0
  *


### PR DESCRIPTION
These are from someone's malformed docblock template - they need to go.

Requires: https://github.com/the-events-calendar/tribe-common/pull/2637