### PR TITLE
[SMTNC-1899] RSVPs made by the same user should update the same attendee record and not create a new one

### DIFF
--- a/changelog/fix-smtnc-1899-rsvps-made-by-the-same-user-should-update-the-same-attendee.yaml
+++ b/changelog/fix-smtnc-1899-rsvps-made-by-the-same-user-should-update-the-same-attendee.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where clicking Go or Not Going on an RSVP created a new
+  attendee record instead of updating the same user's existing attendee.
+timestamp: 2026-08-11T22:23:40.743Z

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -2151,6 +2151,23 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	}
 
 	/**
+	 * Get the IDs of the attendee record(s) a user already holds for a specific RSVP ticket.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $product_id The RSVP ticket (product) ID.
+	 * @param int $user_id    The user ID.
+	 *
+	 * @return int[] List of attendee IDs.
+	 */
+	public function get_attendee_ids_by_user_for_ticket( $product_id, $user_id ) {
+		/** @var Tribe__Tickets__Attendee_Repository $repository */
+		$repository = tribe_attendees( $this->orm_provider );
+
+		return $repository->by( 'ticket', $product_id )->by( 'user', $user_id )->get_ids();
+	}
+
+	/**
 	 * {@inheritdoc}
 	 *
 	 * Get all the attendees for post type. It returns an array with the
@@ -2805,6 +2822,14 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		$attendee_ids = [];
 
+		/*
+		 * A logged-in user resubmitting the RSVP for this ticket (e.g. switching Going <-> Not
+		 * Going) should update their existing attendee record(s) rather than create duplicates.
+		 */
+		$existing_attendee_ids = is_user_logged_in()
+			? $this->get_attendee_ids_by_user_for_ticket( $product_id, get_current_user_id() )
+			: [];
+
 		// Iterate over all the amount of tickets purchased (for this product).
 		for ( $i = 0; $i < $qty; $i++ ) {
 			try {
@@ -2818,7 +2843,15 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 					'user_id'           => is_user_logged_in() ? get_current_user_id() : 0,
 				];
 
-				$attendee_ids[] = $this->create_attendee_for_ticket( $ticket_type, $attendee_data );
+				$existing_attendee_id = array_shift( $existing_attendee_ids );
+
+				if ( $existing_attendee_id ) {
+					$this->update_sales_and_stock_by_order_status( $existing_attendee_id, $attendee_order_status, $product_id );
+					$this->update_attendee( $existing_attendee_id, $attendee_data );
+					$attendee_ids[] = $existing_attendee_id;
+				} else {
+					$attendee_ids[] = $this->create_attendee_for_ticket( $ticket_type, $attendee_data );
+				}
 			} catch ( Exception $exception ) {
 				// Stop processing and return false.
 				return new WP_Error( 'rsvp-invalid-stock-request', $exception->getMessage() );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -2726,6 +2726,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 *
 	 * @since 5.5.0 Return WP_Error in case of errors to show proper error messages.
 	 * @since 5.29.1 Reject the request unless the requesting user can access the ticket's event.
+	 * @since TBD Only require the additional stock needed on top of the seats held by the reused attendees.
 	 *
 	 * @param int     $product_id       The ticket post ID.
 	 * @param int     $ticket_qty       The number of attendees that should be generated.
@@ -2800,8 +2801,30 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		$qty = max( $ticket_qty, 0 );
 
-		// Throw an error if Qty is bigger then Remaining
-		if ( $ticket_type->managing_stock() && $ticket_type->inventory() < $qty ) {
+		/*
+		 * A logged-in user resubmitting the RSVP for this ticket (e.g. switching Going <-> Not
+		 * Going) should update their existing attendee record(s) rather than create duplicates.
+		 */
+		$existing_attendee_ids = is_user_logged_in()
+			? $this->get_attendee_ids_by_user_for_ticket( $product_id, get_current_user_id() )
+			: [];
+
+		// Seats already held by the attendee record(s) this submission is going to update in place.
+		$held_stock = 0;
+
+		foreach ( array_slice( $existing_attendee_ids, 0, $qty ) as $attendee_id ) {
+			$previous_status = get_post_meta( $attendee_id, self::ATTENDEE_RSVP_KEY, true );
+
+			if ( isset( $rsvp_options[ $previous_status ] ) ) {
+				$held_stock += $rsvp_options[ $previous_status ]['decrease_stock_by'];
+			}
+		}
+
+		// Only the additional stock, on top of what the reused attendees already hold, is required.
+		$required_stock = max( 0, ( $status_stock_size * $qty ) - $held_stock );
+
+		// Throw an error if the additional stock required is bigger than the remaining stock.
+		if ( $ticket_type->managing_stock() && $ticket_type->inventory() < $required_stock ) {
 			if ( $redirect ) {
 				$url = add_query_arg( 'rsvp_error', 2, get_permalink( $post_id ) );
 				wp_redirect( esc_url_raw( $url ) );
@@ -2821,14 +2844,6 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		do_action( 'tribe_tickets_rsvp_before_attendee_ticket_creation', $post_id, $ticket_type, $_POST );
 
 		$attendee_ids = [];
-
-		/*
-		 * A logged-in user resubmitting the RSVP for this ticket (e.g. switching Going <-> Not
-		 * Going) should update their existing attendee record(s) rather than create duplicates.
-		 */
-		$existing_attendee_ids = is_user_logged_in()
-			? $this->get_attendee_ids_by_user_for_ticket( $product_id, get_current_user_id() )
-			: [];
 
 		// Iterate over all the amount of tickets purchased (for this product).
 		for ( $i = 0; $i < $qty; $i++ ) {

--- a/tests/wpunit/Tribe/Tickets/RSVPTest.php
+++ b/tests/wpunit/Tribe/Tickets/RSVPTest.php
@@ -178,6 +178,90 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * @test
+	 * it should allow updating an existing attendee to not going when stock is zero, as that releases the held seat
+	 *
+	 * @since TBD
+	 */
+	public function it_should_update_existing_attendee_to_not_going_when_stock_is_zero() {
+		$ticket_id = $this->make_stock_ticket( 1, $this->event_id );
+		$user_id   = $this->factory()->user->create();
+
+		wp_set_current_user( $user_id );
+
+		$sut = $this->make_instance();
+
+		$going_attendee_ids = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'yes' ] ), false );
+
+		$this->assertCount( 1, $going_attendee_ids );
+		$this->assertEquals( 0, get_post_meta( $ticket_id, '_stock', true ) );
+
+		$not_going_attendee_ids = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'no' ] ), false );
+
+		$this->assertNotWPError( $not_going_attendee_ids, 'Switching to Not Going should be allowed even when stock is zero, as it releases a held seat.' );
+		$this->assertCount( 1, $not_going_attendee_ids );
+		$this->assertEquals( $going_attendee_ids, $not_going_attendee_ids );
+		$this->assertEquals( 'no', get_post_meta( $going_attendee_ids[0], RSVP::ATTENDEE_RSVP_KEY, true ) );
+		$this->assertEquals( 1, get_post_meta( $ticket_id, '_stock', true ) );
+	}
+
+	/**
+	 * @test
+	 * it should allow resubmitting the same RSVP status when stock is zero, as no additional seat is needed
+	 *
+	 * @since TBD
+	 */
+	public function it_should_allow_resubmitting_same_rsvp_status_when_stock_is_zero() {
+		$ticket_id = $this->make_stock_ticket( 1, $this->event_id );
+		$user_id   = $this->factory()->user->create();
+
+		wp_set_current_user( $user_id );
+
+		$sut = $this->make_instance();
+
+		$first_attendee_ids = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'yes' ] ), false );
+
+		$this->assertCount( 1, $first_attendee_ids );
+		$this->assertEquals( 0, get_post_meta( $ticket_id, '_stock', true ) );
+
+		$second_attendee_ids = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'yes' ] ), false );
+
+		$this->assertNotWPError( $second_attendee_ids, 'Resubmitting the same RSVP status should be allowed when stock is zero, as no additional seat is needed.' );
+		$this->assertCount( 1, $second_attendee_ids );
+		$this->assertEquals( $first_attendee_ids, $second_attendee_ids );
+		$this->assertEquals( 'yes', get_post_meta( $first_attendee_ids[0], RSVP::ATTENDEE_RSVP_KEY, true ) );
+	}
+
+	/**
+	 * @test
+	 * it should reject increasing attendance when stock is zero, even when reusing an existing attendee
+	 *
+	 * @since TBD
+	 */
+	public function it_should_reject_increasing_attendance_when_stock_is_zero() {
+		$ticket_id = $this->make_stock_ticket( 1, $this->event_id );
+		$user_id   = $this->factory()->user->create();
+
+		$sut = $this->make_instance();
+
+		// An anonymous attendee consumes the only available seat.
+		wp_set_current_user( 0 );
+		$sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'yes', 'email' => 'other@doe.com' ] ), false );
+		$this->assertEquals( 0, get_post_meta( $ticket_id, '_stock', true ) );
+
+		// This user can RSVP "not going" without needing a seat...
+		wp_set_current_user( $user_id );
+		$not_going_attendee_ids = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'no' ] ), false );
+		$this->assertNotWPError( $not_going_attendee_ids );
+
+		// ...but switching to "going" still requires an available seat.
+		$result = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'yes' ] ), false );
+
+		$this->assertWPError( $result, 'Switching from Not Going to Going should still require available stock.' );
+		$this->assertEquals( 'rsvp-invalid-stock-request', $result->get_error_code() );
+	}
+
+	/**
+	 * @test
 	 * it should reject a ticket generated directly for a private event's ticket, even when
 	 * the caller never checked the event's accessibility (e.g. a smuggled `product_id`).
 	 *

--- a/tests/wpunit/Tribe/Tickets/RSVPTest.php
+++ b/tests/wpunit/Tribe/Tickets/RSVPTest.php
@@ -147,6 +147,37 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * @test
+	 * it should update the existing attendee instead of creating a duplicate when the same user resubmits the RSVP
+	 *
+	 * @since TBD
+	 */
+	public function it_should_update_existing_attendee_when_same_user_resubmits_rsvp() {
+		$ticket_id = $this->make_stock_ticket( 10, $this->event_id );
+		$user_id   = $this->factory()->user->create();
+
+		wp_set_current_user( $user_id );
+
+		$sut = $this->make_instance();
+
+		$first_attendee_ids  = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'no' ] ), false );
+		$second_attendee_ids = $sut->generate_tickets_for( $ticket_id, 1, $this->fake_attendee_details( [ 'order_status' => 'yes' ] ), false );
+
+		$this->assertCount( 1, $first_attendee_ids );
+		$this->assertCount( 1, $second_attendee_ids );
+		$this->assertEquals(
+			$first_attendee_ids,
+			$second_attendee_ids,
+			'Resubmitting the RSVP as the same user should update the existing attendee, not create a new one.'
+		);
+
+		$attendees = $sut->get_attendees_by_user_id( $user_id, $this->event_id );
+		$this->assertCount( 1, $attendees, 'Only one attendee record should exist for this user after resubmitting the RSVP.' );
+
+		$this->assertEquals( 'yes', get_post_meta( $first_attendee_ids[0], RSVP::ATTENDEE_RSVP_KEY, true ) );
+	}
+
+	/**
+	 * @test
 	 * it should reject a ticket generated directly for a private event's ticket, even when
 	 * the caller never checked the event's accessibility (e.g. a smuggled `product_id`).
 	 *


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1899](https://linear.app/nexcess/issue/SMTNC-1899/rsvps-made-by-the-same-user-should-update-the-same-attendee-record-and)

### 🗒️ Description

**Fix** (bug fix - duplicate attendee records)

Resolved an issue where a logged-in user clicking Go or Not Going on an RSVP repeatedly created a new attendee record each time instead of updating their existing one. `Tribe__Tickets__RSVP::generate_tickets_for()` now looks up the user's existing attendee for the ticket and updates it in place, adjusting sales/stock accordingly, rather than always inserting a duplicate.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/64626db5c14b466597109b1409103501

**Testing IAC**

https://www.loom.com/share/3b6b39efab1942a983d460a5f422c4ee

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
