### PR TITLE
[SOFT-4178] My RSVPs section missing on migrated sites

### DIFF
--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -257,14 +257,6 @@ class Controller extends Controller_Contract {
 			$this->container->callback( Attendees::class, 'void_order_after_last_attendee_deleted' )
 		);
 
-		// Frontend.
-		add_filter(
-			'tribe_template_done',
-			$this->container->callback( Frontend::class, 'prevent_template_render' ),
-			10,
-			2
-		);
-
 		// Add show_not_going property to REST responses for RSVP tickets.
 		$this->hook_add_show_not_going_to_properties();
 
@@ -343,10 +335,6 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_front_end_rsvp_form_template_content',
 			$this->container->callback( Frontend::class, 'render_rsvp_template' )
-		);
-		remove_filter(
-			'tribe_template_done',
-			$this->container->callback( Frontend::class, 'prevent_template_render' )
 		);
 		remove_action(
 			'event_tickets_attendee_update',

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -277,37 +277,6 @@ class Frontend {
 	}
 
 	/**
-	 * Prevents the rendering of some RSVP templates in the context of the RSVP v2 implementation.
-	 *
-	 * @since TBD
-	 *
-	 * @param string|null     $done Whether the template has been rendered or not.
-	 * @param string|string[] $name The template name in the form of a string or an array of strings.
-	 *
-	 * @return string|null An empty string to prevent template rendering if required, or the original value.
-	 */
-	public function prevent_template_render( $done, $name ) {
-		if ( null !== $done ) {
-			return $done;
-		}
-
-		$do_not_render = [
-			'v2/commerce/rsvp/attendees',
-			'v2/commerce/rsvp/attendees/attendee',
-			'v2/commerce/rsvp/attendees/attendee/name',
-			'v2/commerce/rsvp/attendees/attendee/rsvp',
-			'v2/commerce/rsvp/attendees/title',
-		];
-
-		if ( in_array( $name, $do_not_render, true ) ) {
-			// Return a non-null value to indicate the template was done.
-			return '';
-		}
-
-		return $done;
-	}
-
-	/**
 	 * Render the RSVP ticket status on the My Tickets page.
 	 *
 	 * Hooked to `tec_tickets_my_tickets_ticket_information_after_ticket_name`.

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/Success_ShortcodeTest.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/Success_ShortcodeTest.php
@@ -279,9 +279,11 @@ class Success_Shortcode_Test extends WPTestCase {
 
 		$html = $shortcode->get_html();
 
+		// Replace the order key first: the random hex gateway order ID can contain the post ID
+		// as a substring, which would mangle the key if the post ID were replaced first.
 		$html = str_replace(
-			[ $post_id, $order_key ],
-			[ '{EVENT_ID}', '{ORDER_ID}' ],
+			[ $order_key, $post_id ],
+			[ '{ORDER_ID}', '{EVENT_ID}' ],
 			$html
 		);
 

--- a/tests/rsvp_v2_integration/RSVP/V2/Frontend_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Frontend_Test.php
@@ -124,6 +124,23 @@ class Frontend_Test extends WPTestCase {
 		$this->assertStringStartsWith( 'original content', $result, 'Should preserve original content' );
 	}
 
+	public function test_should_render_rsvp_attendees_template(): void {
+		$fixture = $this->create_rsvp_order_with_attendee();
+		$rsvp    = tribe( Module::class )->get_ticket( $fixture['post_id'], $fixture['ticket_id'] );
+
+		$html = $this->get_template()->template(
+			'v2/commerce/rsvp/attendees',
+			[
+				'attendees' => [ $fixture['attendee_id'] ],
+				'is_going'  => true,
+				'rsvp'      => $rsvp,
+			],
+			false
+		);
+
+		$this->assertStringContainsString( 'tribe-tickets__rsvp-attendees', $html );
+	}
+
 	public function test_do_not_display_rsvp_v1_form_should_remove_hooks_for_rsvp_handler(): void {
 		$frontend = tribe( Frontend::class );
 


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4178](https://linear.app/nexcess/issue/SOFT-4178/my-rsvps-section-missing-on-migrated-sites)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - missing RSVP attendee list on success screen)

Resolved an issue where the RSVP V2 success screen did not render the "Your RSVPs" attendee list, including the PDF ticket and Apple Wallet options. Removed a stale template-rendering suppression hook that short-circuited the RSVP attendee templates, and added a regression test covering the attendee template rendering.


### 🎥 Artifacts <!-- if applicable-->
<img width="708" height="976" alt="Screenshot 2026-08-18 at 00 44 45" src="https://github.com/user-attachments/assets/41f4298d-8b8d-435c-b3bb-2b3bcba5ce55" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
