### PR TITLE
Classy - Integrate ET VE fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
       "Composer\\Config::disableProcessTimeout",
       "test -f ./bin/pup.phar || curl -o ./bin/pup.phar -L -C - https://github.com/stellarwp/pup/releases/download/1.3.8/pup.phar",
       "@php bin/pup.phar"
-    ]
+    ],
+    "classy:format": "vendor/bin/phpcbf src/Tickets/Classy tests/classy_integration"
   },
   "extra": {
     "changelogger": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@wordpress/a11y": "^4.11.0",
         "@wordpress/api-fetch": "^7.26.0",
         "@wordpress/date": "^5.13.0",
+        "@wordpress/element": "^6.28.0",
         "@wordpress/i18n": "^5.11.0",
         "@wordpress/is-shallow-equal": "^5.11.0",
         "@wordpress/url": "^4.11.0",
@@ -5515,7 +5516,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -6764,16 +6764,14 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.25.0.tgz",
-      "integrity": "sha512-zxdaf2s/en5Y+DfiswRZtQ+P8SvQ18+l5I2WmHb66+bVkFg7jrN+AJqLk86k2zcalOEjx7Fg4cce1wWytp8Wsw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.28.0.tgz",
+      "integrity": "sha512-FSojQxfsaDXwc11nMgc/OlIgq1BgjpNf9m2Smw1Z3GmVq8J4E6wAFpJuoUPwyjON4i1apiWl/bqQA84yT9C84g==",
       "dependencies": {
         "@babel/runtime": "7.25.7",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.25.0",
+        "@wordpress/escape-html": "^3.28.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -6788,7 +6786,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
       "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -6798,11 +6795,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.25.0.tgz",
-      "integrity": "sha512-sQ3graObu5K/RWrngk9bsULJ+9E7QLC6gMG34ja0Jm1LdeRjVgHv3FqP/uIkL36EvxEkjQ0LSbgbZsdV/E1q0w==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.28.0.tgz",
+      "integrity": "sha512-LDcr26vX7OkcvHMjAFxg0vNmI7cP5lzLs+HbnwM1H9h0dsj3svIWXXFF/7lQl7sbI9+rjF0GkR1Fgd+DvF7zxw==",
       "dependencies": {
         "@babel/runtime": "7.25.7"
       },
@@ -6815,7 +6810,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
       "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -9062,7 +9056,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "dependencies": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
@@ -9151,7 +9144,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -9178,7 +9170,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "dependencies": {
         "camel-case": "^4.1.2",
         "capital-case": "^1.0.4",
@@ -9656,7 +9647,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -10991,7 +10981,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -13507,7 +13496,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
@@ -14657,7 +14645,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16556,7 +16543,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -17304,7 +17290,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -18048,7 +18033,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -18117,7 +18101,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -18127,7 +18110,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -21633,7 +21615,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -22025,7 +22006,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -23579,8 +23559,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -23907,7 +23886,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -23916,7 +23894,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,11 @@
     "build": "wp-scripts build",
     "start": "wp-scripts start --mode=development --devtool=source-map",
     "dev": "WP_DEVTOOL=eval-source-map wp-scripts start",
-    "changelog": "./vendor/bin/changelogger add"
+    "changelog": "./vendor/bin/changelogger add",
+    "classy:format": "wp-scripts format src/resources/packages/classy tests/classy_jest && composer run classy:format",
+    "classy:jest": "jest --config tests/classy_jest/jest.config.js tests/classy_jest",
+    "classy:test": "npm run classy:jest && slic run classy_integration",
+    "classy:pre-commit": "npm run classy:format && npm run classy:test"
   },
   "engines": {
     "node": "18.17.0",
@@ -110,6 +114,7 @@
     "@wordpress/a11y": "^4.11.0",
     "@wordpress/api-fetch": "^7.26.0",
     "@wordpress/date": "^5.13.0",
+    "@wordpress/element": "^6.28.0",
     "@wordpress/i18n": "^5.11.0",
     "@wordpress/is-shallow-equal": "^5.11.0",
     "@wordpress/url": "^4.11.0",

--- a/src/Tickets/Classy/Controller.php
+++ b/src/Tickets/Classy/Controller.php
@@ -13,6 +13,7 @@ namespace TEC\Tickets\Classy;
 
 use TEC\Common\Classy\Controller as Common_Controller;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\lucatume\DI52\ContainerException;
 use TEC\Common\StellarWP\Assets\Asset;
 use TEC\Tickets\Classy\REST\Controller as REST_Controller;
 use TEC\Tickets\Commerce\Utils\Currency;
@@ -39,6 +40,8 @@ class Controller extends Controller_Contract {
 			add_action( 'tec_common_assets_loaded', [ $this, 'register_assets' ] );
 		}
 
+		$this->register_ecp_integrations();
+
 		$this->container->register( REST_Controller::class );
 	}
 
@@ -53,6 +56,7 @@ class Controller extends Controller_Contract {
 	 */
 	public function unregister(): void {
 		remove_action( 'tec_common_assets_loaded', [ $this, 'register_assets' ] );
+		remove_action( 'tec_events_pro_classy_registered', [ $this, 'register_ecp_editor_meta' ] );
 		$this->container->get( REST_Controller::class )->unregister();
 	}
 
@@ -135,5 +139,37 @@ class Controller extends Controller_Contract {
 				'createTicket' => wp_create_nonce( 'add_ticket_nonce' ),
 			],
 		];
+	}
+
+	/**
+	 * Registers the meta fields supported by Event Tickets when Events Pro is active.
+	 *
+	 * @internal
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_ecp_editor_meta(): void {
+		$this->container->make( ECP_Editor_Meta::class )->register();
+	}
+
+	/**
+	 * Registers Events Pro integrations, if the plugin is active.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function register_ecp_integrations(): void {
+		$this->container->singleton( ECP_Editor_Meta::class );
+
+		if (
+			did_action( 'tec_events_pro_classy_registered' )
+			|| doing_action( 'tec_events_pro_classy_registered' )
+		) {
+			$this->register_ecp_editor_meta();
+		} else {
+			add_action( 'tec_events_pro_classy_registered', [ $this, 'register_ecp_editor_meta' ] );
+		}
 	}
 }

--- a/src/Tickets/Classy/ECP_Editor_Meta.php
+++ b/src/Tickets/Classy/ECP_Editor_Meta.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Handles Event Tickets integration with Classy and Events Pro.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Classy;
+ */
+
+namespace TEC\Tickets\Classy;
+
+use Tribe\Events\Virtual\Compatibility\Event_Tickets\Event_Meta;
+use Tribe__Editor__Meta as Editor_Meta_Contract;
+
+/**
+ * Class ECP_Editor_Meta.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Tickets\Classy;
+ */
+class ECP_Editor_Meta extends Editor_Meta_Contract {
+	/**
+	 * Registers the meta fields supported by Event Tickets when Events Pro is active.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register() {
+		register_meta(
+			'post',
+			Event_Meta::$key_rsvp_email_link,
+			$this->text()
+		);
+
+		register_meta(
+			'post',
+			Event_Meta::$key_ticket_email_link,
+			$this->text()
+		);
+	}
+}

--- a/src/resources/packages/classy/api/tickets.ts
+++ b/src/resources/packages/classy/api/tickets.ts
@@ -3,12 +3,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { addQueryArgs } from '@wordpress/url';
 import { CostDetails } from '../types/CostDetails';
 import { CapacitySettings, SalePriceDetails, TicketSettings } from '../types/Ticket';
-import {
-	GetTicketApiResponse,
-	GetTicketsApiResponse,
-	GetTicketsApiParams,
-	UpsertTicketApiRequest,
-} from '../types/Api';
+import { GetTicketApiResponse, GetTicketsApiResponse, GetTicketsApiParams, UpsertTicketApiRequest } from '../types/Api';
 import { NonceAction, NonceTypes } from '../types/LocalizedData';
 import { getLocalizedData } from '../localizedData.ts';
 
@@ -41,7 +36,7 @@ const getNonce = ( type: NonceTypes ): string => {
  * @param {GetTicketsApiParams} params Optional parameters for the API request.
  * @return {Promise<GetTicketsApiResponse>} A promise that resolves to the tickets response.
  */
-export const fetchTickets = async ( params: GetTicketsApiParams = {} ): Promise<GetTicketsApiResponse> => {
+export const fetchTickets = async ( params: GetTicketsApiParams = {} ): Promise< GetTicketsApiResponse > => {
 	const searchParams = new URLSearchParams();
 
 	if ( params.include_post ) {
@@ -60,13 +55,15 @@ export const fetchTickets = async ( params: GetTicketsApiParams = {} ): Promise<
 
 	const path = addQueryArgs( apiBaseUrl, searchParams );
 
-	return new Promise<GetTicketsApiResponse>( async ( resolve, reject ) => {
+	return new Promise< GetTicketsApiResponse >( async ( resolve, reject ) => {
 		await apiFetch( { path: path } )
 			.then( ( data ) => {
 				if ( ! ( data && typeof data === 'object' ) ) {
 					reject( new Error( 'Failed to fetch tickets: response did not return an object.' ) );
 				} else if ( ! ( data.hasOwnProperty( 'tickets' ) && data.hasOwnProperty( 'total' ) ) ) {
-					reject( new Error( 'Tickets fetch request did not return an object with tickets and total properties.' ) );
+					reject(
+						new Error( 'Tickets fetch request did not return an object with tickets and total properties.' )
+					);
 				} else {
 					resolve( data as GetTicketsApiResponse );
 				}
@@ -89,12 +86,14 @@ export const fetchTickets = async ( params: GetTicketsApiParams = {} ): Promise<
  * @param {number} postId The ID of the post to fetch tickets for.
  * @return {Awaited<TicketSettings[]>} A promise that resolves to an array of tickets.
  */
-export const fetchTicketsForPost = async ( postId: number ): Promise<TicketSettings[]> => {
-	return new Promise<TicketSettings[]>( async ( resolve, reject ) => {
+export const fetchTicketsForPost = async ( postId: number ): Promise< TicketSettings[] > => {
+	return new Promise< TicketSettings[] >( async ( resolve, reject ) => {
 		// todo: Handle the potential for multiple pages of results.
 		await fetchTickets( { include_post: [ postId ] } )
 			.then( ( response: GetTicketsApiResponse ) => {
-				resolve( response.tickets.map( ( ticket: GetTicketApiResponse ) => mapApiResponseToTicketSettings( ticket ) ) );
+				resolve(
+					response.tickets.map( ( ticket: GetTicketApiResponse ) => mapApiResponseToTicketSettings( ticket ) )
+				);
 			} )
 			.catch( ( error ) => {
 				reject( new Error( `Failed to fetch tickets for post ID ${ postId }: ${ error.message }` ) );
@@ -115,10 +114,10 @@ export const fetchTicketsForPost = async ( postId: number ): Promise<TicketSetti
  * @param {TicketSettings} ticketData The data for the ticket to create or update.
  * @return {Promise<TicketSettings>} A promise that resolves to the created or updated ticket.
  */
-export const upsertTicket = async ( ticketData: TicketSettings ): Promise<TicketSettings> => {
+export const upsertTicket = async ( ticketData: TicketSettings ): Promise< TicketSettings > => {
 	const isUpdate = ticketData.id && ticketData.id > 0;
 
-	return new Promise<TicketSettings>( async ( resolve, reject ) => {
+	return new Promise< TicketSettings >( async ( resolve, reject ) => {
 		const nonceKey: NonceAction = isUpdate ? 'edit_ticket_nonce' : 'add_ticket_nonce';
 		await apiFetch( {
 			path: `${ apiBaseUrl }${ isUpdate ? `/${ ticketData.id }` : '' }`,
@@ -130,7 +129,11 @@ export const upsertTicket = async ( ticketData: TicketSettings ): Promise<Ticket
 		} )
 			.then( ( data: GetTicketApiResponse ) => {
 				if ( ! ( data && typeof data === 'object' ) ) {
-					reject( new Error( `Failed to ${ isUpdate ? 'update' : 'create' } ticket: response did not return an object.` ) );
+					reject(
+						new Error(
+							`Failed to ${ isUpdate ? 'update' : 'create' } ticket: response did not return an object.`
+						)
+					);
 				} else {
 					resolve( mapApiResponseToTicketSettings( data ) );
 				}
@@ -150,14 +153,14 @@ export const upsertTicket = async ( ticketData: TicketSettings ): Promise<Ticket
  * @return {Promise<void>} A promise that resolves when the ticket is deleted.
  * @throws {Error} If the deletion fails.
  */
-export const deleteTicket = async ( ticketId: number ): Promise<void> => {
-	return new Promise<void>( async ( resolve, reject ) => {
+export const deleteTicket = async ( ticketId: number ): Promise< void > => {
+	return new Promise< void >( async ( resolve, reject ) => {
 		await apiFetch( {
 			path: `${ apiBaseUrl }/${ ticketId }`,
 			method: 'DELETE',
 			data: {
 				remove_ticket_nonce: getNonce( 'deleteTicket' ),
-			}
+			},
 		} )
 			.then( () => {
 				resolve();
@@ -179,16 +182,13 @@ export const deleteTicket = async ( ticketId: number ): Promise<void> => {
  */
 const mapTicketSettingsToApiRequest = ( ticketData: TicketSettings, isUpdate: boolean ): UpsertTicketApiRequest => {
 	const hasPrice = ticketData?.costDetails?.values.length > 0;
-	const ticket: Record<string, any> = {};
+	const ticket: Record< string, any > = {};
 
 	// Capacity fields.
 	// todo: this needs work.
 	console.log( 'Ticket data settings:', ticketData );
 	if ( ticketData.capacitySettings ) {
-		const {
-			globalStockMode = 'own',
-			enteredCapacity
-		} = ticketData.capacitySettings;
+		const { globalStockMode = 'own', enteredCapacity } = ticketData.capacitySettings;
 
 		ticket.capacity = enteredCapacity.toString();
 
@@ -266,9 +266,7 @@ const mapTicketSettingsToApiRequest = ( ticketData: TicketSettings, isUpdate: bo
 	body.menu_order = ticketData.menuOrder?.toString() || '0';
 
 	// Set the filter as its own full string, to allow for easier discoverability when searching for it.
-	const filterName = isUpdate
-		? 'tec.classy.tickets.updateTicket'
-		: 'tec.classy.tickets.createTicket';
+	const filterName = isUpdate ? 'tec.classy.tickets.updateTicket' : 'tec.classy.tickets.createTicket';
 
 	/**
 	 * Filter the body of the upsert request before sending it to the API.
@@ -278,7 +276,7 @@ const mapTicketSettingsToApiRequest = ( ticketData: TicketSettings, isUpdate: bo
 	 * @param {Record<string, any>} body The object containing additional values to be sent in the request.
 	 * @param {TicketSettings} ticketData The ticket data being sent.
 	 */
-	const additionalValues: Record<string, any> = applyFilters( filterName, {}, ticketData );
+	const additionalValues: Record< string, any > = applyFilters( filterName, {}, ticketData );
 
 	// Append/update additional values in the body.
 	Object.entries( additionalValues ).forEach( ( [ key, value ] ) => {
@@ -288,7 +286,7 @@ const mapTicketSettingsToApiRequest = ( ticketData: TicketSettings, isUpdate: bo
 	} );
 
 	return body;
-}
+};
 
 /**
  * Map API response to TicketSettings type.
@@ -339,4 +337,4 @@ const mapApiResponseToTicketSettings = ( apiResponse: GetTicketApiResponse ): Ti
 		provider: apiResponse.provider || 'tc',
 		type: apiResponse.type || 'default',
 	};
-}
+};

--- a/src/resources/packages/classy/components/AddTicket/AddTicket.tsx
+++ b/src/resources/packages/classy/components/AddTicket/AddTicket.tsx
@@ -5,20 +5,15 @@ import { Button } from '@wordpress/components';
 type AddTicketProps = {
 	buttonText?: string;
 	onClick: () => void;
-}
+};
 
 const defaultButtonText = _x( 'Add Ticket', 'Button text to add a new ticket', 'event-tickets' );
 
 export default function AddTicket( props: AddTicketProps ): JSX.Element {
-
 	const { buttonText, onClick } = props;
 
 	return (
-		<Button
-			className="classy-button"
-			onClick={ onClick }
-			variant="primary"
-		>
+		<Button className="classy-button" onClick={ onClick } variant="primary">
 			{ buttonText || defaultButtonText }
 		</Button>
 	);

--- a/src/resources/packages/classy/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/resources/packages/classy/components/CurrencyInput/CurrencyInput.tsx
@@ -10,11 +10,7 @@ const defaultCurrency: Currency = {
 	code: getCurrencySettings().code,
 };
 
-const {
-	decimalSeparator,
-	thousandSeparator,
-	precision: decimalPrecision,
-} = getCurrencySettings();
+const { decimalSeparator, thousandSeparator, precision: decimalPrecision } = getCurrencySettings();
 
 type CurrencyInputProps = {
 	/**
@@ -36,7 +32,7 @@ type CurrencyInputProps = {
 	 * Whether the input field is required.
 	 */
 	required?: boolean;
-}
+};
 
 const defaultLabel = _x( 'Price', 'Label for the price input field', 'event-tickets' );
 
@@ -49,12 +45,7 @@ const defaultLabel = _x( 'Price', 'Label for the price input field', 'event-tick
  * @return {JSX.Element} The rendered currency input field.
  */
 export default function CurrencyInput( props: CurrencyInputProps ): JSX.Element {
-	const {
-		label,
-		onChange,
-		value,
-		required = false,
-	} = props;
+	const { label, onChange, value, required = false } = props;
 
 	return (
 		<CommonCurrencyInput

--- a/src/resources/packages/classy/components/Icons/ChevronDown.tsx
+++ b/src/resources/packages/classy/components/Icons/ChevronDown.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 export default function ChevronDown(): JSX.Element {
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-			<path d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z" fill="currentColor"/>
+			<path d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z" fill="currentColor" />
 		</svg>
 	);
 }

--- a/src/resources/packages/classy/components/Icons/ChevronUp.tsx
+++ b/src/resources/packages/classy/components/Icons/ChevronUp.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 export default function ChevronUp(): JSX.Element {
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-			<path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" fill="currentColor"/>
+			<path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" fill="currentColor" />
 		</svg>
 	);
 }

--- a/src/resources/packages/classy/components/Icons/Clipboard.tsx
+++ b/src/resources/packages/classy/components/Icons/Clipboard.tsx
@@ -12,28 +12,32 @@ export default function Clipboard(): JSX.Element {
 		<svg xmlns="http://www.w3.org/2000/svg" width="17" height="16" viewBox="0 0 17 16" fill="none">
 			<path
 				d="M9.69961 1.6V1.06667C9.69961 0.476444 9.16542 0 8.49961 0C7.8338 0 7.29961 0.476444 7.29961 1.06667V1.6C6.6338 1.6 6.09961 2.07644 6.09961 2.66667V3.2H10.8996V2.65956C10.8996 2.07644 10.3654 1.6 9.69961 1.6Z"
-				fill="#727272"/>
+				fill="#727272"
+			/>
 			<path
 				d="M5.19399 1.59998H3.2998V14.4H13.6998V1.59998H11.7768"
 				stroke="#727272"
 				strokeWidth="1.5"
 				strokeMiterlimit="10"
 				strokeLinecap="round"
-				strokeLinejoin="round"/>
+				strokeLinejoin="round"
+			/>
 			<path
 				d="M6.09961 6.80005H10.8996"
 				stroke="#727272"
 				strokeWidth="1.5"
 				strokeMiterlimit="10"
 				strokeLinecap="round"
-				strokeLinejoin="round"/>
+				strokeLinejoin="round"
+			/>
 			<path
 				d="M6.09961 10.832H10.8996"
 				stroke="#727272"
 				strokeWidth="1.5"
 				strokeMiterlimit="10"
 				strokeLinecap="round"
-				strokeLinejoin="round"/>
+				strokeLinejoin="round"
+			/>
 		</svg>
 	);
 }

--- a/src/resources/packages/classy/components/Icons/Clock.tsx
+++ b/src/resources/packages/classy/components/Icons/Clock.tsx
@@ -7,13 +7,7 @@ import * as React from 'react';
  */
 export default function Clock(): JSX.Element {
 	return (
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			width="16"
-			height="16"
-			viewBox="0 0 16 16"
-			fill="none"
-		>
+		<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
 			<path
 				d="M8 14.5C11.5899 14.5 14.5 11.5899 14.5 8C14.5 4.41015 11.5899 1.5 8 1.5C4.41015 1.5 1.5 4.41015 1.5 8C1.5 11.5899 4.41015 14.5 8 14.5Z"
 				stroke="#727272"

--- a/src/resources/packages/classy/components/TicketRow/TicketRow.tsx
+++ b/src/resources/packages/classy/components/TicketRow/TicketRow.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { CapacitySettings, TicketSettings } from '../../types/Ticket';
 import { TicketComponentProps } from '../../types/TicketComponentProps';
 import { ClipboardIcon, ClockIcon } from '../Icons';
-import { TicketRowMover } from "../TicketRowMover";
+import { TicketRowMover } from '../TicketRowMover';
 
 type TicketRowProps = {
 	canMoveDown?: boolean;
@@ -39,11 +39,7 @@ const unlimitedLowercase = _x( 'unlimited', 'Label for unlimited capacity', 'eve
  * @returns {string|number} The calculated capacity based on the input settings. Returns `unlimitedLowercase` for unlimited capacity.
  */
 const getCapacityNumber = ( settings: CapacitySettings ): string | number => {
-	const {
-		enteredCapacity,
-		isShared,
-		sharedCapacity = 0
-	} = settings;
+	const { enteredCapacity, isShared, sharedCapacity = 0 } = settings;
 	const enteredIsUnlimited = '' === enteredCapacity || -1 === enteredCapacity;
 	const enteredAsNumber = enteredIsUnlimited ? -1 : Number( enteredCapacity );
 
@@ -64,7 +60,7 @@ const getCapacityNumber = ( settings: CapacitySettings ): string | number => {
 	} else {
 		return sharedCapacity;
 	}
-}
+};
 
 const noop = () => {};
 
@@ -86,7 +82,7 @@ export default function TicketRow( props: TicketRowProps ): JSX.Element {
 		showMovers = false,
 		tabIndex,
 		ticketPosition = 0,
-		value: ticket
+		value: ticket,
 	} = props;
 
 	// todo: This should be based on whether any icons should be shown.
@@ -105,13 +101,15 @@ export default function TicketRow( props: TicketRowProps ): JSX.Element {
 					{ hasIcons && (
 						<span className="classy-field__ticket-row__icons">
 							{ /* todo: fill in icons properly */ }
-							<ClipboardIcon/>
-							<ClockIcon/>
+							<ClipboardIcon />
+							<ClockIcon />
 						</span>
 					) }
 				</h4>
 				{ ticket.description && (
-					<span className="classy-field__ticket-row__description">{ decodeEntities( ticket.description ) }</span>
+					<span className="classy-field__ticket-row__description">
+						{ decodeEntities( ticket.description ) }
+					</span>
 				) }
 			</td>
 

--- a/src/resources/packages/classy/components/TicketRowMover/TicketRowMover.tsx
+++ b/src/resources/packages/classy/components/TicketRowMover/TicketRowMover.tsx
@@ -32,21 +32,27 @@ export default function TicketRowMover( props: TicketRowMoverProps ): JSX.Elemen
 		ticketPosition = 0,
 	} = props;
 
-	const handleMoveUp = useCallback( ( event: MouseEvent<HTMLButtonElement> ) => {
-		event.preventDefault();
-		event.stopPropagation();
-		if ( canMoveUp && onMoveUp ) {
-			onMoveUp();
-		}
-	}, [ canMoveUp, onMoveUp ] );
+	const handleMoveUp = useCallback(
+		( event: MouseEvent< HTMLButtonElement > ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if ( canMoveUp && onMoveUp ) {
+				onMoveUp();
+			}
+		},
+		[ canMoveUp, onMoveUp ]
+	);
 
-	const handleMoveDown = useCallback( ( event: MouseEvent<HTMLButtonElement> ) => {
-		event.preventDefault();
-		event.stopPropagation();
-		if ( canMoveDown && onMoveDown ) {
-			onMoveDown();
-		}
-	}, [ canMoveDown, onMoveDown ] );
+	const handleMoveDown = useCallback(
+		( event: MouseEvent< HTMLButtonElement > ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if ( canMoveDown && onMoveDown ) {
+				onMoveDown();
+			}
+		},
+		[ canMoveDown, onMoveDown ]
+	);
 
 	const getMoveUpLabel = () => {
 		if ( ! canMoveUp ) {
@@ -74,7 +80,7 @@ export default function TicketRowMover( props: TicketRowMoverProps ): JSX.Elemen
 			<Button
 				__next40pxDefaultSize
 				className="classy-field__ticket-row__movers__up"
-				icon={ <ChevronUpIcon/> }
+				icon={ <ChevronUpIcon /> }
 				label={ getMoveUpLabel() }
 				disabled={ ! canMoveUp }
 				accessibleWhenDisabled
@@ -85,7 +91,7 @@ export default function TicketRowMover( props: TicketRowMoverProps ): JSX.Elemen
 			<Button
 				__next40pxDefaultSize
 				className="classy-field__ticket-row__movers__down"
-				icon={ <ChevronDownIcon/> }
+				icon={ <ChevronDownIcon /> }
 				label={ getMoveDownLabel() }
 				disabled={ ! canMoveDown }
 				accessibleWhenDisabled

--- a/src/resources/packages/classy/components/TicketTable/TicketTable.tsx
+++ b/src/resources/packages/classy/components/TicketTable/TicketTable.tsx
@@ -5,11 +5,11 @@ import { TicketSettings } from '../../types/Ticket';
 import { TicketComponentProps } from '../../types/TicketComponentProps';
 import { TicketRow } from '../TicketRow';
 import { STORE_NAME } from '../../constants';
-import { StoreDispatch, StoreSelect, CoreEditorSelect } from "../../types/Store";
+import { StoreDispatch, StoreSelect, CoreEditorSelect } from '../../types/Store';
 
 type TicketTableProps = {
 	onEditTicket: ( ticket: TicketSettings ) => void;
-} & Omit<TicketComponentProps, 'value'>;
+} & Omit< TicketComponentProps, 'value' >;
 
 type MoveDirection = 'up' | 'down';
 
@@ -26,7 +26,7 @@ const moveTicket = ( tickets: TicketSettings[], direction: MoveDirection, index:
 	}
 
 	return newTickets;
-}
+};
 
 /**
  * TicketTable component for displaying a list of tickets in a table format.
@@ -36,9 +36,7 @@ const moveTicket = ( tickets: TicketSettings[], direction: MoveDirection, index:
  * @param {TicketTableProps} props
  */
 export default function TicketTable( props: TicketTableProps ): JSX.Element {
-	const {
-		onEditTicket,
-	} = props;
+	const { onEditTicket } = props;
 
 	const { tickets } = useSelect( ( select ) => {
 		const { getTickets }: StoreSelect = select( STORE_NAME );
@@ -56,10 +54,13 @@ export default function TicketTable( props: TicketTableProps ): JSX.Element {
 
 	// todo: update the menu order of the tickets when moving them.
 
-	const handleMoveTicket = useCallback( ( direction: MoveDirection, index: number ) => {
-		const updatedTickets = moveTicket( tickets, direction, index );
-		setTickets( updatedTickets );
-	}, [ tickets, setTickets ] );
+	const handleMoveTicket = useCallback(
+		( direction: MoveDirection, index: number ) => {
+			const updatedTickets = moveTicket( tickets, direction, index );
+			setTickets( updatedTickets );
+		},
+		[ tickets, setTickets ]
+	);
 
 	return (
 		<table className="classy-field classy-field__ticket-table">

--- a/src/resources/packages/classy/components/TicketUpsert/TicketUpsert.tsx
+++ b/src/resources/packages/classy/components/TicketUpsert/TicketUpsert.tsx
@@ -6,14 +6,9 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { _x } from '@wordpress/i18n';
 import * as React from 'react';
 import { Fragment, useCallback, useState } from 'react';
-import { Capacity, SaleDuration, SalePrice, TicketDescription, TicketName, } from '../../fields';
+import { Capacity, SaleDuration, SalePrice, TicketDescription, TicketName } from '../../fields';
 import { CoreEditorSelect } from '../../types/Store';
-import {
-	CapacitySettings,
-	SalePriceDetails,
-	TicketId,
-	TicketSettings
-} from '../../types/Ticket';
+import { CapacitySettings, SalePriceDetails, TicketId, TicketSettings } from '../../types/Ticket';
 import { CurrencyInput } from '../CurrencyInput';
 import * as TicketApi from '../../api/tickets';
 
@@ -23,7 +18,7 @@ type TicketUpsertProps = {
 	onDelete?: ( ticketId: TicketId ) => void;
 	onSave: ( data: TicketSettings ) => void;
 	value: TicketSettings;
-}
+};
 
 const defaultValues: TicketSettings = {
 	id: 0,
@@ -46,7 +41,7 @@ const defaultValues: TicketSettings = {
 		currencyDecimalSeparator: '.',
 		currencyThousandSeparator: ',',
 		suffix: '',
-		values: []
+		values: [],
 	},
 	fees: {
 		availableFees: [],
@@ -68,13 +63,7 @@ const noop = () => {};
  * @return {JSX.Element} The rendered ticket upsert component.
  */
 export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
-	const {
-		isUpdate,
-		onCancel,
-		onDelete = noop,
-		onSave,
-		value,
-	} = props;
+	const { isUpdate, onCancel, onDelete = noop, onSave, value } = props;
 
 	const { eventId } = useSelect( ( select: SelectFunction ) => {
 		const { getCurrentPostId }: CoreEditorSelect = select( 'core/editor' );
@@ -83,22 +72,20 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 		};
 	}, [] );
 
-	const [ currentValues, setCurrentValues ] = useState<TicketSettings>( {
+	const [ currentValues, setCurrentValues ] = useState< TicketSettings >( {
 		eventId: eventId,
 		...defaultValues,
 		...value,
 	} );
 
-	const [ costValue, setCostValue ] = useState<number>(
-		currentValues.costDetails.values.length > 0
-			? currentValues.costDetails.values[ 0 ]
-			: 0
+	const [ costValue, setCostValue ] = useState< number >(
+		currentValues.costDetails.values.length > 0 ? currentValues.costDetails.values[ 0 ] : 0
 	);
 
 	// Tickets must have a name at a minimum.
-	const [ confirmEnabled, setConfirmEnabled ] = useState<boolean>( currentValues.name !== '' );
-	const [ ticketUpsertError, setTicketUpsertError ] = useState<Error | null>( null );
-	const [ saveInProgress, setSaveInProgress ] = useState<boolean>( false );
+	const [ confirmEnabled, setConfirmEnabled ] = useState< boolean >( currentValues.name !== '' );
+	const [ ticketUpsertError, setTicketUpsertError ] = useState< Error | null >( null );
+	const [ saveInProgress, setSaveInProgress ] = useState< boolean >( false );
 
 	const onValueChange = ( key: string, newValue: any ): void => {
 		return setCurrentValues( {
@@ -113,7 +100,11 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 
 		// If the ticket name is empty, we cannot save.
 		if ( ! confirmEnabled ) {
-			setTicketUpsertError( new Error( _x( 'Please enter a ticket name.', 'Error message for missing ticket name', 'event-tickets' ) ) );
+			setTicketUpsertError(
+				new Error(
+					_x( 'Please enter a ticket name.', 'Error message for missing ticket name', 'event-tickets' )
+				)
+			);
 			return;
 		}
 
@@ -152,7 +143,7 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 	return (
 		<div className="classy-root">
 			<header className="classy-modal__header classy-modal__header--ticket">
-				<IconNew/>
+				<IconNew />
 				<h4 className="classy-modal__header-title">
 					{ isUpdate
 						? _x( 'Edit Ticket', 'Update ticket modal header title', 'event-tickets' )
@@ -162,7 +153,7 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 
 			<hr className="classy-modal__section-separator"></hr>
 
-			{ /* todo: this should highlight any errors in the form, instead of showing a message */}
+			{ /* todo: this should highlight any errors in the form, instead of showing a message */ }
 			{ ticketUpsertError && (
 				<Fragment>
 					<div className="classy-modal__error">
@@ -214,7 +205,7 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 				/>
 			</section>
 
-			<hr className="classy-modal__section-separator"/>
+			<hr className="classy-modal__section-separator" />
 
 			<section className="classy-modal__content classy-modal__content--ticket classy-field__inputs classy-field__inputs--unboxed">
 				<div className="classy-field__input-title">
@@ -224,12 +215,14 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 				<div className="classy-field__capacity">
 					<Capacity
 						value={ currentValues.capacitySettings }
-						onChange={ ( value: CapacitySettings ) => onValueChange( 'capacitySettings', value as CapacitySettings ) }
+						onChange={ ( value: CapacitySettings ) =>
+							onValueChange( 'capacitySettings', value as CapacitySettings )
+						}
 					/>
 				</div>
 			</section>
 
-			<hr className="classy-modal__section-separator"/>
+			<hr className="classy-modal__section-separator" />
 
 			<section className="classy-modal__content classy-modal__content--ticket classy-field__inputs classy-field__inputs--unboxed">
 				<div className="classy-field__input-title">
@@ -239,9 +232,7 @@ export default function TicketUpsert( props: TicketUpsertProps ): JSX.Element {
 						'event-tickets'
 					) }
 				</div>
-				<SaleDuration
-
-				/>
+				<SaleDuration />
 			</section>
 
 			<footer className="classy-modal__footer classy-modal__footer--ticket">

--- a/src/resources/packages/classy/components/TicketUpsertModal/TicketUpsertModal.tsx
+++ b/src/resources/packages/classy/components/TicketUpsertModal/TicketUpsertModal.tsx
@@ -22,14 +22,7 @@ type TicketUpsertModalProps = {
  * @return {JSX.Element} The rendered modal component.
  */
 export default function TicketUpsertModal( props: TicketUpsertModalProps ): JSX.Element {
-	const {
-		isUpdate,
-		onCancel,
-		onClose,
-		onDelete,
-		onSave,
-		value
-	} = props;
+	const { isUpdate, onCancel, onClose, onDelete, onSave, value } = props;
 
 	return (
 		<Modal

--- a/src/resources/packages/classy/constants.tsx
+++ b/src/resources/packages/classy/constants.tsx
@@ -3,3 +3,7 @@ export const POST_TYPE_TICKET = 'tribe_tpp_ticket';
 
 // Data store name for the Classy tickets.
 export const STORE_NAME = 'tec/classy/tickets';
+
+// Meta data keys for Virtual Events
+export const METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK = '_tribe_events_virtual_rsvp_email_link';
+export const METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK = '_tribe_events_virtual_ticket_email_link';

--- a/src/resources/packages/classy/fields/Capacity/Capacity.tsx
+++ b/src/resources/packages/classy/fields/Capacity/Capacity.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { LabeledInput } from '@tec/common/classy/components';
-import {
-	__experimentalInputControl as InputControl,
-	RadioControl,
-	Slot,
-	ToggleControl
-} from '@wordpress/components';
+import { __experimentalInputControl as InputControl, RadioControl, Slot, ToggleControl } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { CapacitySettings, Seating } from '../../types/Ticket';
 import { TicketComponentProps } from '../../types/TicketComponentProps';
@@ -22,7 +17,7 @@ const defaultValue: CapacitySettings = {
 	globalStockMode: 'own',
 };
 
-const capacityOptions: { label: string, value: Seating }[] = [
+const capacityOptions: { label: string; value: Seating }[] = [
 	{
 		label: _x( 'General Admission', 'Label for general admission capacity type', 'event-tickets' ),
 		value: 'general-admission',
@@ -42,7 +37,7 @@ const capacityOptions: { label: string, value: Seating }[] = [
 export default function Capacity( props: CapacityProps ): JSX.Element {
 	const { value, onChange } = props;
 
-	const [ currentValue, setCurrentValue ] = useState<CapacitySettings>( {
+	const [ currentValue, setCurrentValue ] = useState< CapacitySettings >( {
 		...defaultValue,
 		...value,
 	} );
@@ -124,9 +119,7 @@ export default function Capacity( props: CapacityProps ): JSX.Element {
 				options={ capacityOptions }
 			/>
 
-			<LabeledInput
-				label={ _x( 'Ticket Capacity', 'Label for the ticket capacity field', 'event-tickets' ) }
-			>
+			<LabeledInput label={ _x( 'Ticket Capacity', 'Label for the ticket capacity field', 'event-tickets' ) }>
 				<InputControl
 					__next40pxDefaultSize={ true }
 					className="classy-field__control classy-field__control--input classy-field__control--input-narrow"
@@ -192,7 +185,7 @@ export default function Capacity( props: CapacityProps ): JSX.Element {
 				/>
 			}
 
-			{ /* todo: this should be part of ET+ */}
+			{ /* todo: this should be part of ET+ */ }
 			<ToggleControl
 				label={ _x(
 					'Share capacity with other tickets',

--- a/src/resources/packages/classy/fields/SaleDuration/EndSelector.tsx
+++ b/src/resources/packages/classy/fields/SaleDuration/EndSelector.tsx
@@ -46,10 +46,7 @@ export default function EndSelector( props: {
 
 	return (
 		<div className="classy-field__group">
-			<div
-				className="classy-field__input classy-field__input--end-date"
-				ref={ ref }
-			>
+			<div className="classy-field__input classy-field__input--end-date" ref={ ref }>
 				<DatePicker
 					anchor={ ref.current }
 					dateWithYearFormat={ dateWithYearFormat }

--- a/src/resources/packages/classy/fields/SaleDuration/SaleDuration.tsx
+++ b/src/resources/packages/classy/fields/SaleDuration/SaleDuration.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import  { Fragment } from 'react';
+import { Fragment } from 'react';
 import { ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { RefObject, useCallback, useMemo, useRef, useState } from '@wordpress/element';
@@ -19,7 +19,6 @@ const timeFormat = 'g:i a';
 const saleStart = '2025-06-23 08:00:00';
 const saleEnd = '2025-07-23 17:00:00';
 const isMultiday = true;
-
 
 type DateTimeRefs = {
 	endTimeHours: number;
@@ -221,5 +220,5 @@ export default function SaleDuration() {
 			</div>
 			{ endSelector }
 		</div>
-	)
-};
+	);
+}

--- a/src/resources/packages/classy/fields/SaleDuration/StartSelector.tsx
+++ b/src/resources/packages/classy/fields/SaleDuration/StartSelector.tsx
@@ -7,7 +7,6 @@ import { DatePicker, TimePicker } from '@tec/common/classy/components';
 import type { StartOfWeek } from '@tec/common/classy/types/StartOfWeek';
 import { _x } from '@wordpress/i18n';
 
-
 export default function StartSelector( props: {
 	dateWithYearFormat: string;
 	endDate: Date;

--- a/src/resources/packages/classy/fields/SalePrice/SalePrice.tsx
+++ b/src/resources/packages/classy/fields/SalePrice/SalePrice.tsx
@@ -5,15 +5,15 @@ import { _x } from '@wordpress/i18n';
 import { StartSelector, EndSelector } from '@tec/common/classy/components';
 import { StartOfWeek } from '@tec/common/classy/types/StartOfWeek';
 import { TicketComponentProps } from '../../types/TicketComponentProps';
-import { SalePriceDetails } from "../../types/Ticket";
-import { CurrencyInput} from '../../components';
+import { SalePriceDetails } from '../../types/Ticket';
+import { CurrencyInput } from '../../components';
 
 // todo: These should be based on site settings.
 const currentDate = new Date();
 const dateWithYearFormat = 'Y-m-d';
 const startOfWeek: StartOfWeek = 0;
 
-type SalePriceProps = Omit<TicketComponentProps, 'label' | 'onChange'> & {
+type SalePriceProps = Omit< TicketComponentProps, 'label' | 'onChange' > & {
 	value: SalePriceDetails;
 	onChange: ( value: SalePriceDetails ) => void;
 };
@@ -28,25 +28,16 @@ const salePriceLabel = _x( 'Add sale price', 'Label for the sale price field', '
  * @param {SalePriceProps} props
  * @return {JSX.Element} The rendered SalePrice component.
  */
-export default function SalePrice( props: SalePriceProps ) : JSX.Element {
-	const {
-		onChange,
-		value,
-	} = props;
+export default function SalePrice( props: SalePriceProps ): JSX.Element {
+	const { onChange, value } = props;
 
-	const [ currentValue, setCurrentValue ] = useState<SalePriceDetails>( value );
+	const [ currentValue, setCurrentValue ] = useState< SalePriceDetails >( value );
 
-	const {
-		enabled: hasSalePrice,
-		salePrice,
-		startDate,
-		endDate,
-	} = currentValue;
+	const { enabled: hasSalePrice, salePrice, startDate, endDate } = currentValue;
 
 	const [ isSelectingDate, setIsSelectingDate ] = useState< 'start' | 'end' | false >( false );
 
 	const ref: RefObject< HTMLDivElement > = useRef( null );
-
 
 	const onDateInputClick = useCallback(
 		( selecting: 'start' | 'end' ) => {
@@ -69,15 +60,18 @@ export default function SalePrice( props: SalePriceProps ) : JSX.Element {
 		}
 	};
 
-	const onFieldChange = useCallback( ( field: keyof SalePriceDetails, value: any ) => {
-		const newValue: SalePriceDetails = {
-			...currentValue,
-			[field]: value,
-		};
+	const onFieldChange = useCallback(
+		( field: keyof SalePriceDetails, value: any ) => {
+			const newValue: SalePriceDetails = {
+				...currentValue,
+				[ field ]: value,
+			};
 
-		setCurrentValue( newValue );
-		onChange( newValue );
-	}, [ onChange, currentValue ] );
+			setCurrentValue( newValue );
+			onChange( newValue );
+		},
+		[ onChange, currentValue ]
+	);
 
 	return (
 		<Fragment>
@@ -121,7 +115,7 @@ export default function SalePrice( props: SalePriceProps ) : JSX.Element {
 							dateWithYearFormat={ dateWithYearFormat }
 							endDate={ endDate }
 							isMultiday={ true }
-							isSelectingDate={isSelectingDate }
+							isSelectingDate={ isSelectingDate }
 							onChange={ onDateChange }
 							onClick={ () => onDateInputClick( 'end' ) }
 							onClose={ () => setIsSelectingDate( false ) }

--- a/src/resources/packages/classy/fields/TicketDescription/TicketDescription.tsx
+++ b/src/resources/packages/classy/fields/TicketDescription/TicketDescription.tsx
@@ -4,7 +4,6 @@ import { TextareaControl } from '@wordpress/components';
 import { LabeledInput } from '@tec/common/classy/components';
 import { TicketComponentProps } from '../../types/TicketComponentProps';
 
-
 /**
  * Renders the ticket description field in the Classy editor.
  *
@@ -27,4 +26,4 @@ export default function TicketDescription( props: TicketComponentProps ): JSX.El
 			/>
 		</LabeledInput>
 	);
-};
+}

--- a/src/resources/packages/classy/fields/Tickets/Tickets.tsx
+++ b/src/resources/packages/classy/fields/Tickets/Tickets.tsx
@@ -4,7 +4,7 @@ import { SelectFunction } from '@wordpress/data/build-types/types';
 import { _x } from '@wordpress/i18n';
 import * as React from 'react';
 import { useCallback, useState } from 'react';
-import { AddTicket, TicketTable, TicketUpsertModal, } from '../../components';
+import { AddTicket, TicketTable, TicketUpsertModal } from '../../components';
 import { STORE_NAME } from '../../constants';
 import { CoreEditorSelect, StoreDispatch, StoreSelect } from '../../types/Store';
 import { TicketId, TicketSettings } from '../../types/Ticket';
@@ -42,32 +42,31 @@ export default function Tickets(): JSX.Element {
 		};
 	}, [] );
 
-	const {
-		addTicket,
-		deleteTicket,
-		updateTicket,
-	}: StoreDispatch = useDispatch( STORE_NAME );
+	const { addTicket, deleteTicket, updateTicket }: StoreDispatch = useDispatch( STORE_NAME );
 
 	const [ isUpserting, setIsUpserting ] = useState( false );
 	const [ isNewTicket, setIsNewTicket ] = useState( false );
-	const [ ticketToEdit, setTicketToEdit ] = useState<TicketSettings>( defaultTicket );
+	const [ ticketToEdit, setTicketToEdit ] = useState< TicketSettings >( defaultTicket );
 
 	const onTicketAddedClicked = useCallback( () => {
 		setIsUpserting( true );
 		setIsNewTicket( true );
 	}, [] );
 
-	const onTicketUpsertSaved = useCallback( ( ticket: TicketSettings ) => {
-		if ( isNewTicket ) {
-			addTicket( ticket );
-		} else {
-			console.log( 'Updating ticket:', ticket );
-			updateTicket( ticket.id, ticket );
-		}
+	const onTicketUpsertSaved = useCallback(
+		( ticket: TicketSettings ) => {
+			if ( isNewTicket ) {
+				addTicket( ticket );
+			} else {
+				console.log( 'Updating ticket:', ticket );
+				updateTicket( ticket.id, ticket );
+			}
 
-		setIsUpserting( false );
-		setTicketToEdit( defaultTicket );
-	}, [ isNewTicket, defaultTicket ] );
+			setIsUpserting( false );
+			setTicketToEdit( defaultTicket );
+		},
+		[ isNewTicket, defaultTicket ]
+	);
 
 	const onEditTicket = useCallback( ( ticket: TicketSettings ) => {
 		setTicketToEdit( ticket );
@@ -88,16 +87,21 @@ export default function Tickets(): JSX.Element {
 
 	// If the tickets are not yet loaded, show a spinner.
 	if ( isLoading ) {
-		return <CenteredSpinner/>;
+		return <CenteredSpinner />;
 	}
 
-	const addTicketText = tickets.length > 0
-		? _x( 'Add Ticket', 'Button text to add a new ticket when tickets already exist', 'event-tickets' )
-		: _x( 'Add Tickets', 'Button text to add a new ticket when no tickets exist', 'event-tickets' );
+	const addTicketText =
+		tickets.length > 0
+			? _x( 'Add Ticket', 'Button text to add a new ticket when tickets already exist', 'event-tickets' )
+			: _x( 'Add Tickets', 'Button text to add a new ticket when no tickets exist', 'event-tickets' );
 
 	return (
 		<ErrorBoundary
-			errorMessage={ _x( 'There was an error in the tickets component:', 'Error message for loading tickets', 'event-tickets' ) }
+			errorMessage={ _x(
+				'There was an error in the tickets component:',
+				'Error message for loading tickets',
+				'event-tickets'
+			) }
 		>
 			<div className="classy-field classy-field--tickets">
 				<div className="classy-field__input-title">
@@ -115,14 +119,9 @@ export default function Tickets(): JSX.Element {
 					/>
 				) }
 
-				<TicketTable
-					onEditTicket={ onEditTicket }
-				/>
+				<TicketTable onEditTicket={ onEditTicket } />
 
-				<AddTicket
-					buttonText={ addTicketText }
-					onClick={ onTicketAddedClicked }
-				/>
+				<AddTicket buttonText={ addTicketText } onClick={ onTicketAddedClicked } />
 			</div>
 		</ErrorBoundary>
 	);

--- a/src/resources/packages/classy/fields/VirtualLocation/AdditionalSettings.tsx
+++ b/src/resources/packages/classy/fields/VirtualLocation/AdditionalSettings.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { _x } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { Settings } from '../../types/VirtualLocation';
+import { useSelect } from '@wordpress/data';
+import {
+	METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK,
+	METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK,
+} from '../../constants.tsx';
+
+const includeVideoLinkOptions: {
+	label: string;
+	value: 'rsvp' | 'ticket';
+}[] = [
+	{
+		label: _x( 'In RSVP emails', 'Include videe link option label', 'event-tickets' ),
+		value: 'rsvp',
+	},
+	{
+		label: _x( 'In Ticket emails', 'Show when option label', 'tribe-events-calendar-pro' ),
+		value: 'ticket',
+	},
+];
+
+const defaultSettings: Settings = {
+	includeVideoLinkInRsvpEmails: true,
+	includeVideoLinkInTicketEmails: true,
+};
+
+export default function AdditionalSettings(): JSX.Element {
+	const postSettings: Settings = useSelect( ( select ) => {
+		const store: {
+			getEditedPostAttribute: ( key: string ) => any;
+		} = select( 'core/editor' );
+
+		const meta = store.getEditedPostAttribute( 'meta' );
+		const settingsFromMeta = { ...defaultSettings };
+
+		[ METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK, METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK ].map(
+			( metaKey: string ) => {
+				settingsFromMeta[ metaKey ] = meta.hasOwnProperty( metaKey )
+					? meta[ metaKey ] === 'yes'
+					: defaultSettings[ metaKey ];
+			}
+		);
+
+		return settingsFromMeta;
+	}, [] );
+
+	const [ settings, setSettings ] = useState< Settings >( postSettings );
+
+	return (
+		<section className="classy-modal__section">
+			<h5 className="classy-modal__section-title">
+				{ _x( 'Include video link', 'Virtual location settings section title', 'event-tickets' ) }
+			</h5>
+
+			<ToggleControl
+				className="classy-modal__section-text"
+				__nextHasNoMarginBottom
+				label={ _x( 'In RSVP emails', 'Setting label', 'event-tickets' ) }
+				onChange={ ( newValue: boolean ): void =>
+					setSettings( {
+						...settings,
+						includeVideoLinkInRsvpEmails: newValue,
+					} )
+				}
+				checked={ settings.includeVideoLinkInRsvpEmails }
+			/>
+
+			<ToggleControl
+				className="classy-modal__section-text"
+				__nextHasNoMarginBottom
+				label={ _x( 'In Ticket emails', 'Setting label', 'event-tickets' ) }
+				onChange={ ( newValue: boolean ): void =>
+					setSettings( { ...settings, includeVideoLinkInTicketEmails: newValue } )
+				}
+				checked={ settings.includeVideoLinkInTicketEmails }
+			/>
+		</section>
+	);
+}

--- a/src/resources/packages/classy/fields/VirtualLocation/ViewingPermissions.tsx
+++ b/src/resources/packages/classy/fields/VirtualLocation/ViewingPermissions.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { Fragment } from 'react';
+import { _x } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+import { CheckboxControl, RadioControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import {
+	METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK,
+	METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK,
+} from '../../constants.tsx';
+import { addFilter, hasFilter, removeFilter } from '@wordpress/hooks';
+
+export default function ViewingPermissions(): JSX.Element {
+	const meta: {
+		showAtRsvpAttendees: boolean;
+		showAtTicketAttendees: boolean;
+	} = useSelect( ( select ) => {
+		const store: {
+			getEditedPostAttribute: ( key: string ) => any;
+		} = select( 'core/editor' );
+		const meta = store.getEditedPostAttribute( 'meta' );
+		return {
+			showAtRsvpAttendees: ( meta?.[ METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK ] ?? '' ) === 'yes',
+			showAtTicketAttendees: ( meta?.[ METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK ] ?? '' ) === 'yes',
+		};
+	}, [] );
+
+	const [ showAtTicketAttendees, setShowAtTicketAttendees ] = useState< boolean >( meta.showAtTicketAttendees );
+	const [ showAtRsvpAttendees, setShowAtRsvpAttendees ] = useState< boolean >( meta.showAtRsvpAttendees );
+	const [ showOptions, setShowOptions ] = useState< boolean >( showAtRsvpAttendees || showAtTicketAttendees );
+
+	console.log( 'showOptions', showOptions );
+	console.log( 'showAtTicketAttendees', showAtTicketAttendees );
+	console.log( 'showAtRsvpAttendees', showAtRsvpAttendees );
+
+	useEffect( () => {
+		if ( hasFilter( 'tec.classy.events-pro.virtual-location.meta.update', 'tec.classy.event-tickets' ) ) {
+			console.log( 'updateMeta.removingFilter' );
+
+			removeFilter( 'tec.classy.events-pro.virtual-location.meta.update', 'tec.classy.event-tickets' );
+		}
+
+		console.log( 'updateMeta.addingFilter' );
+
+		addFilter(
+			'tec.classy.events-pro.virtual-location.meta.update',
+			'tec.classy.event-tickets',
+			( meta: Object ): Object => {
+				meta[ METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK ] = showAtRsvpAttendees ? 'yes' : '';
+				meta[ METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK ] = showAtTicketAttendees ? 'yes' : '';
+
+				console.log( 'updateMeta', meta );
+
+				return meta;
+			}
+		);
+
+		if ( ! hasFilter( 'tec.classy.events-pro.virtual-location.meta.unset', 'tec.classy.event-tickets' ) ) {
+			console.log( 'unsetMeta.addingFilter' );
+			addFilter(
+				'tec.classy.events-pro.virtual-location.meta.unset',
+				'tec.classy.event-tickets',
+				( meta: Object ): Object => {
+					meta[ METADATA_EVENTS_VIRTUAL_RSVP_EMAIL_LINK ] = null;
+					meta[ METADATA_EVENTS_VIRTUAL_TICKET_EMAIL_LINK ] = null;
+
+					console.log( 'unsetMeta', meta );
+
+					return meta;
+				}
+			);
+		}
+	}, [ showAtRsvpAttendees, showAtTicketAttendees ] );
+
+	return (
+		<Fragment>
+			<RadioControl
+				style={ { position: 'relative', top: '-2px' } }
+				className="classy-modal__section-text"
+				label={ _x( 'Tickets viewing permissions', 'Virtual location setting label', 'event-tickets' ) }
+				hideLabelFromVision={ true }
+				options={ [
+					{
+						label: _x( 'Only attendees', 'Viewing permission option label', 'event-tickets' ),
+						value: 'attendees',
+					},
+				] }
+				selected={ showOptions ? 'attendees' : null }
+				onChange={ (): void => {} }
+				onClick={ (): void => {
+					setShowOptions( ! showOptions );
+				} }
+			/>
+
+			{ showOptions && (
+				<div className="classy-toggle-indented classy-checkbox-list">
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ showAtRsvpAttendees }
+						onChange={ ( newValue: boolean ): void => setShowAtRsvpAttendees( newValue ) }
+						label={ _x( 'RSVP attendees', 'Viewing permission option label', 'event-tickets' ) }
+					/>
+
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ showAtTicketAttendees }
+						onChange={ ( newValue: boolean ): void => setShowAtTicketAttendees( newValue ) }
+						label={ _x( 'Ticketed attendees', 'Viewing permission option label', 'event-tickets' ) }
+					/>
+				</div>
+			) }
+		</Fragment>
+	);
+}

--- a/src/resources/packages/classy/fields/VirtualLocation/index.ts
+++ b/src/resources/packages/classy/fields/VirtualLocation/index.ts
@@ -1,0 +1,2 @@
+export { default as AdditionalSettings } from './AdditionalSettings';
+export { default as ViewingPermissions } from './ViewingPermissions';

--- a/src/resources/packages/classy/fields/index.ts
+++ b/src/resources/packages/classy/fields/index.ts
@@ -4,3 +4,7 @@ export { SalePrice } from './SalePrice';
 export { TicketName } from './TicketName';
 export { TicketDescription } from './TicketDescription';
 export { Tickets } from './Tickets';
+export {
+	ViewingPermissions as VirtualLocationViewingPermissions,
+	AdditionalSettings as VirtualLocationAdditionalSettings,
+} from './VirtualLocation';

--- a/src/resources/packages/classy/functions/renderFields.tsx
+++ b/src/resources/packages/classy/functions/renderFields.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Fill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { Tickets } from '../fields';
+import { Tickets, VirtualLocationViewingPermissions, VirtualLocationAdditionalSettings } from '../fields';
 import { CoreEditorSelect } from '../types/Store';
 import { getSettings } from '../localizedData';
 
@@ -42,10 +42,18 @@ export default function renderFields( fields: React.ReactNode | null ): React.Re
 
 			{ /* Portal-render the fields into the Classy form. */ }
 			<Fill name="tec.classy.fields.tickets">
-
 				<Tickets />
+			</Fill>
 
+			{ /* Portal-render the fields into the Virtual Event settings form. */ }
+			<Fill name="tec.classy.virtual-location.settings.viewing-permissions.after">
+				<VirtualLocationViewingPermissions />
+			</Fill>
+
+			{ /* Portal-render the fields into the Virtual Event settings form. */ }
+			<Fill name="tec.classy.virtual-location.settings.after">
+				<VirtualLocationAdditionalSettings />
 			</Fill>
 		</Fragment>
 	);
-};
+}

--- a/src/resources/packages/classy/functions/tickets.ts
+++ b/src/resources/packages/classy/functions/tickets.ts
@@ -94,31 +94,31 @@ const combineTicketWithPartial = ( ticket1: Ticket, ticket2: PartialTicket ): Ti
 		...ticket2,
 		availableFromDetails: {
 			...ticket1.availableFromDetails,
-			...ticket2?.availableFromDetails || {},
+			...( ticket2?.availableFromDetails || {} ),
 		},
 		availableUntilDetails: {
 			...ticket1.availableUntilDetails,
-			...ticket2?.availableUntilDetails || {},
+			...( ticket2?.availableUntilDetails || {} ),
 		},
 		capacityDetails: {
 			...ticket1.capacityDetails,
-			...ticket2?.capacityDetails || {},
+			...( ticket2?.capacityDetails || {} ),
 		},
 		costDetails: {
 			...ticket1.costDetails,
-			...ticket2?.costDetails || {},
+			...( ticket2?.costDetails || {} ),
 		},
 		salePriceData: {
 			...ticket1.salePriceData,
-			...ticket2?.salePriceData || {},
+			...( ticket2?.salePriceData || {} ),
 		},
 		checkin: {
 			...ticket1.checkin,
-			...ticket2?.checkin || {},
+			...( ticket2?.checkin || {} ),
 		},
 		fees: {
 			...ticket1.fees,
-			...ticket2?.fees || {},
+			...( ticket2?.fees || {} ),
 		},
 	};
 };

--- a/src/resources/packages/classy/localizedData.ts
+++ b/src/resources/packages/classy/localizedData.ts
@@ -1,9 +1,4 @@
-import {
-	LocalizedData,
-	Settings,
-	ETClassyGlobal,
-	CurrencySettings,
-} from './types/LocalizedData';
+import { LocalizedData, Settings, ETClassyGlobal, CurrencySettings } from './types/LocalizedData';
 
 /**
  * Returns the default localized data.

--- a/src/resources/packages/classy/store/actions.ts
+++ b/src/resources/packages/classy/store/actions.ts
@@ -26,7 +26,7 @@ import { StoreDispatch } from '../types/Store';
  */
 const addTicket = ( ticket: TicketSettings ): CreateTicketAction => ( {
 	type: CREATE_TICKET,
-	ticket
+	ticket,
 } );
 
 /**
@@ -51,7 +51,7 @@ const deleteTicket = ( ticketId: number ): DeleteTicketAction => ( {
  */
 const setEventCapacity = ( capacity: number ): SetEventCapacityAction => ( {
 	type: SET_EVENT_CAPACITY,
-	capacity
+	capacity,
 } );
 
 /**
@@ -63,7 +63,7 @@ const setEventCapacity = ( capacity: number ): SetEventCapacityAction => ( {
  */
 const setEventHasSharedCapacity = ( hasSharedCapacity: boolean ): SetEventHasSharedCapacityAction => ( {
 	type: SET_EVENT_HAS_SHARED_CAPACITY,
-	hasSharedCapacity
+	hasSharedCapacity,
 } );
 
 /**
@@ -75,7 +75,7 @@ const setEventHasSharedCapacity = ( hasSharedCapacity: boolean ): SetEventHasSha
  */
 const setIsLoading = ( isLoading: boolean ): SetIsLoadingAction => ( {
 	type: SET_IS_LOADING,
-	isLoading
+	isLoading,
 } );
 
 /**
@@ -87,7 +87,7 @@ const setIsLoading = ( isLoading: boolean ): SetIsLoadingAction => ( {
  */
 const setTickets = ( tickets: TicketSettings[] ): SetTicketsAction => ( {
 	type: SET_TICKETS,
-	tickets
+	tickets,
 } );
 
 /**
@@ -112,4 +112,4 @@ export const actions: StoreDispatch = {
 	setIsLoading,
 	setTickets,
 	updateTicket,
-}
+};

--- a/src/resources/packages/classy/store/index.ts
+++ b/src/resources/packages/classy/store/index.ts
@@ -9,7 +9,7 @@ const initialState: StoreState = {
 	eventHasSharedCapacity: false,
 	loading: true,
 	tickets: null,
-}
+};
 
 export const storeConfig = {
 	reducer,

--- a/src/resources/packages/classy/store/reducer.ts
+++ b/src/resources/packages/classy/store/reducer.ts
@@ -25,7 +25,7 @@ const initialState: StoreState = {
 	tickets: null,
 };
 
-export const reducer: Reducer<StoreState> = ( state: StoreState = initialState, action ) => {
+export const reducer: Reducer< StoreState > = ( state: StoreState = initialState, action ) => {
 	switch ( action.type ) {
 		case CREATE_TICKET:
 			const newTicket = ( action as CreateTicketAction ).ticket;
@@ -37,7 +37,7 @@ export const reducer: Reducer<StoreState> = ( state: StoreState = initialState, 
 			const ticketIdToDelete = ( action as DeleteTicketAction ).ticketId;
 			return {
 				...state,
-				tickets: state.tickets.filter( ticket => ticket.id !== ticketIdToDelete ),
+				tickets: state.tickets.filter( ( ticket ) => ticket.id !== ticketIdToDelete ),
 			};
 		case SET_EVENT_CAPACITY:
 			const capacity = ( action as SetEventCapacityAction ).capacity;
@@ -66,7 +66,7 @@ export const reducer: Reducer<StoreState> = ( state: StoreState = initialState, 
 			const { ticketId, ticketData } = action as UpdateTicketAction;
 			return {
 				...state,
-				tickets: state.tickets.map( ticket =>
+				tickets: state.tickets.map( ( ticket ) =>
 					ticket.id === ticketId ? { ...ticket, ...hydrateTicket( ticketData ) } : ticket
 				),
 			};

--- a/src/resources/packages/classy/store/resolvers.ts
+++ b/src/resources/packages/classy/store/resolvers.ts
@@ -3,8 +3,9 @@ import { TicketSettings } from '../types/Ticket';
 import { StoreDispatch } from '../types/Store';
 
 export default {
-	getTickets: ( eventId: number ) =>
-		async ( { dispatch }: { dispatch: StoreDispatch } ): Promise<void> => {
+	getTickets:
+		( eventId: number ) =>
+		async ( { dispatch }: { dispatch: StoreDispatch } ): Promise< void > => {
 			if ( ! eventId ) {
 				console.warn( 'Event ID is required to fetch tickets.' );
 				return;

--- a/src/resources/packages/classy/store/selectors.ts
+++ b/src/resources/packages/classy/store/selectors.ts
@@ -11,7 +11,7 @@ import { TicketSettings } from '../types/Ticket';
  */
 export const getEventHasSharedCapacity = ( state: StoreState ): boolean => {
 	return state?.eventHasSharedCapacity || false;
-}
+};
 
 /**
  * Retrieves the event capacity from the given application state.
@@ -23,7 +23,7 @@ export const getEventHasSharedCapacity = ( state: StoreState ): boolean => {
  */
 export const getEventCapacity = ( state: StoreState ): number | undefined => {
 	return state?.eventCapacity;
-}
+};
 
 /**
  * Returns the tickets from the store state.
@@ -35,7 +35,7 @@ export const getEventCapacity = ( state: StoreState ): number | undefined => {
  */
 export const getTickets = ( state: StoreState ): TicketSettings[] => {
 	return state?.tickets || [];
-}
+};
 
 /**
  * Returns a specific ticket by its ID from the store state.
@@ -46,9 +46,9 @@ export const getTickets = ( state: StoreState ): TicketSettings[] => {
  */
 export const getTicketById = ( state: StoreState ) => {
 	return ( ticketId: number ): TicketSettings | undefined => {
-		return state?.tickets?.find( ticket => ticket.id === ticketId );
+		return state?.tickets?.find( ( ticket ) => ticket.id === ticketId );
 	};
-}
+};
 
 /**
  * Checks if the store is currently loading.
@@ -60,4 +60,4 @@ export const getTicketById = ( state: StoreState ) => {
  */
 export const isLoading = ( state: StoreState ): boolean => {
 	return state?.loading || false;
-}
+};

--- a/src/resources/packages/classy/types/Actions.ts
+++ b/src/resources/packages/classy/types/Actions.ts
@@ -11,29 +11,29 @@ export const UPDATE_TICKET = 'UPDATE_TICKET';
 
 export type CreateTicketAction = {
 	ticket: TicketSettings;
-} & Action<typeof CREATE_TICKET>;
+} & Action< typeof CREATE_TICKET >;
 
 export type DeleteTicketAction = {
 	ticketId: number;
-} & Action<typeof DELETE_TICKET>;
+} & Action< typeof DELETE_TICKET >;
 
 export type SetEventCapacityAction = {
 	capacity: number;
-} & Action<typeof SET_EVENT_CAPACITY>;
+} & Action< typeof SET_EVENT_CAPACITY >;
 
 export type SetEventHasSharedCapacityAction = {
 	hasSharedCapacity: boolean;
-} & Action<typeof SET_EVENT_HAS_SHARED_CAPACITY>;
+} & Action< typeof SET_EVENT_HAS_SHARED_CAPACITY >;
 
 export type SetIsLoadingAction = {
 	isLoading: boolean;
-} & Action<typeof SET_IS_LOADING>;
+} & Action< typeof SET_IS_LOADING >;
 
 export type SetTicketsAction = {
 	tickets: TicketSettings[];
-} & Action<typeof SET_TICKETS>;
+} & Action< typeof SET_TICKETS >;
 
 export type UpdateTicketAction = {
 	ticketId: number;
 	ticketData: TicketSettings;
-} & Action<typeof UPDATE_TICKET>;
+} & Action< typeof UPDATE_TICKET >;

--- a/src/resources/packages/classy/types/Api.d.ts
+++ b/src/resources/packages/classy/types/Api.d.ts
@@ -31,7 +31,7 @@ type ApiDate = {
 	hour: string;
 	minutes: string;
 	seconds: string;
-}
+};
 
 /**
  * Response structure for retrieving a single ticket from the API.
@@ -59,7 +59,7 @@ export type GetTicketApiResponse = {
 	capacity_details: {
 		max: number;
 		global_stock_mode: string;
-	}
+	};
 
 	// Price/cost details.
 	cost: string;
@@ -83,9 +83,7 @@ export type GetTicketApiResponse = {
 	available_from_details: ApiDate;
 	available_until_details: ApiDate;
 
-
 	// Detail objects.
-
 
 	// Additional fields from the WordPress post object.
 	author: string | number;
@@ -126,7 +124,7 @@ export type UpsertTicketApiRequest = {
 	menu_order: string;
 
 	// Additional values from filters.
-	[key: string]: any;
+	[ key: string ]: any;
 };
 
 /**

--- a/src/resources/packages/classy/types/CostDetails.d.ts
+++ b/src/resources/packages/classy/types/CostDetails.d.ts
@@ -7,4 +7,4 @@ export type CostDetails = {
 	currencyThousandSeparator: string;
 	suffix?: string;
 	values: number[];
-}
+};

--- a/src/resources/packages/classy/types/LocalizedData.d.ts
+++ b/src/resources/packages/classy/types/LocalizedData.d.ts
@@ -86,7 +86,7 @@ export type Settings = {
  */
 export type LocalizedData = {
 	settings: Settings;
-	nonces: Record<NonceTypes, string>;
+	nonces: Record< NonceTypes, string >;
 };
 
 /**
@@ -98,6 +98,6 @@ export type ETClassyGlobal = TecGlobal & {
 	tickets: {
 		classy: {
 			data: LocalizedData;
-		}
-	}
+		};
+	};
 };

--- a/src/resources/packages/classy/types/Store.d.ts
+++ b/src/resources/packages/classy/types/Store.d.ts
@@ -55,5 +55,5 @@ export type CoreEditorSelect = {
  * @since TBD
  */
 export type CoreEditorDispatch = {
-	editPost: ( attributes: Record<string, any> ) => void;
-}
+	editPost: ( attributes: Record< string, any > ) => void;
+};

--- a/src/resources/packages/classy/types/Ticket.d.ts
+++ b/src/resources/packages/classy/types/Ticket.d.ts
@@ -8,7 +8,7 @@ import { Months } from '@tec/common/classy/types/Months';
 
 // These types are simple aliases and do not require export statements.
 type Seconds = Minutes;
-type Percentage = NumericRange<0, 100>;
+type Percentage = NumericRange< 0, 100 >;
 
 export type Seating = 'general-admission' | 'assigned-seating';
 export type GlobalStockMode = 'own' | 'capped' | 'global';
@@ -21,7 +21,7 @@ export type CapacityDetails = {
 	max: number;
 	sold?: number;
 	pending?: number;
-}
+};
 
 /**
  * Represents the capacity settings for a ticket.
@@ -39,25 +39,25 @@ export type CapacitySettings = {
 	isShared: boolean;
 	sharedCapacity?: number;
 	globalStockMode?: GlobalStockMode;
-}
+};
 
 export type CheckinDetails = {
 	checkedIn: number;
 	uncheckedIn: number;
 	checkedInPercentage?: Percentage;
 	uncheckedInPercentage?: Percentage;
-}
+};
 
 type FeeDataKeys = 'availableFees' | 'automaticFees' | 'selectedFees';
 
-export type FeesData = Record<FeeDataKeys, Fee[]>;
+export type FeesData = Record< FeeDataKeys, Fee[] >;
 
 export type SalePriceDetails = {
 	enabled: boolean;
 	endDate: string;
 	salePrice: string;
 	startDate: string;
-}
+};
 
 export type TicketDate = {
 	year: number;
@@ -66,7 +66,7 @@ export type TicketDate = {
 	hour?: Hours;
 	minute?: Minutes;
 	second?: Seconds;
-}
+};
 
 // todo: Some kind of positive number type for TicketId.
 export type TicketId = number;
@@ -94,7 +94,7 @@ export type TicketSettings = {
 	// Features.
 	supportsAttendeeInformation?: boolean;
 	iac?: string;
-}
+};
 
 export type Ticket = {
 	// API response fields.
@@ -142,5 +142,4 @@ export type Ticket = {
 	fees: FeesData;
 };
 
-
-export type PartialTicket = Partial<Ticket>;
+export type PartialTicket = Partial< Ticket >;

--- a/src/resources/packages/classy/types/TicketComponentProps.d.ts
+++ b/src/resources/packages/classy/types/TicketComponentProps.d.ts
@@ -2,4 +2,4 @@ export type TicketComponentProps = {
 	label?: string;
 	onChange?: ( value: any ) => void;
 	value?: any;
-}
+};

--- a/src/resources/packages/classy/types/VirtualLocation.d.ts
+++ b/src/resources/packages/classy/types/VirtualLocation.d.ts
@@ -1,0 +1,4 @@
+export type Settings = {
+	includeVideoLinkInRsvpEmails: boolean;
+	includeVideoLinkInTicketEmails: boolean;
+};


### PR DESCRIPTION
This PR scaffolds missing build files and scripts (e.g. `classy:format` in Composer and node) and implements support for Virtual Location fields in ET.

In the previous code, the ET support is done in VE (i.e. in ECP), but this implementation moves the burden to ET using the Slot/Fill API and filters.

See the supporting [ECP PR](https://github.com/the-events-calendar/events-pro/pull/2821).

WIP
