### PR TITLE
ET-2547 Add coupons and fees to emails

### DIFF
--- a/src/views/emails/purchase-receipt/body.php
+++ b/src/views/emails/purchase-receipt/body.php
@@ -33,8 +33,6 @@ $this->template( 'template-parts/body/order/post-title' );
 
 $this->template( 'template-parts/body/order/ticket-totals' );
 
-$this->template( 'template-parts/body/order/order-total' );
-
 $this->template( 'template-parts/body/order/payment-info' );
 
 $this->template( 'template-parts/body/order/attendees-table' );

--- a/src/views/emails/template-parts/body/order/ticket-totals.php
+++ b/src/views/emails/template-parts/body/order/ticket-totals.php
@@ -35,6 +35,9 @@ if ( empty( $order->items ) ) {
 			<?php foreach ( $order->items as $cart_item ) : ?>
 				<?php $this->template( 'template-parts/body/order/ticket-totals/ticket-row', [ 'cart_item' => $cart_item ] ); ?>
 			<?php endforeach; ?>
+			<?php $this->template( 'template-parts/body/order/ticket-totals/fees-row' ); ?>
+			<?php $this->template( 'template-parts/body/order/ticket-totals/coupons-row' ); ?>
+			<?php $this->template( 'template-parts/body/order/ticket-totals/total-row' ); ?>
 		</table>
 	</td>
 </tr>

--- a/src/views/emails/template-parts/body/order/ticket-totals/coupons-row.php
+++ b/src/views/emails/template-parts/body/order/ticket-totals/coupons-row.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Event Tickets Emails: Order Ticket Totals - Coupons Row
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/emails/template-parts/body/order/ticket-totals/coupons-row.php
+ *
+ * See more documentation about our views templating system.
+ *
+ * @link https://evnt.is/tickets-emails-tpl Help article for Tickets Emails template files.
+ *
+ * @version TBD
+ *
+ * @since   TBD
+ *
+ * @var Tribe__Template                    $this               Current template object.
+ * @var \TEC\Tickets\Emails\Email_Abstract $email              The email object.
+ * @var string                             $heading            The email heading.
+ * @var string                             $title              The email title.
+ * @var bool                               $preview            Whether the email is in preview mode or not.
+ * @var string                             $additional_content The email additional content.
+ * @var bool                               $is_tec_active      Whether `The Events Calendar` is active or not.
+ * @var \WP_Post                           $order              The order object.
+ */
+
+declare( strict_types=1 );
+
+use TEC\Tickets\Commerce\Utils\Value;
+use TEC\Tickets\Commerce\Values\Currency_Value;
+use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
+
+// If there are no coupons, we don't need to display anything.
+if ( empty( $order ) || empty( $order->coupons ) ) {
+	return;
+}
+
+$discounts = array_map(
+	fn( Value $value ) => Legacy_Value_Factory::to_currency_value( $value ),
+	wp_list_pluck( array_values( $order->coupons ), 'sub_total' )
+);
+
+$total_discount = Currency_Value::sum( ...$discounts );
+
+?>
+<tr class="tec-tickets__email-table-content-order-ticket-totals-coupons-row">
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-left" align="left">
+		&nbsp;
+	</td>
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-center" align="center">
+		<?php esc_html_e( 'Discount:', 'event-tickets' ); ?>
+	</td>
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-right" align="right">
+		<?php echo esc_html( $total_discount->get() ); ?>
+	</td>
+</tr>

--- a/src/views/emails/template-parts/body/order/ticket-totals/fees-row.php
+++ b/src/views/emails/template-parts/body/order/ticket-totals/fees-row.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Event Tickets Emails: Order Ticket Totals - Fees Row
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/emails/template-parts/body/order/ticket-totals/fees-row.php
+ *
+ * See more documentation about our views templating system.
+ *
+ * @link https://evnt.is/tickets-emails-tpl Help article for Tickets Emails template files.
+ *
+ * @version TBD
+ *
+ * @since   TBD
+ *
+ * @var Tribe__Template                    $this               Current template object.
+ * @var \TEC\Tickets\Emails\Email_Abstract $email              The email object.
+ * @var string                             $heading            The email heading.
+ * @var string                             $title              The email title.
+ * @var bool                               $preview            Whether the email is in preview mode or not.
+ * @var string                             $additional_content The email additional content.
+ * @var bool                               $is_tec_active      Whether `The Events Calendar` is active or not.
+ * @var \WP_Post                           $order              The order object.
+ */
+
+use TEC\Tickets\Commerce\Values\Currency_Value;
+
+// If there are no fees, we don't need to display anything.
+if ( empty( $order ) || empty( $order->fees ) ) {
+	return;
+}
+
+$fees = array_map(
+	fn( float $value ) => Currency_Value::create_from_float( $value ),
+	wp_list_pluck( $order->fees, 'sub_total' )
+);
+
+$total_fees = Currency_Value::sum( ...$fees );
+
+?>
+<tr class="tec-tickets__email-table-content-order-ticket-totals-fees-row">
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-left" align="left">
+		&nbsp;
+	</td>
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-center" align="center">
+		<?php esc_html_e( 'Fees:', 'event-tickets' ); ?>
+	</td>
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-right" align="right">
+		<?php echo esc_html( $total_fees->get() ); ?>
+	</td>
+</tr>

--- a/src/views/emails/template-parts/body/order/ticket-totals/header-row.php
+++ b/src/views/emails/template-parts/body/order/ticket-totals/header-row.php
@@ -25,13 +25,13 @@
 
 ?>
 <tr class="tec-tickets__email-table-content-order-ticket-totals-header-row">
-	<th style="width: 80%" class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-left" align="left">
+	<th style="width: 60%" class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-left" align="left">
 		<?php echo esc_html__( 'Ticket', 'event-tickets' ); ?>
 	</th>
-	<th class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-center" align="center">
+	<th style="width: 25%" class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-center" align="center">
 		<?php echo esc_html__( 'Qty', 'event-tickets' ); ?>
 	</th>
-	<th class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-right" align="right">
+	<th style="width: 15%" class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-right" align="right">
 		<?php echo esc_html__( 'Price', 'event-tickets' ); ?>
 	</th>
 </tr>

--- a/src/views/emails/template-parts/body/order/ticket-totals/total-row.php
+++ b/src/views/emails/template-parts/body/order/ticket-totals/total-row.php
@@ -1,18 +1,17 @@
 <?php
 /**
- * Event Tickets Emails: Order Total
+ * Event Tickets Emails: Order Ticket Totals - Total Row
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/tickets/emails/template-parts/body/order/order-total.php
+ * [your-theme]/tribe/tickets/emails/template-parts/body/order/ticket-totals/total-row.php
  *
  * See more documentation about our views templating system.
  *
  * @link https://evnt.is/tickets-emails-tpl Help article for Tickets Emails template files.
  *
- * @version 5.5.11
+ * @version TBD
  *
- * @since 5.5.11
- * @since 5.10.0 Allow for zero value total.
+ * @since   TBD
  *
  * @var Tribe__Template                    $this               Current template object.
  * @var \TEC\Tickets\Emails\Email_Abstract $email              The email object.
@@ -29,17 +28,14 @@ if ( empty( $order ) || empty( $order->total_value ) ) {
 }
 
 ?>
-<tr>
-	<td class="tec-tickets__email-table-content-order-total-container" align="right">
-		<table class="tec-tickets__email-table-content-order-total-table">
-			<tr>
-				<td class="tec-tickets__email-table-content-order-total-left-cell">
-					<?php echo esc_html__( 'Order Total', 'event-tickets' ); ?>
-				</td>
-				<td class="tec-tickets__email-table-content-order-total-right-cell">
-					<?php echo esc_html( $order->total_value->get_currency() ); ?>
-				</td>
-			</tr>
-		</table>
+<tr class="tec-tickets__email-table-content-order-ticket-totals-total-row">
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-align-left" align="left">
+		&nbsp;
+	</td>
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-ticket-totals-total-cell tec-tickets__email-table-content-order-align-center" align="center">
+		<strong><?php echo esc_html__( 'Order Total', 'event-tickets' ); ?></strong>
+	</td>
+	<td class="tec-tickets__email-table-content-order-ticket-totals-cell tec-tickets__email-table-content-order-ticket-totals-total-cell tec-tickets__email-table-content-order-align-right" align="right">
+		<strong><?php echo esc_html( $order->total_value->get_currency() ); ?></strong>
 	</td>
 </tr>

--- a/src/views/emails/template-parts/header/head/styles.php
+++ b/src/views/emails/template-parts/header/head/styles.php
@@ -151,7 +151,7 @@
 		margin: 0;
 		padding: 0;
 	}
-	
+
 	div.tec-tickets__email-table-content-ticket-seat-label {
 		color: <?php echo esc_attr( $ticket_text_color ); ?>;
 		display: inline-block;
@@ -159,7 +159,7 @@
 		font-weight: 400;
 		margin-top: 8px;
 	}
-	
+
 	div.tec-tickets__email-table-content-ticket-seat-label-separator {
 		color: <?php echo esc_attr( $ticket_text_color ); ?>;
 		display: inline-block;
@@ -292,27 +292,26 @@
 		padding-top:43px;
 	}
 
-	td.tec-tickets__email-table-content-order-total-container {
-		padding-top: 20px;
-		text-align: right;
-	}
-
-	.tec-tickets__email-table-content-order-total-table {
-		display: inline-block;
-		width: auto;
-	}
-
-	td.tec-tickets__email-table-content-order-total-left-cell {
+	.tec-tickets__email-table-content-order-ticket-totals-fees-row,
+	.tec-tickets__email-table-content-order-ticket-totals-coupons-row {
+		border: none;
 		font-size: 14px;
 		font-weight: 400;
 		line-height: 24px;
-		padding-right: 10px;
 	}
 
-	.tec-tickets__email-table-content-order-total-right-cell {
-		font-size: 16px;
+	.tec-tickets__email-table-content-order-ticket-totals-total-row {
+		border: none;
+		border-top: 2px solid #333;
+		font-size: 14px;
 		font-weight: 700;
 		line-height: 24px;
+	}
+
+	.tec-tickets__email-table-content-order-ticket-totals-total-cell {
+		font-weight: bold;
+		padding-top: 2px;
+		padding-bottom: 2px;
 	}
 
 	td.tec-tickets__email-table-content-order-payment-info-container {


### PR DESCRIPTION
### 🎫 Ticket

[ET-2547]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We need to add the coupons and fees to our purchase receipt and completed order emails to give more accurate information about why the order total is what it is. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

After:
<img width="1178" height="542" alt="ET-2547-After" src="https://github.com/user-attachments/assets/910173eb-4f39-453e-9eed-18f8c0ba8a5c" />

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
