### PR TITLE
fix/ETP 1044

### DIFF
--- a/changelog/fix-ETP-1044
+++ b/changelog/fix-ETP-1044
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly invalidate ticket caches to deal with ETP order-of-operation issue. [ETP-1044]

--- a/src/Tribe/Events/Views/V2/Hooks.php
+++ b/src/Tribe/Events/Views/V2/Hooks.php
@@ -113,8 +113,13 @@ class Hooks extends \TEC\Common\Contracts\Service_Provider {
 	 * @since 4.10.9
 	 */
 	protected function add_actions() {
-		add_action( 'wp_insert_post', [ $this, 'regenerate_post_kv_caches' ], 100 );
-		add_action( 'clean_post_cache', [ $this, 'regenerate_post_kv_caches' ], 100 );
+		if ( ! has_action( 'wp_insert_post', [ $this, 'regenerate_post_kv_caches' ] ) ) {
+			add_action( 'wp_insert_post', [ $this, 'regenerate_post_kv_caches' ], 100 );
+		}
+
+		if ( ! has_action( 'clean_post_cache', [ $this, 'regenerate_post_kv_caches' ] ) ) {
+			add_action( 'clean_post_cache', [ $this, 'regenerate_post_kv_caches' ], 100 );
+		}
 	}
 
 	/**
@@ -123,9 +128,27 @@ class Hooks extends \TEC\Common\Contracts\Service_Provider {
 	 * @since 4.10.9
 	 */
 	protected function add_filters() {
-		add_filter( 'tribe_template_path_list', [ $this, 'filter_template_path_list' ], 15, 2 );
-		add_filter( 'tribe_template_origin_namespace_map', [ $this, 'filter_add_template_origin_namespace' ], 15, 3 );
-		add_filter( 'tribe_post_type_events_properties', [ $this, 'add_tickets_data' ], 20, 2 );
+		if ( ! has_filter( 'tribe_template_path_list', [ $this, 'filter_template_path_list' ] ) ) {
+			add_filter( 'tribe_template_path_list', [ $this, 'filter_template_path_list' ], 15, 2 );
+		}
+
+
+		if ( ! has_filter(
+			'tribe_template_origin_namespace_map',
+			[ $this, 'filter_add_template_origin_namespace' ]
+		) ) {
+			add_filter(
+				'tribe_template_origin_namespace_map',
+				[ $this, 'filter_add_template_origin_namespace' ],
+				15,
+				3
+			);
+		}
+
+
+		if ( ! has_filter( 'tribe_post_type_events_properties', [ $this, 'add_tickets_data' ] ) ) {
+			add_filter( 'tribe_post_type_events_properties', [ $this, 'add_tickets_data' ], 20, 2 );
+		}
 	}
 
 	/**

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -109,6 +109,16 @@ class Tickets implements ArrayAccess, Serializable {
 			return;
 		}
 
+		/*
+		 * Flush the cached post queries.
+		 * Repositories will build `WP_Query` objects that will benefit from the built-in caching of post queries.
+		 * The `post-queries` cache group is a persistent group, but some results cached during the rebuild of this
+		 * cache will need to be refetched.
+		 * Since we cannot guess or map the exact keys to invalidate, the best we can do is invalidate all the
+		 * currently cached results.
+		 */
+		wp_cache_flush_group( 'post-queries' );
+
 		if ( $post->post_type === TEC::POSTTYPE ) {
 			// It's an Event: refresh its cache.
 			$model = new self( $post->ID );

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -154,10 +154,13 @@ class Tickets implements ArrayAccess, Serializable {
 
 			foreach ( $connected_event_ids as $connected_event_id ) {
 				// Reset the `Tribe__Tickets__Tickets::get_tickets` method cache to get the last version of them.
-				$provider                          = Tickets_Tickets::get_event_ticket_provider_object( $connected_event_id );
-				$orm_provider                      = $provider->orm_provider;
-				$tickets_cache_key                 = "{$tickets_class}::get_tickets-{$orm_provider}-{$connected_event_id}";
-				$tribe_cache[ $tickets_cache_key ] = null;
+				$provider = Tickets_Tickets::get_event_ticket_provider_object( $connected_event_id );
+
+				if ( $provider ) {
+					$orm_provider                      = $provider->orm_provider;
+					$tickets_cache_key                 = "{$tickets_class}::get_tickets-{$orm_provider}-{$connected_event_id}";
+					$tribe_cache[ $tickets_cache_key ] = null;
+				}
 
 				$model = new self( $connected_event_id );
 				// The call will trigger a priming of the model cache.

--- a/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
+++ b/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
@@ -168,5 +168,22 @@ class Tickets_Test extends WPTestCase {
 		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
 		Tickets::regenerate_caches( $event_id );
 		$this->assertTrue( tec_kv_cache()->has( $event_cache_key ) );
+
+		$array_model = ( new Tickets( $event_id ) )->to_array();
+
+		$this->assertEquals( [
+			'link'  =>
+				[
+					'anchor'             => 'http://wordpress.test/?tribe_events=test-event#tribe-tickets__tickets-form',
+					'label'              => 'Get Tickets',
+					'__original_class__' => 'stdClass',
+				],
+			'stock' =>
+				[
+					'available'          => '291 tickets left',
+					'sold_out'           => '',
+					'__original_class__' => 'stdClass',
+				],
+		], $array_model );
 	}
 }


### PR DESCRIPTION
Ticket: [ETP-1044](https://stellarwp.atlassian.net/browse/ETP-1044)

This updates the KV-cache logic to fix three issues:
1. Not all ticket and attendee post types would trigger a cache recreation
2. The order-of-operation imposed by the KV cache hook firing on `clean_post_cache` would set the tickets cache too soon.
3. Some repositories queries' results would be cached while still in flux leading to following repository queries for the same results to return the incorrect results.

The fix for the first is simply to use `array_values` on the map, while the fix for the second consists in explicitly unsetting the two ticket related caches:
* one from `Tribe__Tickets__Tickets::get_tickets`
* one from the providers' `get_ticket` methods

As for the third, I'm suspending the post results caching while running the cache regeneration to avoid in-flux results being cached.

I've added one test to cover the cache invalidation.

[Related ETP PR](https://github.com/the-events-calendar/event-tickets-plus/pull/1970)


[ETP-1044]: https://stellarwp.atlassian.net/browse/ETP-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ