### PR TITLE
[SOFT-4170] Block editor: RSVP button too greyed out

### DIFF
--- a/src/modules/blocks/rsvp-v2/frontend-mirror/__tests__/__snapshots__/template.test.js.snap
+++ b/src/modules/blocks/rsvp-v2/frontend-mirror/__tests__/__snapshots__/template.test.js.snap
@@ -81,7 +81,6 @@ exports[`RSVPFrontendMirror should mirror frontend markup structure 1`] = `
             >
               <button
                 className="tribe-common-c-btn tribe-tickets__rsvp-actions-button-going tribe-common-b1 tribe-common-b2--min-medium"
-                disabled={true}
                 type="button"
               >
                 Going
@@ -92,7 +91,6 @@ exports[`RSVPFrontendMirror should mirror frontend markup structure 1`] = `
             >
               <button
                 className="tribe-common-cta tribe-common-cta--alt tribe-tickets__rsvp-actions-button-not-going"
-                disabled={true}
                 type="button"
               >
                 Can't go

--- a/src/modules/blocks/rsvp-v2/frontend-mirror/partials/actions-going.js
+++ b/src/modules/blocks/rsvp-v2/frontend-mirror/partials/actions-going.js
@@ -1,5 +1,9 @@
 /**
- * Mirrors `src/views/v2/commerce/rsvp/actions/rsvp/going.php` (disabled in editor).
+ * Mirrors `src/views/v2/commerce/rsvp/actions/rsvp/going.php` (non-interactive in editor).
+ *
+ * The button is intentionally left enabled so it renders with the full accent
+ * color, matching the frontend. The editor wrapper (`style.pcss`) blocks
+ * interaction via `pointer-events: none`.
  */
 import React from 'react';
 import { _x } from '@wordpress/i18n';
@@ -8,7 +12,6 @@ const RSVPActionsGoing = () => (
 	<div className="tribe-tickets__rsvp-actions-rsvp-going">
 		<button
 			className="tribe-common-c-btn tribe-tickets__rsvp-actions-button-going tribe-common-b1 tribe-common-b2--min-medium"
-			disabled
 			type="button"
 		>
 			{ _x( 'Going', 'Label for the RSVP going button', 'event-tickets' ) }

--- a/src/modules/blocks/rsvp-v2/frontend-mirror/partials/actions-not-going.js
+++ b/src/modules/blocks/rsvp-v2/frontend-mirror/partials/actions-not-going.js
@@ -1,5 +1,9 @@
 /**
- * Mirrors `src/views/v2/commerce/rsvp/actions/rsvp/not-going.php` (disabled in editor).
+ * Mirrors `src/views/v2/commerce/rsvp/actions/rsvp/not-going.php` (non-interactive in editor).
+ *
+ * The button is intentionally left enabled so it renders with the full accent
+ * color, matching the frontend. The editor wrapper (`style.pcss`) blocks
+ * interaction via `pointer-events: none`.
  */
 import React from 'react';
 import { _x } from '@wordpress/i18n';
@@ -8,7 +12,6 @@ const RSVPActionsNotGoing = () => (
 	<div className="tribe-tickets__rsvp-actions-rsvp-not-going">
 		<button
 			className="tribe-common-cta tribe-common-cta--alt tribe-tickets__rsvp-actions-button-not-going"
-			disabled
 			type="button"
 		>
 			{ _x(


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4170](https://linear.app/nexcess/issue/SOFT-4170/block-editor-rsvp-button-too-greyed-out)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - RSVP block editor button styling)

Fixed the RSVP block editor preview rendering the Going / Can't go buttons with the muted disabled color (`--tec-color-button-primary-background`). The editor mirror buttons no longer render with a hardcoded `disabled` attribute — interaction stays blocked via the wrapper's `pointer-events: none`, and the buttons now display at full opacity with the accent primary color, matching the frontend appearance.


### 🎥 Artifacts <!-- if applicable-->
<img width="1271" height="582" alt="Screenshot 2026-08-15 at 00 10 38" src="https://github.com/user-attachments/assets/842dfb25-93fe-4348-ac58-ad198f4425af" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
