### PR TITLE
Updates plugin version to 5.24.2

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -3,7 +3,7 @@
  * Plugin Name: Event Tickets
  * Plugin URI:  https://evnt.is/1acb
  * Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
- * Version: 5.24.1.1
+ * Version: 5.24.2
  * Requires at least: 6.6
  * Requires PHP: 7.4
  * Author: The Events Calendar

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-tickets",
-  "version": "5.24.1",
+  "version": "5.24.2",
   "repository": "git@github.com:the-events-calendar/event-tickets.git",
   "_zipname": "event-tickets",
   "_zipfoldername": "event-tickets",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: theeventscalendar, brianjessee, camwynsp, redscar, tribalmike, rafsuntaskin, aguseo, bordoni, borkweb, jentheo, leahkoerper, lucatume, neillmcshea, vicskf, zbtirrell
 Tags: tickets, event registration, RSVP, ticket sales, attendee management
-Stable tag: 5.24.1.1
+Stable tag: 5.24.2
 Requires at least: 6.6
 Tested up to: 6.8.1
 Requires PHP: 7.4

--- a/src/Tickets/Commerce/Tables.php
+++ b/src/Tickets/Commerce/Tables.php
@@ -83,7 +83,7 @@ class Tables extends Controller_Contract {
 	 * @return void
 	 */
 	public function schedule_webhook_storage_clean_up(): void {
-		if ( as_has_scheduled_action( self::WEBHOOK_STORAGE_CLEAN_UP_ACTION ) ) {
+		if ( as_has_scheduled_action( self::WEBHOOK_STORAGE_CLEAN_UP_ACTION, [], self::TICKETS_COMMERCE_ACTION_GROUP ) ) {
 			return;
 		}
 

--- a/src/Tickets/Commerce/Tables/Webhooks.php
+++ b/src/Tickets/Commerce/Tables/Webhooks.php
@@ -142,7 +142,7 @@ class Webhooks extends Table {
 			DB::prepare(
 				'DELETE FROM %i WHERE processed_at is NULL and created_at < %s',
 				self::table_name( true ),
-				time() - DAY_IN_SECONDS
+				gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS )
 			)
 		);
 	}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -18,7 +18,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin.
 	 */
-	const VERSION = '5.24.1.1';
+	const VERSION = '5.24.2';
 
 	/**
 	 * Used to store the version history.

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Tables_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Tables_Test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace TEC\Tickets\Commerce;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Tickets\Commerce\Tables\Webhooks as Webhooks_Table;
+
+class Tables_Test extends Controller_Test_Case {
+	protected string $controller_class = Tables::class;
+
+	public function test_it_should_schedule_webhook_storage_clean_up(): void {
+		$this->assertFalse( as_has_scheduled_action( Tables::WEBHOOK_STORAGE_CLEAN_UP_ACTION, [], Tables::TICKETS_COMMERCE_ACTION_GROUP ) );
+		$this->make_controller()->schedule_webhook_storage_clean_up();
+		$this->assertTrue( as_has_scheduled_action( Tables::WEBHOOK_STORAGE_CLEAN_UP_ACTION, [], Tables::TICKETS_COMMERCE_ACTION_GROUP ) );
+	}
+
+	public function test_it_should_clean_up_webhook_storage(): void {
+		Webhooks_Table::insert_many([
+			[
+				'event_id'     => 1,
+				'order_id'     => 1,
+				'event_type'   => 'test',
+				'event_data'   => 'test',
+				'created_at'   => gmdate( 'Y-m-d H:i:s', time() - 2 ),
+				'processed_at' => gmdate( 'Y-m-d H:i:s', time() ),
+			],
+			[
+				'event_id'     => 4,
+				'order_id'     => 4,
+				'event_type'   => 'test',
+				'event_data'   => 'test',
+				'created_at'   => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
+				'processed_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+			]
+		]);
+
+		Webhooks_Table::insert_many([
+			[
+				'event_id'     => 2,
+				'order_id'     => 2,
+				'event_type'   => 'test',
+				'event_data'   => 'test',
+				'created_at'   => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+			],
+			[
+				'event_id'     => 3,
+				'order_id'     => 3,
+				'event_type'   => 'test',
+				'event_data'   => 'test',
+				'created_at'   => gmdate( 'Y-m-d H:i:s', time() - 2 ),
+			],
+			[
+				'event_id'     => 5,
+				'order_id'     => 5,
+				'event_type'   => 'test',
+				'event_data'   => 'test',
+				'created_at'   => gmdate( 'Y-m-d H:i:s', time() - 4 * DAY_IN_SECONDS ),
+			],
+		]);
+
+		$this->assertEquals( 5, Webhooks_Table::get_total_items() );
+		$this->make_controller()->clean_up_webhook_storage();
+		$this->assertEquals( 3, Webhooks_Table::get_total_items() );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2059]

### 🗒️ Description

- Bumps the plugin version to 5.24.2 across relevant files.
- Corrects a timestamp formatting issue in the webhook cleanup query.
- Ensures the webhook cleanup action is properly scheduled with the correct action group.
- Adds a test to confirm the scheduled action and the cleanup logic.

### 🎥 Artifacts 


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.