### PR TITLE
Update to prevent Potential Fatal on earlier MySQL verisons

### DIFF
--- a/src/Tickets/Flexible_Tickets/Custom_Tables/Ticket_Groups.php
+++ b/src/Tickets/Flexible_Tickets/Custom_Tables/Ticket_Groups.php
@@ -58,7 +58,7 @@ class Ticket_Groups extends Table {
 			CREATE TABLE `$table_name` (
 				`id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 				`slug` varchar(255) DEFAULT '' NOT NULL,
-				`data` text DEFAULT ('') NOT NULL,
+				`data` text NOT NULL,
 				`capacity` int(11) DEFAULT 0 NOT NULL,
 				`cost` decimal(10,2) DEFAULT 0 NOT NULL,
 				`name` varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
- Bump schema version from 1.1.0 to 1.2.0
- Add migration method for MySQL compatibility
- Ensure `data` column has a valid JSON structure for older MySQL versions
- Prevent issues with NULL or empty TEXT column values
- Improve database schema robustness and compatibility