### PR TITLE
[SL-291] Fix issues with Seating timer getting expired for WooCommerce Cart block page and TicketsCommerce coupon application.

### DIFF
--- a/src/Tickets/Seating/app/frontend/session/index.js
+++ b/src/Tickets/Seating/app/frontend/session/index.js
@@ -750,6 +750,7 @@ export function setTargetDom( targetDocument ) {
  * @return {void} The timer is synced.
  */
 export async function syncOnLoad() {
+	console.log('syncOnLoad called');
 	const syncTimerElements = Array.from( getTimerElements() ).filter( ( syncTimerElement ) => {
 		return 'syncOnLoad' in syncTimerElement.dataset;
 	} );

--- a/src/Tickets/Seating/app/frontend/ticketsBlock/checkout-handlers.js
+++ b/src/Tickets/Seating/app/frontend/ticketsBlock/checkout-handlers.js
@@ -1,5 +1,5 @@
 import { applyFilters } from '@wordpress/hooks';
-import { setIsInterruptable } from '../../frontend/session';
+import { setIsInterruptable } from '@tec/tickets/seating/frontend/session';
 
 /**
  * Checks out a ticket using the Tickets Commerce module.

--- a/src/Tickets/Seating/app/frontend/ticketsBlock/index.js
+++ b/src/Tickets/Seating/app/frontend/ticketsBlock/index.js
@@ -14,7 +14,7 @@ import { TicketRow } from './ticket-row';
 import { localizedData } from './localized-data';
 import { formatWithCurrency } from '../../currency';
 import { getCheckoutHandlerForProvider } from './checkout-handlers';
-import { start as startTimer, reset as resetTimer } from '../../frontend/session';
+import { start as startTimer, reset as resetTimer } from '@tec/tickets/seating/frontend/session';
 import './filters';
 
 const {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,27 @@ customEntryPoints['wizard/wizard'] = exposeEntry('tec.tickets.wizard', __dirname
  */
 doNotPrefixSVGIdsClasses(defaultConfig);
 
+defaultConfig.externals = [
+	// TEC legacy
+	( { context, request }, callback ) => {
+		if ( /^@moderntribe\//.test( request ) ) {
+			const path = request.replace( /\//g, '.' ).replace( '@moderntribe', 'tec' ).replace( /-/g, '_' );
+			return callback( null, `var ${ path }` );
+		}
+
+		return callback();
+	},
+	// TEC modern
+	( { context, request }, callback ) => {
+		if ( /^@tec\//.test( request ) ) {
+			const path = request.replace( /\//g, '.' ).replace( '@tec', 'tec' ).replace( /-/g, '_' );
+			return callback( null, `var ${ path }` );
+		}
+
+		return callback();
+	},
+];
+
 /**
  * Finally the customizations are merged with the default WebPack configuration.
  */


### PR DESCRIPTION
By importing the frontend/session module by file path in two different bundles (session, ticketsBlock) the file is included twice and its side-effect fires twice. By using a named import the file will be included only once, from the window object.

### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
* refactor(Seating) import by name to avoid loading same file twice.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
