### PR TITLE
[SOFT-4179] My Tickets page UI changes missing on migrated sites

### DIFF
--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -810,7 +810,7 @@ class Attendee {
 		if ( ! tec_tickets_commerce_is_enabled() ) {
 			return [];
 		}
-		
+
 		/*
 		 * Check cache. The cache is keyed to the `save_post` trigger so creating, updating or deleting
 		 * an Attendee (a post) invalidates it. Without this trigger the cached list would survive for the
@@ -930,16 +930,19 @@ class Attendee {
 	 * Returns the product title related to an attendee
 	 *
 	 * @since 5.2.0
+	 * @since TBD Return the ticket title instead of reading an undefined property on this class, and
+	 *        resolve the ticket from the attendee product instead of the unique ID.
 	 *
 	 * @param \WP_Post $attendee the attendee object.
 	 *
 	 * @return string
 	 */
 	public function get_product_title( \WP_Post $attendee ) {
-		$ticket = get_post( $attendee->ticket_id );
+		$ticket_id = ! empty( $attendee->product_id ) ? $attendee->product_id : get_post_meta( $attendee->ID, Module::ATTENDEE_PRODUCT_KEY, true );
+		$ticket    = $ticket_id ? get_post( $ticket_id ) : null;
 
 		return ! empty( $ticket->post_title ) ?
-			esc_html( $this->post_title ) :
+			esc_html( $ticket->post_title ) :
 			get_post_meta( $attendee->ID, static::$deleted_ticket_meta_key, true );
 	}
 

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -141,6 +141,12 @@ class Controller extends Controller_Contract {
 			'tec_tickets_my_tickets_ticket_information_after_ticket_name',
 			$this->container->callback( Frontend::class, 'render_my_tickets_ticket_status' )
 		);
+		add_filter(
+			'tribe_template_pre_html',
+			$this->container->callback( Frontend::class, 'render_my_tickets_user_details' ),
+			10,
+			5
+		);
 		add_action(
 			'tribe_tickets_tickets_hook',
 			$this->container->callback( Frontend::class, 'do_not_display_rsvp_v1_tickets_form' ),
@@ -355,6 +361,11 @@ class Controller extends Controller_Contract {
 		remove_action(
 			'tec_tickets_my_tickets_ticket_information_after_ticket_name',
 			$this->container->callback( Frontend::class, 'render_my_tickets_ticket_status' ),
+		);
+		remove_filter(
+			'tribe_template_pre_html',
+			$this->container->callback( Frontend::class, 'render_my_tickets_user_details' ),
+			10
 		);
 		remove_action(
 			'tribe_tickets_tickets_hook',

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -321,24 +321,49 @@ class Frontend {
 			return;
 		}
 
-		$ticket_id         = (int) ( $attendee['product_id'] ?? 0 );
 		$attendee_is_going = metadata_exists( 'post', $attendee['ID'], Constants::RSVP_STATUS_META_KEY )
 			? tribe_is_truthy( get_post_meta( $attendee['ID'], Constants::RSVP_STATUS_META_KEY, true ) )
 			: true;
-		$show_not_going    = false;
-
-		if ( $ticket_id ) {
-			$show_not_going = tribe_is_truthy( get_post_meta( $ticket_id, Constants::SHOW_NOT_GOING_META_KEY, true ) );
-		}
 
 		tribe( 'tickets.editor.template' )->template(
 			'v2/commerce/rsvp/my-tickets/ticket-status',
 			[
 				'attendee_is_going' => $attendee_is_going,
-				'show_not_going'    => $show_not_going,
 				'attendee_id'       => $attendee['ID'],
 			]
 		);
+	}
+
+	/**
+	 * Replaces the default `tickets/my-tickets/user-details` template for TC-RSVP orders.
+	 *
+	 * Hooked to the template's `tribe_template_pre_html` filter so the alternate template
+	 * supports both echoed and non-echoed template rendering.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null         $html    The filtered template HTML, or null before rendering.
+	 * @param string              $file    The template file path.
+	 * @param array<string>       $name    The template name parts.
+	 * @param Tribe__Template     $template The current template instance.
+	 * @param array<string,mixed> $context The context data passed to the template.
+	 *
+	 * @return string|null The alternate template HTML, or the original value.
+	 */
+	public function render_my_tickets_user_details( $html, $file, $name, $template, $context ) {
+		$name = is_array( $name ) ? implode( '/', $name ) : $name;
+
+		if ( 'tickets/my-tickets/user-details' !== $name ) {
+			return $html;
+		}
+
+		$attendees = $context['attendees'] ?? [];
+
+		if ( empty( $attendees ) || Constants::TC_RSVP_TYPE !== ( $attendees[0]['ticket_type'] ?? '' ) ) {
+			return $html;
+		}
+
+		return $template->template( 'v2/commerce/rsvp/my-tickets/user-details', $context, false );
 	}
 
 	/**

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -321,14 +321,17 @@ class Frontend {
 			return;
 		}
 
+		$ticket_id         = (int) ( $attendee['product_id'] ?? 0 );
 		$attendee_is_going = metadata_exists( 'post', $attendee['ID'], Constants::RSVP_STATUS_META_KEY )
 			? tribe_is_truthy( get_post_meta( $attendee['ID'], Constants::RSVP_STATUS_META_KEY, true ) )
 			: true;
+		$show_not_going    = $ticket_id && tribe_is_truthy( get_post_meta( $ticket_id, Constants::SHOW_NOT_GOING_META_KEY, true ) );
 
 		tribe( 'tickets.editor.template' )->template(
 			'v2/commerce/rsvp/my-tickets/ticket-status',
 			[
 				'attendee_is_going' => $attendee_is_going,
+				'show_not_going'    => $show_not_going,
 				'attendee_id'       => $attendee['ID'],
 			]
 		);

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -873,6 +873,27 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
+	 * Verifies if we have RSVP V2 (Tickets Commerce backed) attendees for this user and event.
+	 *
+	 * RSVP V2 attendees are Tickets Commerce attendees (provider `tc`), so they are not caught
+	 * by `has_ticket_attendees()` (which excludes the TC-RSVP ticket type) nor by the RSVP V1
+	 * templates. This check lets the My Tickets page route them through the Tickets Commerce
+	 * templates that render the RSVP V2 UI.
+	 *
+	 * @since TBD
+	 *
+	 * @param int      $event_id The Event ID we're checking.
+	 * @param int|null $user_id  An Optional User ID.
+	 *
+	 * @return bool Whether the user has RSVP V2 attendees for the event.
+	 */
+	public function has_rsvp_v2_attendees( $event_id, $user_id = null ) {
+		$attendees = $this->get_event_rsvp_attendees( $event_id, $user_id );
+
+		return ! empty( $attendees ) && 'tc' === ( $attendees[0]['provider_slug'] ?? '' );
+	}
+
+	/**
 	 * Gets the name(s) of the type(s) of ticket(s) the specified user (optional) has for the specified event.
 	 *
 	 * @since 4.2

--- a/src/views/tickets/my-tickets/orders-list.php
+++ b/src/views/tickets/my-tickets/orders-list.php
@@ -13,6 +13,14 @@
  * @var  int    $post_id The ID of the post the tickets are for.
  */
 
+use TEC\Tickets\RSVP\V2\Constants;
+
+// Merge with any titles passed by the parent context (e.g. Event Tickets Plus), keeping
+// the default and RSVP ticket type titles available.
+$titles                              = (array) ( $titles ?? [] );
+$titles['default']                 ??= tec_tickets_get_default_ticket_type_label_lowercase( 'order list view' );
+$titles[ Constants::TC_RSVP_TYPE ] ??= tribe_get_rsvp_label_plural( 'order list view' );
+
 ?>
 <ul class="tribe-orders-list">
 	<input type="hidden" name="event_id" value="<?php echo absint( $post_id ); ?>">
@@ -41,6 +49,7 @@
 					'order'     => $order,
 					'attendees' => $attendees,
 					'order_id'  => $order_id,
+					'titles'    => $titles,
 				] );
 			?>
 		</li>

--- a/src/views/tickets/my-tickets/ticket-information.php
+++ b/src/views/tickets/my-tickets/ticket-information.php
@@ -14,6 +14,8 @@
  * @var array                   $attendee The attendee data.
  */
 
+use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
+
 ?>
 <div class="tribe-ticket-information">
 	<?php
@@ -22,7 +24,7 @@
 		$price = $provider->get_price_html( $attendee['product_id'], $attendee );
 	}
 	?>
-	<?php if ( ! empty( $attendee['ticket_exists'] ) ) : ?>
+	<?php if ( ! empty( $attendee['ticket_exists'] ) && RSVP_V2_Constants::TC_RSVP_TYPE !== ( $attendee['ticket_type'] ?? '' ) ) : ?>
 		<span class="ticket-name"><?php echo esc_html( $attendee['ticket'] ); ?></span>
 	<?php endif; ?>
 	<?php

--- a/src/views/tickets/orders-rsvp.php
+++ b/src/views/tickets/orders-rsvp.php
@@ -29,6 +29,13 @@ if ( ! $view->has_rsvp_attendees( $post_id, $user_id ) ) {
 	return;
 }
 
+// RSVP V2 attendees are Tickets Commerce attendees and render through the Tickets Commerce
+// My Tickets templates (`orders-tc-tickets.php`), which provide the V2 RSVP UI. Keep this
+// legacy list for RSVP V1 data only.
+if ( $view->has_rsvp_v2_attendees( $post_id, $user_id ) ) {
+	return;
+}
+
 $post_type_singular = $post_type ? $post_type->labels->singular_name : _x( 'Post', 'fallback post type singular name', 'event-tickets' );
 
 $attendee_groups = $view->get_event_rsvp_attendees_by_purchaser( $post_id, $user_id );

--- a/src/views/tickets/orders-tc-tickets.php
+++ b/src/views/tickets/orders-tc-tickets.php
@@ -16,7 +16,7 @@ $post      = get_post( $post_id );
 $post_type = get_post_type_object( $post->post_type );
 $user_id   = get_current_user_id();
 
-if ( ! $view->has_ticket_attendees( $post_id, $user_id ) ) {
+if ( ! $view->has_ticket_attendees( $post_id, $user_id ) && ! $view->has_rsvp_v2_attendees( $post_id, $user_id ) ) {
 	return;
 }
 

--- a/src/views/v2/commerce/rsvp/my-tickets/user-details.php
+++ b/src/views/v2/commerce/rsvp/my-tickets/user-details.php
@@ -1,19 +1,22 @@
 <?php
 /**
- * My Tickets: User Details
+ * RSVP V2: My Tickets - User Details
  *
- * Override this template in your own theme by creating a file at [your-theme]/tribe/tickets/tickets/my-tickets/user-details.php
+ * Renders the "Reserved by" details line for a TC-RSVP order on the My Tickets page, replacing
+ * `tickets/my-tickets/user-details.php` for RSVP orders (see
+ * `TEC\Tickets\RSVP\V2\Frontend::render_my_tickets_user_details()`).
  *
- * @since 5.6.7
- * @since 5.9.1 Corrected template override filepath
- * @since TBD Fixed the `mailto:` link escaping.
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/v2/commerce/rsvp/my-tickets/user-details.php
  *
- * @version 5.9.1
+ * @since TBD
  *
- * @var int    $order_id  The ID of the order.
- * @var array  $order     The order data.
- * @var array  $attendees The attendees for the current order.
- * @var int    $post_id   The ID of the post the tickets are for.
+ * @version TBD
+ *
+ * @var array $order     The order data.
+ * @var array $attendees The attendees for the current order.
+ * @var int   $order_id  The order ID.
+ * @var int   $post_id   The ID of the post the tickets are for.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,19 +29,9 @@ $purchase_time   = $order && ! empty( $order['purchase_time'] ) ? $order['purcha
 <div class="user-details">
 	<?php
 		printf(
-			// Translators: 1: order number, 2: count of attendees in the order, 3: ticket label (dynamically singular or plural), 4: purchaser name, 5: linked purchaser email, 6: date of purchase.
-			esc_html__( 'Order #%1$s: %2$d %3$s reserved by %4$s (%5$s) on %6$s', 'event-tickets' ),
-			(int) $order_id,
-			(int) count( $attendees ),
-			esc_html(
-				_n(
-					'Ticket',
-					'Tickets',
-					count( $attendees ),
-					'event-tickets'
-				)
-			),
-			esc_attr( $purchaser_name ),
+			// Translators: 1: attendee name, 2: linked attendee email, 3: date of RSVP.
+			esc_html__( 'Reserved by %1$s (%2$s) on %3$s', 'event-tickets' ),
+			esc_html( $purchaser_name ),
 			'<a href="' . esc_url( 'mailto:' . $purchaser_email ) . '">' . esc_html( $purchaser_email ) . '</a>',
 			esc_html( $purchase_time ? date_i18n( tribe_get_date_format( true ), strtotime( $purchase_time ) ) : __( 'Unknown Time (invalid order)', 'event-tickets' ) )
 		);
@@ -62,3 +55,4 @@ $purchase_time   = $order && ! empty( $order['purchase_time'] ) ? $order['purcha
 		do_action( 'tec_tickets_user_details_tickets', $attendees, $post_id );
 		?>
 </div>
+

--- a/tests/rsvp_v2_integration/RSVP/V2/My_Tickets_RSVP_List_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/My_Tickets_RSVP_List_Test.php
@@ -9,12 +9,14 @@ use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe__Tickets__Tickets_View as Tickets_View;
 
 /**
- * Regression tests for the classic My Tickets RSVP list flow
- * (the `tickets/orders-rsvp.php` template) when the event has TC-RSVP tickets.
+ * Regression tests for the classic My Tickets RSVP list flow when the event has TC-RSVP tickets.
  *
- * The RSVP V1 handler cannot build attendee data for TC-RSVP attendees: the V2
- * `Attendees::get_rsvp_attendees_by_user_id` implementation provides it through the
- * `tec_tickets_rsvp_get_attendees_by_user_id_pre` filter. These tests lock that flow.
+ * TC-RSVP attendees must NOT render through the legacy `tickets/orders-rsvp.php` template: they
+ * are Tickets Commerce attendees and render through the `tickets/orders-tc-tickets.php` ->
+ * `tickets/my-tickets` templates that provide the RSVP V2 UI. The RSVP V1 handler cannot build
+ * attendee data for TC-RSVP attendees, so the V2 `Attendees::get_rsvp_attendees_by_user_id`
+ * implementation provides it through the `tec_tickets_rsvp_get_attendees_by_user_id_pre` filter.
+ * These tests lock that flow.
  */
 class My_Tickets_RSVP_List_Test extends WPTestCase {
 	use Ticket_Maker;
@@ -108,6 +110,24 @@ class My_Tickets_RSVP_List_Test extends WPTestCase {
 		return tribe( 'tickets.editor.template' )->template( 'tickets/orders-rsvp', [], false );
 	}
 
+	/**
+	 * Renders the My Tickets TC tickets template the way the tickets page does: as the current user,
+	 * with the post set as the global post.
+	 *
+	 * @param int $post_id The post ID.
+	 * @param int $user_id The user ID to render as.
+	 *
+	 * @return string The rendered template HTML.
+	 */
+	private function render_orders_tc_tickets_template( int $post_id, int $user_id ): string {
+		wp_set_current_user( $user_id );
+
+		$GLOBALS['post'] = get_post( $post_id );
+		setup_postdata( $GLOBALS['post'] );
+
+		return tribe( 'tickets.editor.template' )->template( 'tickets/orders-tc-tickets', [], false );
+	}
+
 	public function test_should_return_tc_rsvp_attendees_for_user_and_event(): void {
 		// Arrange.
 		$fixture = $this->create_rsvp_fixture( 'yes' );
@@ -180,7 +200,7 @@ class My_Tickets_RSVP_List_Test extends WPTestCase {
 		$this->assertSame( 'Jane Doe', $group[0]['purchaser_name'] );
 	}
 
-	public function test_should_render_tc_rsvp_attendees_in_the_orders_rsvp_template(): void {
+	public function test_should_not_render_the_legacy_rsvp_list_for_tc_rsvp_attendees(): void {
 		// Arrange.
 		$fixture = $this->create_rsvp_fixture( 'yes' );
 
@@ -188,11 +208,22 @@ class My_Tickets_RSVP_List_Test extends WPTestCase {
 		$html = $this->render_orders_rsvp_template( $fixture['post_id'], $fixture['user_id'] );
 
 		// Assert.
-		$this->assertStringContainsString( 'tribe-rsvp-list', $html, 'The RSVP list should be rendered' );
-		$this->assertStringContainsString( 'Attendee 1', $html, 'The attendee label should be rendered' );
-		$this->assertStringContainsString( 'RSVPs', $html, 'The RSVP title should be rendered' );
-		$this->assertStringContainsString( 'tribe-answer-select', $html, 'The RSVP status selector should be rendered' );
-		$this->assertStringContainsString( 'Test User', $html, 'The purchaser name should be rendered' );
+		$this->assertSame( '', $html, 'TC-RSVP attendees should not render through the legacy RSVP list template' );
+	}
+
+	public function test_should_render_tc_rsvp_attendees_through_the_tc_my_tickets_templates(): void {
+		// Arrange.
+		$fixture = $this->create_rsvp_fixture( 'yes', 'Test User' );
+
+		// Act.
+		$html = $this->render_orders_tc_tickets_template( $fixture['post_id'], $fixture['user_id'] );
+
+		// Assert.
+		$this->assertStringContainsString( 'tribe-orders-list', $html, 'The Tickets Commerce orders list should be rendered' );
+		$this->assertStringContainsString( 'RSVPs', $html, 'The RSVP ticket type title should be rendered' );
+		$this->assertStringContainsString( 'Reserved by Test User', $html, 'The RSVP purchaser details should be rendered' );
+		$this->assertStringContainsString( 'ticket-status', $html, 'The RSVP response status should be rendered' );
+		$this->assertStringContainsString( 'Test User', $html, 'The attendee name should be rendered' );
 	}
 
 	public function test_should_not_render_the_rsvp_list_for_users_without_rsvps(): void {
@@ -205,5 +236,21 @@ class My_Tickets_RSVP_List_Test extends WPTestCase {
 
 		// Assert.
 		$this->assertSame( '', $html, 'The template should not render for users without RSVPs' );
+	}
+
+	public function test_should_detect_tc_rsvp_attendees_for_the_user_and_event(): void {
+		// Arrange.
+		$fixture       = $this->create_rsvp_fixture( 'yes' );
+		$other_user_id = static::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		// Act & Assert.
+		$this->assertTrue(
+			Tickets_View::instance()->has_rsvp_v2_attendees( $fixture['post_id'], $fixture['user_id'] ),
+			'The user with TC-RSVP attendees should be detected as having RSVP V2 attendees'
+		);
+		$this->assertFalse(
+			Tickets_View::instance()->has_rsvp_v2_attendees( $fixture['post_id'], $other_user_id ),
+			'A user without RSVP attendees should not be detected as having RSVP V2 attendees'
+		);
 	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/My_Tickets_Template_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/My_Tickets_Template_Test.php
@@ -177,6 +177,46 @@ class My_Tickets_Template_Test extends WPTestCase {
 
 	/**
 	 * @test
+	 */
+	public function it_should_not_render_the_ticket_name_for_rsvp_attendees(): void {
+		$data     = $this->create_rsvp_fixture( false, 'yes', 'Jane Doe' );
+		$template = $this->get_template();
+
+		$html = $template->template(
+			'tickets/my-tickets/ticket-information',
+			[ 'attendee' => $data['attendee'] ],
+			false
+		);
+
+		$this->assertStringNotContainsString( 'ticket-name', $html, 'The RSVP ticket name should not be rendered for RSVP attendees' );
+		$this->assertStringNotContainsString( 'Test TC ticket', $html, 'The RSVP ticket title should not leak into the ticket information' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_the_ticket_name_for_non_rsvp_attendees(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+
+		$order     = $this->create_order( [ $ticket_id => 1 ] );
+		$attendees = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
+		$attendee  = $attendees[0];
+
+		$attendee['ticket_type'] = 'default';
+
+		$template = $this->get_template();
+		$html     = $template->template(
+			'tickets/my-tickets/ticket-information',
+			[ 'attendee' => $attendee ],
+			false
+		);
+
+		$this->assertStringContainsString( 'ticket-name', $html, 'The ticket name should still render for non-RSVP attendees' );
+	}
+
+	/**
+	 * @test
 	 * @dataProvider tickets_list_data_provider
 	 */
 	public function it_should_render_tickets_list( Closure $fixture ): void {

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_ticket_information_for_rsvp__RSVP going with show_not_going disabled__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_ticket_information_for_rsvp__RSVP going with show_not_going disabled__0.snapshot.html
@@ -1,6 +1,5 @@
 <div class="tribe-ticket-information">
-				<span class="ticket-name">Test TC ticket for {{ POST_ID }}</span>
-							<span class="ticket-status">
-				Response:				<span class="ticket-status-value">Going</span>
-			</span>
-					</div>
+				<span class="ticket-status">
+		Response:		<span class="ticket-status-value">Going</span>
+	</span>
+		</div>

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_ticket_information_for_rsvp__RSVP going with show_not_going enabled__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_ticket_information_for_rsvp__RSVP going with show_not_going enabled__0.snapshot.html
@@ -1,9 +1,8 @@
 <div class="tribe-ticket-information">
-				<span class="ticket-name">Test TC ticket for {{ POST_ID }}</span>
-							<span class="ticket-status">
-				Response:				<select name="attendee[{{ ATTENDEE_ID }}][order_status]" class="ticket-status-select">
-					<option value="going"  selected='selected'>Going</option>
-					<option value="not_going" >Not going</option>
-				</select>
-			</span>
-					</div>
+				<span class="ticket-status">
+		Response:		<select name="attendee[{{ ATTENDEE_ID }}][order_status]" class="ticket-status-select">
+			<option value="going"  selected='selected'>Going</option>
+			<option value="not_going" >Not going</option>
+		</select>
+	</span>
+		</div>

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_ticket_information_for_rsvp__RSVP not going with show_not_going enabled__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_ticket_information_for_rsvp__RSVP not going with show_not_going enabled__0.snapshot.html
@@ -1,9 +1,8 @@
 <div class="tribe-ticket-information">
-				<span class="ticket-name">Test TC ticket for {{ POST_ID }}</span>
-							<span class="ticket-status">
-				Response:				<select name="attendee[{{ ATTENDEE_ID }}][order_status]" class="ticket-status-select">
-					<option value="going" >Going</option>
-					<option value="not_going"  selected='selected'>Not going</option>
-				</select>
-			</span>
-					</div>
+				<span class="ticket-status">
+		Response:		<select name="attendee[{{ ATTENDEE_ID }}][order_status]" class="ticket-status-select">
+			<option value="going" >Going</option>
+			<option value="not_going"  selected='selected'>Not going</option>
+		</select>
+	</span>
+		</div>

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_tickets_list__RSVP attendee with holder name__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/My_Tickets_Template_Test__it_should_render_tickets_list__RSVP attendee with holder name__0.snapshot.html
@@ -8,11 +8,10 @@
 					<input type="hidden" name="attendee[{{ ORDER_ID }}][attendees][]" value="{{ ATTENDEE_ID }}">
 					<div class="list-attendee">
 	Jane Doe</div>					<div class="tribe-ticket-information">
-				<span class="ticket-name">Test TC ticket for {{ POST_ID }}</span>
-							<span class="ticket-status">
-				Response:				<span class="ticket-status-value">Going</span>
-			</span>
-					</div>
+				<span class="ticket-status">
+		Response:		<span class="ticket-status-value">Going</span>
+	</span>
+		</div>
 									</li>
 					</ul>
 			</div>

--- a/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__order with 1 regular tickets__0.snapshot.html
+++ b/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__order with 1 regular tickets__0.snapshot.html
@@ -3,7 +3,7 @@
 	<input type="hidden" name="event_id" value="{{ID}}">
 					<li class="tribe-item" id="order-{{ID}}">
 			 <div class="user-details">
-	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:http://test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
+	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
 	<div class="tec-tickets__my-tickets-list-title-container type-default">
 	<div class="tec-tickets__my-tickets-list-title">
 		standard ticket	</div>

--- a/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__order with 1 seated tickets with assigned seat__0.snapshot.html
+++ b/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__order with 1 seated tickets with assigned seat__0.snapshot.html
@@ -3,7 +3,7 @@
 	<input type="hidden" name="event_id" value="{{ID}}">
 					<li class="tribe-item" id="order-{{ID}}">
 			 <div class="user-details">
-	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:http://test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
+	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
 	<div class="tec-tickets__my-tickets-list-title-container type-default">
 	<div class="tec-tickets__my-tickets-list-title">
 		standard ticket	</div>

--- a/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__order with 1 seated tickets without assigned seat__0.snapshot.html
+++ b/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__order with 1 seated tickets without assigned seat__0.snapshot.html
@@ -3,7 +3,7 @@
 	<input type="hidden" name="event_id" value="{{ID}}">
 					<li class="tribe-item" id="order-{{ID}}">
 			 <div class="user-details">
-	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:http://test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
+	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
 	<div class="tec-tickets__my-tickets-list-title-container type-default">
 	<div class="tec-tickets__my-tickets-list-title">
 		standard ticket	</div>

--- a/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__regular post with tickets__0.snapshot.html
+++ b/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_my_tickets_page_has_seat_info__regular post with tickets__0.snapshot.html
@@ -3,7 +3,7 @@
 	<input type="hidden" name="event_id" value="{{ID}}">
 					<li class="tribe-item" id="order-{{ID}}">
 			 <div class="user-details">
-	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:http://test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
+	Order #{{ID}}: 1 Ticket reserved by Test Purchaser (<a href="mailto:test-purchaser@test.com">test-purchaser@test.com</a>) on {{order_date}}</div>
 	<div class="tec-tickets__my-tickets-list-title-container type-default">
 	<div class="tec-tickets__my-tickets-list-title">
 		standard ticket	</div>


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4179](https://linear.app/nexcess/issue/SOFT-4179/my-tickets-page-ui-changes-missing-on-migrated-sites)

Depends on: https://github.com/the-events-calendar/event-tickets-plus/pull/2137

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - RSVP display missing on migrated sites)

Resolved an issue where RSVP V2 attendees were not routed through the Tickets Commerce My Tickets templates on migrated sites, leaving their RSVPs invisible or rendered with the legacy UI. RSVP orders now render the "Reserved by" details line and the attendee response ("Response: Going"/"Not going") without the redundant RSVP ticket name, status changes via the "Can't go" dropdown work as expected, and `get_product_title()` was corrected to return the actual ticket title instead of an undefined property. The legacy RSVP list is now skipped whenever TC-RSVP attendees are present, and template output is guarded so existing V1 RSVP and paid-ticket display is unchanged.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/11989a32123d492a910fed6ca4ab8109

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
