### PR TITLE
[SOFT-4187] RSVP window pop up overflows block editor

### DIFF
--- a/src/modules/blocks/rsvp-v2/edit-popovers/limit-popover.js
+++ b/src/modules/blocks/rsvp-v2/edit-popovers/limit-popover.js
@@ -27,7 +27,7 @@ const RSVPLimitPopover = ( { anchorRef, isOpen, isSaving, onCancel, onSave, onTe
 			className="tribe-editor__rsvp-limit-popover"
 			onClose={ onCancel }
 			onFocusOutside={ onCancel }
-			position="bottom center"
+			placement="bottom-start"
 		>
 			<div className="tribe-editor__rsvp-limit-popover__content">
 				<h4 className="tribe-editor__rsvp-limit-popover__title tribe-common-h6">

--- a/src/modules/blocks/rsvp-v2/edit-popovers/style.pcss
+++ b/src/modules/blocks/rsvp-v2/edit-popovers/style.pcss
@@ -4,7 +4,8 @@
 }
 
 .tribe-editor__rsvp-window-popover__content {
-	min-width: 480px;
+	max-width: 480px;
+	min-width: 280px;
 	padding: var(--tec-spacer-4);
 }
 

--- a/src/modules/blocks/rsvp-v2/edit-popovers/window-popover.js
+++ b/src/modules/blocks/rsvp-v2/edit-popovers/window-popover.js
@@ -44,7 +44,7 @@ const RSVPWindowPopover = ( { anchorRef, hasDurationError, isOpen, isSaving, onC
 			focusOnMount={ false }
 			onClose={ handleDismiss }
 			onFocusOutside={ handleDismiss }
-			position="bottom start"
+			placement="bottom-start"
 		>
 			<div className="tribe-editor__rsvp-window-popover__content">
 				<h4 className="tribe-editor__rsvp-window-popover__title tribe-common-h6">


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4187](https://linear.app/nexcess/issue/SOFT-4187/rsvp-window-pop-up-overflows-block-editor)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - popover overflow)

Fixed the RSVP Window popover overflowing the block editor viewport by replacing the legacy `position` prop with `placement="bottom-start"` on the WordPress Popover component, so the popover now anchors its left edge to the RSVP Window label instead of centering on the anchor. Applied the same `placement="bottom-start"` change to the RSVP Limit popover for consistent alignment, and updated the RSVP Window popover content width constraints to a max-width of 480px and min-width of 280px.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/143942e3d2734b9f9c6e001ecb77605c

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
