### PR TITLE
ET-2530 Add conditional for ticket description

### DIFF
--- a/changelog/fix-ET-2530-conditionally-show-more-info
+++ b/changelog/fix-ET-2530-conditionally-show-more-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add conditional to only show ticket description toggle if there is a description. [ET-2530]

--- a/src/views/v2/commerce/checkout/cart/item/details.php
+++ b/src/views/v2/commerce/checkout/cart/item/details.php
@@ -30,8 +30,15 @@
 
 	<?php $this->template( 'checkout/cart/item/details/title', [ 'item' => $item ] ); ?>
 
-	<?php $this->template( 'checkout/cart/item/details/toggle', [ 'item' => $item ] ); ?>
+	<?php
+	// Only show the toggle and description if the ticket has a description and should show description.
+	if ( ! empty( $item['obj'] ) && $item['obj']->show_description() && ! empty( $item['obj']->description ) ) :
+		?>
+		<?php $this->template( 'checkout/cart/item/details/toggle', [ 'item' => $item ] ); ?>
 
-	<?php $this->template( 'checkout/cart/item/details/description', [ 'item' => $item ] ); ?>
+		<?php $this->template( 'checkout/cart/item/details/description', [ 'item' => $item ] ); ?>
+		<?php
+	endif;
+	?>
 
 </div>

--- a/src/views/v2/commerce/checkout/cart/item/details/toggle.php
+++ b/src/views/v2/commerce/checkout/cart/item/details/toggle.php
@@ -10,6 +10,7 @@
  * @link    https://evnt.is/1amp Help article for RSVP & Ticket template files.
  *
  * @since 5.1.9
+ * @since TBD Add condition to check if ticket description should be shown.
  *
  * @version 5.1.9
  *

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/ItemDetailsTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/ItemDetailsTest.php
@@ -21,4 +21,50 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 		) );
 
 	}
+
+	/**
+	 * Test that toggle and description are NOT rendered when ticket has no description.
+	 *
+	 * @since TBD
+	 */
+	public function test_should_render_cart_item_details_without_toggle_when_no_description() {
+		$ticket_id = $this->get_mock_thing( 'tickets/1.json' );
+		$ticket_obj = tribe( Ticket::class )->get_ticket( $ticket_id );
+		
+		// Remove the description to test the conditional logic.
+		$ticket_obj->description = '';
+		
+		$ticket['obj'] = $ticket_obj;
+		$ticket['ticket_id'] = $ticket_id;
+
+		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
+				'item' => $ticket,
+			]
+		) );
+	}
+
+	/**
+	 * Test that toggle and description are NOT rendered when ticket shouldn't show description.
+	 *
+	 * @since TBD
+	 */
+	public function test_should_render_cart_item_details_without_toggle_when_show_description_false() {
+		$ticket_id = $this->get_mock_thing( 'tickets/1.json' );
+		$ticket_obj = tribe( Ticket::class )->get_ticket( $ticket_id );
+		
+		// Create a mock that returns false for show_description().
+		$mock_ticket = $this->createMock( get_class( $ticket_obj ) );
+		$mock_ticket->method( 'show_description' )->willReturn( false );
+		$mock_ticket->description = 'This ticket has a description but should not show it';
+		$mock_ticket->post_title = $ticket_obj->post_title;
+		$mock_ticket->ID = $ticket_obj->ID;
+		
+		$ticket['obj'] = $mock_ticket;
+		$ticket['ticket_id'] = $ticket_id;
+
+		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
+				'item' => $ticket,
+			]
+		) );
+	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/ItemDetailsTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/ItemDetailsTest.php
@@ -9,17 +9,19 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 
 	protected $partial_path = 'checkout/cart/item/details';
 
+	/**
+	 * Test that toggle and description ARE rendered when ticket has a description and should show it.
+	 *
+	 * @since TBD
+	 */
 	public function test_should_render_cart_item_details() {
-
-		$ticket_id        = $this->get_mock_thing( 'tickets/1.json' );
-		$ticket['obj'] = tribe( Ticket::class )->get_ticket( $ticket_id );
+		$ticket_id           = $this->get_mock_thing( 'tickets/1.json' );
+		$ticket['obj']       = tribe( Ticket::class )->get_ticket( $ticket_id );
 		$ticket['ticket_id'] = $ticket_id;
 
 		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-				'item' => $ticket,
-			]
-		) );
-
+			'item' => $ticket,
+		] ) );
 	}
 
 	/**
@@ -28,19 +30,18 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 	 * @since TBD
 	 */
 	public function test_should_render_cart_item_details_without_toggle_when_no_description() {
-		$ticket_id = $this->get_mock_thing( 'tickets/1.json' );
-		$ticket_obj = tribe( Ticket::class )->get_ticket( $ticket_id );
+		$ticket_id           = $this->get_mock_thing( 'tickets/1.json' );
+		$ticket_obj          = tribe( Ticket::class )->get_ticket( $ticket_id );
 		
 		// Remove the description to test the conditional logic.
 		$ticket_obj->description = '';
 		
-		$ticket['obj'] = $ticket_obj;
+		$ticket['obj']       = $ticket_obj;
 		$ticket['ticket_id'] = $ticket_id;
 
 		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-				'item' => $ticket,
-			]
-		) );
+			'item' => $ticket,
+		] ) );
 	}
 
 	/**
@@ -49,22 +50,21 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 	 * @since TBD
 	 */
 	public function test_should_render_cart_item_details_without_toggle_when_show_description_false() {
-		$ticket_id = $this->get_mock_thing( 'tickets/1.json' );
-		$ticket_obj = tribe( Ticket::class )->get_ticket( $ticket_id );
+		$ticket_id           = $this->get_mock_thing( 'tickets/1.json' );
+		$ticket_obj          = tribe( Ticket::class )->get_ticket( $ticket_id );
 		
 		// Create a mock that returns false for show_description().
-		$mock_ticket = $this->createMock( get_class( $ticket_obj ) );
+		$mock_ticket              = $this->createMock( get_class( $ticket_obj ) );
 		$mock_ticket->method( 'show_description' )->willReturn( false );
 		$mock_ticket->description = 'This ticket has a description but should not show it';
-		$mock_ticket->post_title = $ticket_obj->post_title;
-		$mock_ticket->ID = $ticket_obj->ID;
+		$mock_ticket->post_title  = $ticket_obj->post_title;
+		$mock_ticket->ID          = $ticket_obj->ID;
 		
-		$ticket['obj'] = $mock_ticket;
+		$ticket['obj']       = $mock_ticket;
 		$ticket['ticket_id'] = $ticket_id;
 
 		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-				'item' => $ticket,
-			]
-		) );
+			'item' => $ticket,
+		] ) );
 	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/ItemDetailsTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/ItemDetailsTest.php
@@ -19,9 +19,9 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 		$ticket['obj']       = tribe( Ticket::class )->get_ticket( $ticket_id );
 		$ticket['ticket_id'] = $ticket_id;
 
-		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-			'item' => $ticket,
-		] ) );
+		$html = $this->get_partial_html( [ 'item' => $ticket ] );
+		$this->assertMatchesHtmlSnapshot( $html );
+		$this->assertContains( "tribe-tickets__commerce-checkout-cart-item-details-toggle", $html );
 	}
 
 	/**
@@ -39,9 +39,9 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 		$ticket['obj']       = $ticket_obj;
 		$ticket['ticket_id'] = $ticket_id;
 
-		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-			'item' => $ticket,
-		] ) );
+		$html = $this->get_partial_html( [ 'item' => $ticket ] );
+		$this->assertMatchesHtmlSnapshot( $html );
+		$this->assertNotContains( "tribe-tickets__commerce-checkout-cart-item-details-toggle", $html );
 	}
 
 	/**
@@ -63,8 +63,8 @@ class ItemDetailsTest extends TicketsCommerceSnapshotTestCase {
 		$ticket['obj']       = $mock_ticket;
 		$ticket['ticket_id'] = $ticket_id;
 
-		$this->assertMatchesHtmlSnapshot( $this->get_partial_html( [
-			'item' => $ticket,
-		] ) );
+		$html = $this->get_partial_html( [ 'item' => $ticket ] );
+		$this->assertMatchesHtmlSnapshot( $html );
+		$this->assertNotContains( "tribe-tickets__commerce-checkout-cart-item-details-toggle", $html );
 	}
 }

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/__snapshots__/ItemDetailsTest__test_should_render_cart_item_details_without_toggle_when_no_description__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/__snapshots__/ItemDetailsTest__test_should_render_cart_item_details_without_toggle_when_no_description__0.snapshot.html
@@ -1,0 +1,7 @@
+<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	Ticket A</div>
+
+	
+</div>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/__snapshots__/ItemDetailsTest__test_should_render_cart_item_details_without_toggle_when_show_description_false__0.snapshot.html
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Partials/Checkout/Cart/Item/__snapshots__/ItemDetailsTest__test_should_render_cart_item_details_without_toggle_when_show_description_false__0.snapshot.html
@@ -1,0 +1,7 @@
+<div class="tribe-tickets__commerce-checkout-cart-item-details">
+
+	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
+	</div>
+
+	
+</div>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
@@ -32,7 +32,7 @@
 	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
 	Test TC ticket for {{page_id}}</div>
 
-	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+			<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
 	<button
 		type="button"
 		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
@@ -55,10 +55,10 @@
 	</button>
 </div>
 
-	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{{ticket_id1}}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+		<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{{ticket_id1}}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
 	Test TC ticket description for {{page_id}}
 	</div>
-
+		
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -149,12 +149,12 @@
 </footer>
 
 </div>
-				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
-	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
-	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
-	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tec-tickets__admin-settings-tickets-commerce-gateway-connected-resync-button-icon" >
+<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 </div>
-		<div id=""  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
+		<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
 	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -41,7 +41,7 @@
 	<div class="tribe-common-h6 tribe-tickets__commerce-checkout-cart-item-details-title">
 	Test TC ticket for {{page_id}}</div>
 
-	<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
+			<div class="tribe-tickets__commerce-checkout-cart-item-details-toggle">
 	<button
 		type="button"
 		class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-button--more"
@@ -64,10 +64,10 @@
 	</button>
 </div>
 
-	<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{{ticket_id2}}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
+		<div id="tribe-tickets__commerce-checkout-cart-item-details-description--{{ticket_id2}}"  class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__commerce-checkout-cart-item-details-description tribe-common-a11y-hidden" >
 	Test TC ticket description for {{page_id}}
 	</div>
-
+		
 </div>
 
 	<div class="tribe-tickets__commerce-checkout-cart-item-price">
@@ -149,12 +149,12 @@
 </footer>
 
 </div>
-				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tec-tickets__admin-settings-tickets-commerce-gateway-connected-resync-button-icon" >
+				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 </div>
-		<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
+		<div id=""  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>
 	
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-tickets__commerce-checkout-notice-content" >

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -149,7 +149,7 @@
 </footer>
 
 </div>
-				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
+				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tec-tickets__admin-settings-tickets-commerce-gateway-connected-resync-button-icon" >
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -149,10 +149,10 @@
 </footer>
 
 </div>
-				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tec-tickets__admin-settings-tickets-commerce-gateway-connected-resync-button-icon" >
-<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
-<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
-<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+				<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
+	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
+	<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third"  viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="7.5" r="7.5"/></svg>
 </div>
 		<div id="tribe-tickets__commerce-checkout-footer-notice-error--no-gateway"  class="tribe-tickets__notice tribe-tickets__notice--error tribe-tickets__commerce-checkout-notice" >
 			<h3 class="tribe-common-h7 tribe-tickets-notice__title">Checkout Error!</h3>


### PR DESCRIPTION
### 🎫 Ticket

[ET-2530]

### 🗒️ Description

The toggle for showing the description of a ticket was showing even if the ticket had no description. This adds a simple conditional to only show the toggle/description if there's something to show. 

### 🎥 Artifacts 

https://github.com/user-attachments/assets/dde35674-95c1-46b2-b3a9-4ef7a8037035

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2530]: https://stellarwp.atlassian.net/browse/ET-2530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ