### PR TITLE
ET-2517 Fix link for My Tickets on Pages

### DIFF
--- a/changelog/fix-ET-2517-pages-my-tickets-link
+++ b/changelog/fix-ET-2517-pages-my-tickets-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed My Tickets link not working on Pages due to canonical redirect. [ET-2517]

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -397,7 +397,8 @@ class Tribe__Tickets__Tickets_View {
 	 * Intercepts the_content from the posts to include the orders structure.
 	 *
 	 * @since 4.11.2 Avoid running when it shouldn't by bailing if not in main query loop on a single post.
-	 *
+	 * @since TBD Added filter to preserve tribe-edit-orders parameter in canonical redirect.
+	 * 
 	 * @param string $content Normally the_content of a post.
 	 *
 	 * @return string
@@ -408,7 +409,7 @@ class Tribe__Tickets__Tickets_View {
 
 		// Prevents firing more than it needs to outside of the loop.
 		if (
-			! is_singular()
+			! is_singular( Tribe__Tickets__Main::instance()->post_types() )
 			|| ! in_the_loop()
 			|| ! is_main_query()
 			|| (

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -37,7 +37,7 @@ class Tribe__Tickets__Tickets_View {
 		add_filter( 'tribe_events_views_v2_bootstrap_should_display_single', [ $myself, 'intercept_views_v2_single_display' ], 15, 4 );
 
 		// Prevent canonical redirect from stripping tribe-edit-orders parameter.
-		add_filter( 'redirect_canonical', [ $myself, 'preserve_tickets_parameter_in_canonical_redirect' ], 10, 2 );
+		add_filter( 'redirect_canonical', [ $myself, 'preserve_tickets_parameter_in_canonical_redirect' ] );
 
 		// Only Applies this to TEC users.
 		if ( class_exists( 'Tribe__Events__Rewrite' ) ) {
@@ -1464,11 +1464,11 @@ class Tribe__Tickets__Tickets_View {
 	 * @since TBD
 	 *
 	 * @param string $redirect_url The URL to redirect to.
-	 * @return string|false The URL to redirect to, or false to prevent redirect.
+	 * @return string The URL to redirect to.
 	 */
 	public function preserve_tickets_parameter_in_canonical_redirect( $redirect_url ) {
 		// If we have the tribe-edit-orders parameter, preserve it in the redirect.
-		if ( get_query_var( 'tribe-edit-orders' ) && ! empty( $redirect_url ) ) {
+		if ( ! empty( $redirect_url ) && get_query_var( 'tribe-edit-orders' ) ) {
 			$redirect_url = add_query_arg( 'tribe-edit-orders', 1, $redirect_url );
 		}
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1463,11 +1463,10 @@ class Tribe__Tickets__Tickets_View {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $redirect_url  The URL to redirect to.
-	 * @param string $requested_url The URL that was requested.
+	 * @param string $redirect_url The URL to redirect to.
 	 * @return string|false The URL to redirect to, or false to prevent redirect.
 	 */
-	public function preserve_tickets_parameter_in_canonical_redirect( $redirect_url, $requested_url ) {
+	public function preserve_tickets_parameter_in_canonical_redirect( $redirect_url ) {
 		// If we have the tribe-edit-orders parameter, preserve it in the redirect.
 		if ( get_query_var( 'tribe-edit-orders' ) && ! empty( $redirect_url ) ) {
 			$redirect_url = add_query_arg( 'tribe-edit-orders', 1, $redirect_url );


### PR DESCRIPTION
### 🎫 Ticket

[ET-2517]

### 🗒️ Description

WordPress treats posts and pages differently in both its canonical redirect system and conditional functions, so when trying to redirect users to the My Tickets page for tickets on a Page, the ticket parameters were not being preserved. This PR addresses this with two additions:
- Added `redirect_canonical` filter and `preserve_tickets_parameter_in_canonical_redirect` method to preserve ticket parameters during WordPress canonical redirects
- Updated conditional logic in `intercept_content()` method to properly handle pages

### 🎥 Artifacts 

https://github.com/user-attachments/assets/2a7d650d-39ce-45b6-a256-b7126ed8b497


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2517]: https://stellarwp.atlassian.net/browse/ET-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ