### PR TITLE
[SOFT-4174] RSVP block: attendee information option should be available immediately

### DIFF
--- a/src/modules/blocks/rsvp-shared/attendee-registration/__tests__/__snapshots__/template.test.js.snap
+++ b/src/modules/blocks/rsvp-shared/attendee-registration/__tests__/__snapshots__/template.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RSVPAttendeeRegistration should render the attendee registration element 1`] = `
+<div
+  data-testid="ar-element"
+>
+  <span
+    data-testid="link-text"
+  >
+    + Add
+  </span>
+  <span
+    data-testid="helper-text"
+  />
+</div>
+`;

--- a/src/modules/blocks/rsvp-shared/attendee-registration/__tests__/template.test.js
+++ b/src/modules/blocks/rsvp-shared/attendee-registration/__tests__/template.test.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+jest.mock( '../../../../elements', () => ( {
+	AttendeesRegistration: ( { helperText, linkText, showHelperText } ) => (
+		<div data-testid="ar-element">
+			<span data-testid="link-text">{ linkText }</span>
+			<span data-testid="helper-text">{ showHelperText ? helperText : null }</span>
+		</div>
+	),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import RSVPAttendeeRegistration from '../template';
+
+describe( 'RSVPAttendeeRegistration', () => {
+	const defaultProps = {
+		attendeeRegistrationURL: 'http://example.test/edit.php?post_type=tribe_events&page=attendee-registration&ticket_id=0&tribe_events_modal=1', // eslint-disable-line max-len
+		hasAttendeeInfoFields: false,
+		isDisabled: false,
+		isModalOpen: false,
+		onClick: jest.fn(),
+		onClose: jest.fn(),
+		onIframeLoad: jest.fn(),
+		helperText: 'Helper text',
+		showHelperText: false,
+	};
+
+	it( 'should render the attendee registration element', () => {
+		const component = renderer.create( <RSVPAttendeeRegistration { ...defaultProps } /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	it( 'should render helper text when showHelperText is true', () => {
+		const component = renderer.create(
+			<RSVPAttendeeRegistration { ...defaultProps } showHelperText={ true } />
+		);
+		const json = JSON.stringify( component.toJSON() );
+		expect( json ).toContain( 'Helper text' );
+	} );
+
+	it( 'should not render helper text when showHelperText is false', () => {
+		const component = renderer.create(
+			<RSVPAttendeeRegistration { ...defaultProps } showHelperText={ false } />
+		);
+		const json = JSON.stringify( component.toJSON() );
+		expect( json ).not.toContain( 'Helper text' );
+	} );
+
+	it( 'should use the add link text when no attendee info fields exist', () => {
+		const component = renderer.create(
+			<RSVPAttendeeRegistration
+				{ ...defaultProps }
+				linkTextAdd="+ Collect attendee information"
+				linkTextEdit="Edit attendee information"
+			/>
+		);
+		const json = JSON.stringify( component.toJSON() );
+		expect( json ).toContain( '+ Collect attendee information' );
+		expect( json ).not.toContain( 'Edit attendee information' );
+	} );
+
+	it( 'should use the edit link text when attendee info fields exist', () => {
+		const component = renderer.create(
+			<RSVPAttendeeRegistration
+				{ ...defaultProps }
+				hasAttendeeInfoFields={ true }
+				linkTextAdd="+ Collect attendee information"
+				linkTextEdit="Edit attendee information"
+			/>
+		);
+		const json = JSON.stringify( component.toJSON() );
+		expect( json ).toContain( 'Edit attendee information' );
+	} );
+} );

--- a/src/modules/blocks/rsvp-shared/attendee-registration/container.js
+++ b/src/modules/blocks/rsvp-shared/attendee-registration/container.js
@@ -31,18 +31,22 @@ const getIsDisabled = ( state ) =>
 	selectors.getRSVPSettingsOpen( state ) ||
 	! selectors.getRSVPCreated( state );
 
-const mapStateToProps = ( state ) => ( {
+const mapStateToProps = ( state, ownProps ) => ( {
 	attendeeRegistrationURL: getAttendeeRegistrationUrl( state ),
 	hasAttendeeInfoFields: selectors.getRSVPHasAttendeeInfoFields( state ),
 	isCreated: selectors.getRSVPCreated( state ),
-	isDisabled: getIsDisabled( state ),
+	isDisabled: ownProps.isDisabled !== undefined ? ownProps.isDisabled : getIsDisabled( state ),
 	isModalOpen: selectors.getRSVPIsModalOpen( state ),
+	helperText: ownProps.helperText || '',
+	showHelperText: ownProps.showHelperText !== undefined ? ownProps.showHelperText : false,
 } );
 
-const mapDispatchToProps = ( dispatch ) => ( {
-	onClick: () => {
-		dispatch( actions.setRSVPIsModalOpen( true ) );
-	},
+const mapDispatchToProps = ( dispatch, ownProps ) => ( {
+	onClick:
+		ownProps.onClick ||
+		( () => {
+			dispatch( actions.setRSVPIsModalOpen( true ) );
+		} ),
 	onClose: () => {
 		dispatch( actions.setRSVPIsModalOpen( false ) );
 	},

--- a/src/modules/blocks/rsvp-shared/attendee-registration/template.js
+++ b/src/modules/blocks/rsvp-shared/attendee-registration/template.js
@@ -22,7 +22,6 @@ const defaultLabel = __( 'Attendee Information', 'event-tickets' );
 const RSVPAttendeeRegistration = ( {
 	attendeeRegistrationURL,
 	hasAttendeeInfoFields,
-	isCreated,
 	isDisabled,
 	isModalOpen,
 	onClick,
@@ -31,12 +30,14 @@ const RSVPAttendeeRegistration = ( {
 	label = defaultLabel,
 	linkTextAdd = defaultLinkTextAdd,
 	linkTextEdit = defaultLinkTextEdit,
+	helperText,
+	showHelperText,
 } ) => {
 	const linkText = hasAttendeeInfoFields ? linkTextEdit : linkTextAdd;
 
 	return (
 		<ARElement
-			helperText={ __( 'Save your RSVP to enable attendee information fields', 'event-tickets' ) }
+			helperText={ helperText }
 			iframeURL={ attendeeRegistrationURL }
 			isDisabled={ isDisabled }
 			isModalOpen={ isModalOpen }
@@ -46,7 +47,7 @@ const RSVPAttendeeRegistration = ( {
 			onClick={ onClick }
 			onClose={ onClose }
 			onIframeLoad={ onIframeLoad }
-			showHelperText={ ! isCreated }
+			showHelperText={ showHelperText }
 			shouldCloseOnClickOutside={ false }
 		/>
 	);
@@ -55,7 +56,6 @@ const RSVPAttendeeRegistration = ( {
 RSVPAttendeeRegistration.propTypes = {
 	attendeeRegistrationURL: PropTypes.string.isRequired,
 	hasAttendeeInfoFields: PropTypes.bool.isRequired,
-	isCreated: PropTypes.bool.isRequired,
 	isDisabled: PropTypes.bool.isRequired,
 	isModalOpen: PropTypes.bool.isRequired,
 	onClick: PropTypes.func.isRequired,
@@ -64,6 +64,8 @@ RSVPAttendeeRegistration.propTypes = {
 	label: PropTypes.string,
 	linkTextAdd: PropTypes.string,
 	linkTextEdit: PropTypes.string,
+	helperText: PropTypes.string.isRequired,
+	showHelperText: PropTypes.bool.isRequired,
 };
 
 export default RSVPAttendeeRegistration;

--- a/src/modules/blocks/rsvp-v2/attendee-registration-link/__tests__/container.test.js
+++ b/src/modules/blocks/rsvp-v2/attendee-registration-link/__tests__/container.test.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+jest.mock( 'react-redux', () => ( {
+	connect: jest.fn( () => ( Component ) => Component ),
+} ) );
+
+jest.mock( '@moderntribe/common/hoc', () => ( {
+	withStore: () => ( Component ) => Component,
+} ) );
+
+jest.mock( '../../../rsvp-shared/attendee-registration/container', () => () => null );
+
+jest.mock( '../../../../data/blocks/rsvp-v2', () => ( {
+	actions: {
+		setRSVPIsModalOpen: jest.fn( ( isOpen ) => ( { type: 'SET_RSVP_IS_MODAL_OPEN', payload: { isOpen } } ) ),
+	},
+	selectors: {
+		getRSVPCreated: jest.fn(),
+		getRSVPIsLoading: jest.fn(),
+		getRSVPSettingsOpen: jest.fn(),
+	},
+	thunks: {
+		persistRSVP: jest.fn( () => ( { type: 'PERSIST_RSVP' } ) ),
+	},
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import RSVPAttendeeRegistrationLink, { getIsDisabled, mergeProps } from '../container';
+import { actions, selectors, thunks } from '../../../../data/blocks/rsvp-v2';
+
+describe( 'RSVP V2 Attendee Registration Link', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render the shared attendee registration container with V2 link copy', () => {
+		expect( RSVPAttendeeRegistrationLink ).toBeDefined();
+	} );
+
+	describe( 'getIsDisabled', () => {
+		it( 'should be disabled while loading or settings are open', () => {
+			selectors.getRSVPIsLoading.mockReturnValue( true );
+			selectors.getRSVPSettingsOpen.mockReturnValue( false );
+
+			expect( getIsDisabled( {} ) ).toBe( true );
+		} );
+
+		it( 'should not be disabled when the RSVP is not created yet', () => {
+			selectors.getRSVPIsLoading.mockReturnValue( false );
+			selectors.getRSVPSettingsOpen.mockReturnValue( false );
+
+			// The link must be available before the RSVP is created so attendee
+			// information can be collected from the first load of the editor.
+			expect( getIsDisabled( {} ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'mergeProps onClick', () => {
+		const createState = ( { created = false, isLoading = false, settingsOpen = false } = {} ) => {
+			selectors.getRSVPCreated.mockReturnValue( created );
+			selectors.getRSVPIsLoading.mockReturnValue( isLoading );
+			selectors.getRSVPSettingsOpen.mockReturnValue( settingsOpen );
+
+			return { tickets: { blocks: { rsvp: {} } } };
+		};
+
+		it( 'should persist the RSVP before opening the modal when not created', async () => {
+			thunks.persistRSVP.mockImplementation( () => async () => {
+				// Simulate the RSVP being created by the thunk.
+				selectors.getRSVPCreated.mockReturnValue( true );
+			} );
+
+			const dispatch = jest.fn( ( action ) => ( typeof action === 'function' ? action( dispatch ) : action ) );
+			const state = createState( { created: false } );
+			const store = { getState: () => state };
+
+			const { onClick } = mergeProps( { state }, { dispatch }, { store } );
+
+			await onClick();
+
+			expect( thunks.persistRSVP ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).toHaveBeenCalledWith( actions.setRSVPIsModalOpen( true ) );
+		} );
+
+		it( 'should open the modal directly when the RSVP is already created', async () => {
+			const dispatch = jest.fn( ( action ) => ( typeof action === 'function' ? action( dispatch ) : action ) );
+			const state = createState( { created: true } );
+			const store = { getState: () => state };
+
+			const { onClick } = mergeProps( { state }, { dispatch }, { store } );
+
+			await onClick();
+
+			expect( thunks.persistRSVP ).not.toHaveBeenCalled();
+			expect( dispatch ).toHaveBeenCalledWith( actions.setRSVPIsModalOpen( true ) );
+		} );
+
+		it( 'should not open the modal when persisting fails to create the RSVP', async () => {
+			thunks.persistRSVP.mockImplementation( () => async () => {} );
+
+			const dispatch = jest.fn( ( action ) => ( typeof action === 'function' ? action( dispatch ) : action ) );
+			const state = createState( { created: false } );
+			const store = { getState: () => state };
+
+			const { onClick } = mergeProps( { state }, { dispatch }, { store } );
+
+			await onClick();
+
+			expect( thunks.persistRSVP ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).not.toHaveBeenCalledWith( actions.setRSVPIsModalOpen( true ) );
+		} );
+	} );
+} );

--- a/src/modules/blocks/rsvp-v2/attendee-registration-link/container.js
+++ b/src/modules/blocks/rsvp-v2/attendee-registration-link/container.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 
 /**
  * WordPress dependencies
@@ -12,6 +14,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import RSVPAttendeeRegistration from '../../rsvp-shared/attendee-registration/container';
+import { actions, selectors, thunks } from '../../../data/blocks/rsvp-v2';
+import { withStore } from '@moderntribe/common/hoc';
 
 /**
  * The V2 attendee registration link wraps the shared attendee registration
@@ -19,13 +23,58 @@ import RSVPAttendeeRegistration from '../../rsvp-shared/attendee-registration/co
  * listeners, IAC sync bridge). The V2 RSVP data layer re-exports the shared
  * selectors and actions, so the shared container connects to the V2 state
  * tree directly. Only the V2 link copy differs from the shared default.
+ *
+ * Unlike the shared default, the link is never gated on the RSVP being
+ * created: clicking it persists the RSVP on demand (creating the ticket when
+ * needed) and only then opens the modal, so attendee information can be
+ * collected from the first load of the editor without requiring a save.
+ *
+ * @param {Object} state The Redux state.
+ * @return {boolean} Whether the link should be disabled.
  */
-const RSVPAttendeeRegistrationLink = () => (
+export const getIsDisabled = ( state ) => selectors.getRSVPIsLoading( state ) || selectors.getRSVPSettingsOpen( state );
+
+export const mapStateToProps = ( state ) => ( {
+	isDisabled: getIsDisabled( state ),
+	showHelperText: false,
+	state,
+} );
+
+export const mapDispatchToProps = ( dispatch ) => ( { dispatch } );
+
+export const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { state, ...restStateProps } = stateProps;
+	const { dispatch } = dispatchProps;
+	const getState = () => ownProps.store.getState();
+
+	return {
+		...ownProps,
+		...restStateProps,
+		onClick: async () => {
+			// The modal iframe needs a real ticket ID, so persist the RSVP
+			// first (creating the ticket when it does not exist yet), then
+			// open the modal once the RSVP is created.
+			if ( ! selectors.getRSVPCreated( getState() ) ) {
+				await dispatch( thunks.persistRSVP() );
+			}
+
+			if ( selectors.getRSVPCreated( getState() ) ) {
+				dispatch( actions.setRSVPIsModalOpen( true ) );
+			}
+		},
+	};
+};
+
+const RSVPAttendeeRegistrationLink = ( props ) => (
 	<RSVPAttendeeRegistration
 		label=""
 		linkTextAdd={ __( '+ Collect attendee information', 'event-tickets' ) }
 		linkTextEdit={ __( 'Edit attendee information', 'event-tickets' ) }
+		{ ...props }
 	/>
 );
 
-export default RSVPAttendeeRegistrationLink;
+export default compose(
+	withStore(),
+	connect( mapStateToProps, mapDispatchToProps, mergeProps )
+)( RSVPAttendeeRegistrationLink );


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4174](https://linear.app/nexcess/issue/SOFT-4174/rsvp-block-attendee-information-option-should-be-available)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - attendee information option was disabled until the RSVP was saved)

Fixed the RSVP block so the "Collect attendee information" option is available from the first load of the editor without requiring the event to be saved first. Clicking the link now persists the RSVP on demand and only then opens the attendee registration modal, and the stale "Save your RSVP to enable attendee information fields" helper text was removed. The legacy V1 block keeps its previous behavior via prop overrides.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1297" height="581" alt="Screenshot 2026-08-14 at 22 44 23" src="https://github.com/user-attachments/assets/b2c89b79-e5f0-4b08-94c0-ecb0c2145ecd" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
