### PR TITLE
fix: Preserve ticketable post types in the sale price deserialization test

### DIFF
--- a/tests/integration/TEC/Tickets/REST/TEC/V1/Sale_Price_Deserialization_Test.php
+++ b/tests/integration/TEC/Tickets/REST/TEC/V1/Sale_Price_Deserialization_Test.php
@@ -11,7 +11,10 @@ class Sale_Price_Deserialization_Test extends WPTestCase {
 
 	protected function filter_params( $sale_price ): array {
 		$event_id = static::factory()->post->create( [ 'post_type' => 'post', 'post_status' => 'publish' ] );
-		tribe_update_option( 'ticket-enabled-post-types', [ 'post' ] );
+
+		$ticketable   = tribe_get_option( 'ticket-enabled-post-types', [] );
+		$ticketable[] = 'post';
+		tribe_update_option( 'ticket-enabled-post-types', array_values( array_unique( $ticketable ) ) );
 
 		return tribe( Ticket::class )->filter_upsert_params(
 			[


### PR DESCRIPTION
### 🎫 Ticket

[SVUL-66](https://linear.app/nexcess/issue/SVUL-66)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Follow-up to SVUL-66. The integration test added in that PR (`Sale_Price_Deserialization_Test`) set the ticketable post types with a destructive write and never restored them:

```php
tribe_update_option( 'ticket-enabled-post-types', [ 'post' ] );
```

That runs inside a shared PHP process, so from that point on `tribe_events` is no longer a ticketable post type for every test that executes afterwards.
`Tribe__Tickets::get_event_for_ticket()` then returns false, which leaves the `events_in_order` postmeta empty on Tickets Commerce orders, which breaks the `meta_in` query behind the order report - surfacing as 5 unrelated failures in `Tribe\Admin\OrderReportTest` on the test (integration) job.

The test now appends post to whatever is already configured, the same pattern already used by ~8 other integration tests (RSVP_Tickets_Test, Tribe/Tickets/AttendeesTest, Tribe/Tickets/MetaboxTest, …).
No production code changes, and no change to what the test asserts: `With_Filtered_Ticket_Params` only does an `in_array()` membership check on that option, never an exclusivity check.

✔️ Checklist

- [ ] Ran npm run changelog to add changelog file(s).
- [x] Code is covered by EXISTING wpunit or integration tests.
- [x] Are all the required tests passing?
- [x] Check the base branch for your PR.


[SVUL-66]: https://stellarwp.atlassian.net/browse/SVUL-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ