### PR TITLE
[SOFT-4173] Remove RSVP option should not remove the entire block

### DIFF
--- a/src/modules/blocks/rsvp-v2/remove-rsvp/container.js
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/container.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { dispatch as wpDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -29,9 +28,9 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		isLoading: stateProps.isLoading,
 		onRemove: async () => {
 			if (
+				// eslint-disable-next-line no-alert
 				! window.confirm(
-					// eslint-disable-line no-alert
-					__( 'Are you sure you want to disable RSVP? This cannot be undone.', 'event-tickets' )
+					__( 'Are you sure you want to remove RSVP? This cannot be undone.', 'event-tickets' )
 				)
 			) {
 				return;
@@ -42,7 +41,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 			}
 
 			dispatch( actions.deleteRSVP() );
-			wpDispatch( 'core/block-editor' ).removeBlocks( [ ownProps.clientId ] );
+			dispatch( actions.setRSVPIsInitializing( false ) );
 		},
 	};
 };


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4173](https://linear.app/nexcess/issue/SOFT-4173/remove-rsvp-option-should-not-remove-the-entire-block)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - block editor behavior)

Resolved an issue where the Remove RSVP link in the RSVP V2 block removed the entire block from the editor. The link now deletes the backing RSVP ticket and resets the block to its initial Add RSVP state, with the confirmation message updated to match the removal action.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/9a0d603cefb14a8b8d92807547729d86

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
