### PR TITLE
TEC-5587 Add upsell message filter for seating

### DIFF
--- a/src/Tickets/Seating/Uplink.php
+++ b/src/Tickets/Seating/Uplink.php
@@ -76,6 +76,7 @@ class Uplink extends Controller_Contract {
 		);
 		add_action( 'stellarwp/uplink/tec/license_field_before_input', [ $this, 'render_legend_before_input' ] );
 		add_action( 'stellarwp/uplink/tec/tec-seating/connected', [ $this, 'reset_data_on_new_connection' ] );
+		add_filter( 'stellarwp_uplink_tec_tec-seating_field_html', [ $this, 'customize_field_html' ], 10, 2 );
 	}
 
 	/**
@@ -103,6 +104,7 @@ class Uplink extends Controller_Contract {
 		);
 		remove_action( 'stellarwp/uplink/tec/license_field_before_input', [ $this, 'render_legend_before_input' ] );
 		remove_action( 'stellarwp/uplink/tec/tec-seating/connected', [ $this, 'reset_data_on_new_connection' ] );
+		remove_filter( 'stellarwp_uplink_tec_tec-seating_field_html', [ $this, 'customize_field_html' ] );
 	}
 
 	/**
@@ -173,5 +175,36 @@ class Uplink extends Controller_Contract {
 		// Clear cache.
 		tribe( Service\Maps::class )->invalidate_cache();
 		tribe( Service\Layouts::class )->invalidate_cache();
+	}
+
+	/**
+	 * Customize the field HTML to include upsell link for seating service.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $field_html The original field HTML.
+	 * @param object $plugin The plugin resource object.
+	 *
+	 * @return string The customized field HTML.
+	 */
+	public function customize_field_html( string $field_html, $plugin ): string {
+		// Only customize for the seating service.
+		if ( 'tec-seating' !== $plugin->get_slug() ) {
+			return $field_html;
+		}
+
+		// Create the upsell tooltip text.
+		$upsell_tooltip = sprintf(
+			/* Translators: %1$s and %2$s are opening and closing <a> tags, respectively. */
+			esc_html__( '%1$sBuy a license%2$s for the Seating service to access seating management features.', 'event-tickets' ),
+			'<a href="https://theeventscalendar.com/products/seating/" target="_blank">',
+			'</a>'
+		);
+
+		// Replace the default tooltip text with our upsell version.
+		$default_tooltip = esc_html__( 'A valid license key is required for support and updates', 'event-tickets' );
+		$field_html = str_replace( $default_tooltip, $upsell_tooltip, $field_html );
+
+		return $field_html;
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5587]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This PR builds on [this one](https://github.com/the-events-calendar/tribe-common/pull/2761) to add an upsell message for Seating. Seating uses StellarWP Uplink and therefore requires some changes in `/event-tickets/src/Tickets/Seating/Uplink.php` to change the `no_license_tooltip` message.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1960" height="1504" alt="TEC-5587-pmt-and-seating" src="https://github.com/user-attachments/assets/1420386d-2951-41d3-aaed-60683a13d505" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
