### PR TITLE
[SOFT-4172] RSVP does not obey Individual Attendee Collection Default Setting

### DIFF
--- a/__mocks__/@moderntribe/common/utils.js
+++ b/__mocks__/@moderntribe/common/utils.js
@@ -1,6 +1,6 @@
 const globals = {
 	tecDateSettings: jest.fn( () => ( { datepickerFormat: 'Y-m-d' } ) ),
-	iacVars: jest.fn( () => ( {} ) ),
+	iacVars: jest.fn( () => window.tribe_editor_config?.ticketsPlus?.iacVars || {} ),
 	tickets: jest.fn( () => ( {
 		end_sale_buffer_duration: 2,
 		end_sale_buffer_years: 1,

--- a/src/modules/data/blocks/rsvp-v2/__tests__/thunks.test.js
+++ b/src/modules/data/blocks/rsvp-v2/__tests__/thunks.test.js
@@ -120,7 +120,25 @@ describe( 'RSVP V2 thunks', () => {
 			expect( data ).not.toHaveProperty( 'iac' );
 		} );
 
-		it( 'should default IAC to none in Redux when not provided', async () => {
+		it( 'should default IAC to the global default in Redux when not provided', async () => {
+			apiFetch.mockResolvedValue( { id: 99 } );
+
+			window.tribe_editor_config.ticketsPlus = {
+				iacVars: { iacDefault: 'allowed' },
+			};
+
+			await createRSVP( {
+				...basePayload,
+				postId: 42,
+			} )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: types.SET_RSVP_IAC,
+				payload: { iac: 'allowed' },
+			} );
+		} );
+
+		it( 'should default IAC to none in Redux when no iacVars are present', async () => {
 			apiFetch.mockResolvedValue( { id: 99 } );
 
 			await createRSVP( {
@@ -181,6 +199,24 @@ describe( 'RSVP V2 thunks', () => {
 
 			const { data } = apiFetch.mock.calls[ 0 ][ 0 ];
 			expect( data ).not.toHaveProperty( 'iac' );
+		} );
+
+		it( 'should default IAC to the global default in Redux when not provided', async () => {
+			apiFetch.mockResolvedValue( {} );
+
+			window.tribe_editor_config.ticketsPlus = {
+				iacVars: { iacDefault: 'required' },
+			};
+
+			await updateRSVP( {
+				...basePayload,
+				id: 99,
+			} )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: types.SET_RSVP_IAC,
+				payload: { iac: 'required' },
+			} );
 		} );
 	} );
 

--- a/src/modules/data/blocks/rsvp-v2/thunks.js
+++ b/src/modules/data/blocks/rsvp-v2/thunks.js
@@ -10,6 +10,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { doAction } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
+import { globals } from '@moderntribe/common/utils';
 
 /**
  * Internal dependencies
@@ -154,7 +155,7 @@ export const createRSVP = ( payload ) => async ( dispatch, getState ) => {
 			}
 			dispatch( actions.createRSVP() );
 			dispatch( actions.setRSVPId( response.id ) );
-			dispatch( actions.setRSVPIAC( payload.iac || 'none' ) );
+			dispatch( actions.setRSVPIAC( payload.iac || globals.iacVars().iacDefault || 'none' ) );
 			dispatch( actions.setRSVPDetails( { ...payload, title: 'RSVP', description: '' } ) );
 			await hydrateAttendanceCountsFromTicket( dispatch, response );
 			dispatch( actions.setRSVPHasChanges( false ) );
@@ -232,7 +233,7 @@ export const updateRSVP = ( payload ) => async ( dispatch, getState ) => {
 		if ( payload.postId && window.tribe_event_tickets_plus?.rsvp?.pendingAttendeeInfo ) {
 			delete window.tribe_event_tickets_plus.rsvp.pendingAttendeeInfo[ payload.postId ];
 		}
-		dispatch( actions.setRSVPIAC( payload.iac || 'none' ) );
+		dispatch( actions.setRSVPIAC( payload.iac || globals.iacVars().iacDefault || 'none' ) );
 		dispatch( actions.setRSVPDetails( { ...payload, title: 'RSVP', description: '' } ) );
 		dispatch(
 			actions.setRSVPTempDetails( {

--- a/src/modules/data/blocks/rsvp-v2/utils/__tests__/hydrate-rsvp-from-editor-config.test.js
+++ b/src/modules/data/blocks/rsvp-v2/utils/__tests__/hydrate-rsvp-from-editor-config.test.js
@@ -1,0 +1,63 @@
+/**
+ * Internal dependencies
+ */
+import { hydrateRsvpFromEditorConfig } from '../hydrate-rsvp-from-editor-config';
+import { getInitialTicket } from '../../config';
+import { hydrateRsvpFromTicket } from '../../../rsvp-shared/utils/hydrate-rsvp-from-ticket';
+
+jest.mock( '../../config', () => ( {
+	getInitialTicket: jest.fn(),
+} ) );
+
+jest.mock( '../../../rsvp-shared/utils/hydrate-rsvp-from-ticket', () => ( {
+	hydrateRsvpFromTicket: jest.fn(),
+} ) );
+
+describe( 'hydrateRsvpFromEditorConfig', () => {
+	let dispatch;
+	let actions;
+
+	beforeEach( () => {
+		dispatch = jest.fn();
+		actions = { setRSVPIAC: jest.fn() };
+
+		getInitialTicket.mockReset();
+		hydrateRsvpFromTicket.mockReset();
+
+		window.tribe_editor_config = {};
+	} );
+
+	it( 'should seed the global IAC default when there is no initial ticket', () => {
+		getInitialTicket.mockReturnValue( null );
+		hydrateRsvpFromTicket.mockReturnValue( false );
+
+		window.tribe_editor_config.ticketsPlus = {
+			iacVars: { iacDefault: 'allowed' },
+		};
+
+		const hydrated = hydrateRsvpFromEditorConfig( dispatch, actions );
+
+		expect( hydrated ).toBe( false );
+		expect( actions.setRSVPIAC ).toHaveBeenCalledWith( 'allowed' );
+	} );
+
+	it( 'should seed none when there is no initial ticket and no iacDefault is set', () => {
+		getInitialTicket.mockReturnValue( null );
+		hydrateRsvpFromTicket.mockReturnValue( false );
+
+		const hydrated = hydrateRsvpFromEditorConfig( dispatch, actions );
+
+		expect( hydrated ).toBe( false );
+		expect( actions.setRSVPIAC ).toHaveBeenCalledWith( 'none' );
+	} );
+
+	it( 'should not seed the default when an initial ticket is hydrated', () => {
+		getInitialTicket.mockReturnValue( { id: 42 } );
+		hydrateRsvpFromTicket.mockReturnValue( true );
+
+		const hydrated = hydrateRsvpFromEditorConfig( dispatch, actions );
+
+		expect( hydrated ).toBe( true );
+		expect( actions.setRSVPIAC ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/modules/data/blocks/rsvp-v2/utils/hydrate-rsvp-from-editor-config.js
+++ b/src/modules/data/blocks/rsvp-v2/utils/hydrate-rsvp-from-editor-config.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { globals } from '@moderntribe/common/utils';
 import { getInitialTicket } from '../config';
 import { hydrateRsvpFromTicket } from '../../rsvp-shared/utils/hydrate-rsvp-from-ticket';
 
@@ -13,6 +14,14 @@ import { hydrateRsvpFromTicket } from '../../rsvp-shared/utils/hydrate-rsvp-from
  */
 export const hydrateRsvpFromEditorConfig = ( dispatch, actions ) => {
 	const ticket = getInitialTicket();
+	const hydrated = hydrateRsvpFromTicket( dispatch, actions, ticket );
 
-	return hydrateRsvpFromTicket( dispatch, actions, ticket );
+	// No existing RSVP ticket yet (e.g. a brand-new event): seed the global IAC
+	// default so a newly created RSVP block reflects the site's default
+	// attendee-collection choice instead of starting at 'none'.
+	if ( ! hydrated ) {
+		dispatch( actions.setRSVPIAC( globals.iacVars().iacDefault || 'none' ) );
+	}
+
+	return hydrated;
 };

--- a/tests/rsvp_to_tc_migration/RSVP_To_Tickets_Commerce_Test.php
+++ b/tests/rsvp_to_tc_migration/RSVP_To_Tickets_Commerce_Test.php
@@ -473,6 +473,83 @@ class RSVP_To_Tickets_Commerce_Test extends WPTestCase {
 
 	/**
 	 * @test
+	 * It should preserve the IAC setting on the ticket during migration.
+	 */
+	public function should_preserve_iac_setting_during_migration(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_production_rsvp_ticket( $post_id, [
+			'meta_input' => [
+				'_tribe_tickets_ar_iac' => 'required',
+			],
+		] );
+
+		$this->run_migration_up();
+		clean_post_cache( $ticket_id );
+
+		// IAC setting should be preserved on the migrated TC ticket.
+		$this->assertEquals( 'required', get_post_meta( $ticket_id, '_tribe_tickets_ar_iac', true ) );
+	}
+
+	/**
+	 * @test
+	 * It should restore the IAC setting on rollback.
+	 */
+	public function should_restore_iac_setting_on_rollback(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_production_rsvp_ticket( $post_id, [
+			'meta_input' => [
+				'_tribe_tickets_ar_iac' => 'allowed',
+			],
+		] );
+
+		$this->run_migration_up();
+		$this->run_migration_down();
+		clean_post_cache( $ticket_id );
+
+		$this->assertEquals( 'allowed', get_post_meta( $ticket_id, '_tribe_tickets_ar_iac', true ) );
+	}
+
+	/**
+	 * @test
+	 * It should preserve ticket-level ARF fields and the meta-enabled flag during migration.
+	 */
+	public function should_preserve_ticket_arf_fields_during_migration(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_production_rsvp_ticket( $post_id, [
+			'meta_input' => [
+				'_tribe_tickets_meta_enabled' => 'yes',
+				'_tribe_tickets_meta'         => [
+					[
+						'type'     => 'text',
+						'required' => '',
+						'label'    => 'Favorite Color',
+						'slug'     => 'favorite-color',
+						'extra'    => [],
+					],
+				],
+			],
+		] );
+
+		$this->run_migration_up();
+		clean_post_cache( $ticket_id );
+
+		$this->assertEquals( 'yes', get_post_meta( $ticket_id, '_tribe_tickets_meta_enabled', true ) );
+		$this->assertEquals(
+			[
+				[
+					'type'     => 'text',
+					'required' => '',
+					'label'    => 'Favorite Color',
+					'slug'     => 'favorite-color',
+					'extra'    => [],
+				],
+			],
+			get_post_meta( $ticket_id, '_tribe_tickets_meta', true )
+		);
+	}
+
+	/**
+	 * @test
 	 * It should rollback simple ticket.
 	 */
 	public function should_rollback_simple_ticket(): void {


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4172](https://linear.app/nexcess/issue/SOFT-4172/rsvp-does-not-obey-individual-attendee-collection-default-setting)

Depends on: https://github.com/the-events-calendar/event-tickets-plus/pull/2130

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - RSVP V2 ignoring the global IAC default)

Fixed RSVP V2 so it honors the global "Individual Attendee Collection Default Setting" instead of always defaulting to no collection. When an RSVP V2 ticket has no explicit IAC choice, the site's global default is now applied on the front end and in both the classic and block editors, including for brand-new RSVPs before a ticket exists. The change is scoped strictly to RSVP V2 tickets — paid tickets and legacy V1 RSVPs are unaffected. Also resolved a JS error in the classic-editor IAC modal and made the modal's IAC selection persist onto a newly created RSVP ticket, and locked in that the rsvp-to-tc migration preserves any existing IAC/ARF settings.


### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/24404d055c90495aa226f2c5d4edc2ac

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
