### PR TITLE
ET-2544 Change links and link texts to point to payment settings

### DIFF
--- a/src/Tickets/Flexible_Tickets/Metabox.php
+++ b/src/Tickets/Flexible_Tickets/Metabox.php
@@ -12,6 +12,7 @@ namespace TEC\Tickets\Flexible_Tickets;
 use TEC\Events_Pro\Custom_Tables\V1\Series\Post_Type as Series_Post_Type;
 use TEC\Tickets\Flexible_Tickets\Series_Passes\Labels;
 use TEC\Tickets\Flexible_Tickets\Templates\Admin_Views;
+use Tribe\Tickets\Admin\Settings as Plugin_Settings;
 use Tribe__Tickets__RSVP as RSVP;
 use Tribe__Tickets__Tickets as Tickets;
 use WP_Post;
@@ -315,13 +316,13 @@ class Metabox {
 	 * @return string The warning message when there is no commerce provider configured.
 	 */
 	public function get_no_commerce_provider_warning_message(): string {
-		$kb_url = 'https://evnt.is/1ao5';
+		$kb_url = tribe( Plugin_Settings::class )->get_url( [ 'tab' => 'payments' ] );
 
 		/* translators: %1$s: URL for help link, %2$s: Label for help link. */
 		$link = sprintf(
 			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 			esc_url( $kb_url ),
-			esc_html_x( 'Learn More', 'Helper link in Ticket Editor', 'event-tickets' )
+			esc_html_x( 'Set up Tickets Commerce.', 'Link to payment settings in Ticket Editor', 'event-tickets' )
 		);
 
 		return sprintf(

--- a/src/Tribe/Editor/Warnings.php
+++ b/src/Tribe/Editor/Warnings.php
@@ -6,6 +6,7 @@
 namespace Tribe\Tickets\Editor;
 
 use Tribe__Tickets__Admin__Views;
+use Tribe\Tickets\Admin\Settings as Plugin_Settings;
 
 /**
  * Warnings handling class.
@@ -65,13 +66,13 @@ class Warnings {
 	 * @return string The Commerce Provider missing message.
 	 */
 	public function get_commerce_provider_missing_warning_message() {
-		$kb_url = 'https://evnt.is/1ao5';
+		$kb_url = tribe( Plugin_Settings::class )->get_url( [ 'tab' => 'payments' ] );
 
 		/* translators: %1$s: URL for help link, %2$s: Label for help link. */
 		$link = sprintf(
 			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 			esc_url( $kb_url ),
-			esc_html_x( 'Learn More', 'Helper link in Ticket Editor', 'event-tickets' )
+			esc_html_x( 'Set up Tickets Commerce.', 'Link to payment settings in Ticket Editor', 'event-tickets' )
 		);
 
 		$message = sprintf(


### PR DESCRIPTION
### 🎫 Ticket

[ET-2544]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

In Classic Editor, when a payment is not configured, there is a notice that has a “learn more” link that directs someone to a document to configure their eCommerce. The link should rather point to the relevant setting of the plugin.


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
