### PR TITLE
Use a filter to prevent interruption in the Seating session

### DIFF
--- a/src/resources/js/v2/tickets-commerce.js
+++ b/src/resources/js/v2/tickets-commerce.js
@@ -310,10 +310,11 @@ window.tribe.tickets.commerce = {};
 	 * @since 5.22.0
 	 */
 	obj.disableInterruption = () => {
-		const setInterruptable = window.tec.tickets?.seating?.frontend?.session?.setIsInterruptable;
-		if ( 'function' === typeof setInterruptable ) {
-			setInterruptable( false );
-		}
+		window.wp.hooks.addFilter(
+			'tec.tickets.seating.frontend.session.isInterruptable',
+			'tec.ticketsCommerce.coupons',
+			() => false
+		);
 	};
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[ET-2519]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Here's a summary of what I believe is causing the issue to reoccur:

1. The `tickets-commerce.js` file calls into the Seating session file. It calls the `setIsInterruptable()` function with a value of `false`.
2. The `setIsInterruptable()` function can be found in the `src/Tickets/Seating/app/frontend/session/index.js` file.
3. In the session index file, the `syncOnLoad()` function is called, and it attaches to the `beforeunload` event for the document. This event is triggered when the user tries to leave the page, regardless of the reason (page refresh, new page, etc.).
4. For some reason (which I was unable to determine), the `beforeunload` event is actually attached *twice* to the document. I assume that there are two different instances of the built session file, but I wasn't able to deterime if that is actually the case. Regardless, this means that the first `beforeunload` event is triggered correctly, and the interruption does not happen. However, the second `beforeunload` event is triggered, and it does not have the `isInterruptable` value set to `false`, so the interruption happens. This is what causes the issue where the user is interrupted when the page is refreshed due to applying or removing a coupon.


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2519]: https://stellarwp.atlassian.net/browse/ET-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ