### PR TITLE
TEC-5529 Fix add_submenu_page deprecation message

### DIFF
--- a/changelog/fix-TEC-5529-str_replace-deprecation-message
+++ b/changelog/fix-TEC-5529-str_replace-deprecation-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure add_submenu_page is called correctly to avoid deprecation messages. [TEC-5529]

--- a/src/Tribe/Commerce/PayPal/Orders/Report.php
+++ b/src/Tribe/Commerce/PayPal/Orders/Report.php
@@ -161,7 +161,7 @@ class Tribe__Tickets__Commerce__PayPal__Orders__Report {
 
 		$page_title        = __( 'PayPal Orders', 'event-tickets' );
 		$this->orders_page = add_submenu_page(
-			null,
+			'',
 			$page_title,
 			$page_title,
 			$cap,


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5529]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The first parameter of `add_submenu_page()` was null, which was then passed to `str_replace()` and `str_pos()`, resulting in deprecation messages. Replacing `null` with an empty string `''` solves the issue and keeps the page hidden.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot showing the deprecation messages](https://dl.dropboxusercontent.com/scl/fi/f4p507ns81bhz2aug71s0/shot_250708_171216.png?rlkey=4tqlcmbmpk6c1p6n6zwkk2fi8&dl=0)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5529]: https://stellarwp.atlassian.net/browse/TEC-5529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ