### PR TITLE
ET-2555 Tweak logic when fetching ticket data

### DIFF
--- a/changelog/tweak-ET-2555-account-for-empty-array
+++ b/changelog/tweak-ET-2555-account-for-empty-array
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Tweak logic when fetching ticket data. [ET-2555]

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -165,6 +165,7 @@ class Tickets implements \ArrayAccess, \Serializable {
 	 * @since 4.10.9
 	 *
 	 * @since 5.6.3 Add support for the updated anchor link from new ticket templates.
+	 * @since TBD Fixed issue where empty arrays were being returned instead of data.
 	 *
 	 * @return array An array of objects containing the post thumbnail data.
 	 */
@@ -173,8 +174,12 @@ class Tickets implements \ArrayAccess, \Serializable {
 			return [];
 		}
 
+		$this->data = [];
+
 		if ( null !== $this->data ) {
-			return $this->data;
+			if ( ! empty( $this->data ) ) {
+				return $this->data;
+			}
 		}
 
 		$num_ticket_types_available = 0;


### PR DESCRIPTION
### 🎫 Ticket

[ET-2555]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The way that the logic is set up in `/event-tickets/src/Tribe/Events/Views/V2/Models/Tickets.php` around line 177 is that it only generates the link as long as `$this->data` is not `null`.  This PR tweaks this logic to also check that it is not empty, which properly generates the link in the scenario where the data is `[]`

This should be included in the `lukecage` release when available. 

### 🎥 Artifacts 
Before:
<img width="3396" height="1802" alt="TEC-5587-Before" src="https://github.com/user-attachments/assets/5621a5ee-b7e9-45ba-ae13-d66e56521017" />
After:
<img width="3432" height="1834" alt="ET-2555-Afterr" src="https://github.com/user-attachments/assets/00815333-ec6b-444b-b2fa-e939ebc2a94c" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
