### PR TITLE
[SOFT-3334] Fix RSVP persistence in the block editor so IAC/ARF attendee information can be configured

### DIFF
--- a/src/modules/data/blocks/rsvp-shared/__tests__/sagas.test.js
+++ b/src/modules/data/blocks/rsvp-shared/__tests__/sagas.test.js
@@ -286,7 +286,7 @@ describe( 'RSVP shared block sagas', () => {
 	} );
 
 	describe( 'initializeRSVP', () => {
-		let state;
+		let state, startMomentMock, endMomentMock;
 		beforeEach( () => {
 			state = {
 				startDate: 'January 1, 2018',
@@ -294,6 +294,8 @@ describe( 'RSVP shared block sagas', () => {
 				endDate: 'January 4, 2018',
 				endTime: '23:32',
 			};
+			startMomentMock = { isAfter: jest.fn() };
+			endMomentMock = { isAfter: jest.fn() };
 			global.window = global.window || {};
 			window.tec = {
 				events: {
@@ -319,13 +321,14 @@ describe( 'RSVP shared block sagas', () => {
 		} );
 
 		it( 'should initialize state from datetime block', () => {
+			endMomentMock.isAfter.mockReturnValue( true );
 			const gen = sagas.initializeRSVP();
 
 			expect( gen.next().value ).toMatchSnapshot();
 			expect( gen.next( state.startDate ).value ).toMatchSnapshot();
 
 			expect( gen.next( {
-				moment: state.startDate,
+				moment: startMomentMock,
 				date: state.startDate,
 				dateInput: state.startDate,
 				time: state.startTime,
@@ -334,12 +337,12 @@ describe( 'RSVP shared block sagas', () => {
 				all( [
 					put( actions.setRSVPStartDate( state.startDate ) ),
 					put( actions.setRSVPStartDateInput( state.startDate ) ),
-					put( actions.setRSVPStartDateMoment( state.startDate ) ),
+					put( actions.setRSVPStartDateMoment( startMomentMock ) ),
 					put( actions.setRSVPStartTime( state.startTime ) ),
 					put( actions.setRSVPStartTimeInput( state.startTime ) ),
 					put( actions.setRSVPTempStartDate( state.startDate ) ),
 					put( actions.setRSVPTempStartDateInput( state.startDate ) ),
-					put( actions.setRSVPTempStartDateMoment( state.startDate ) ),
+					put( actions.setRSVPTempStartDateMoment( startMomentMock ) ),
 					put( actions.setRSVPTempStartTime( state.startTime ) ),
 					put( actions.setRSVPTempStartTimeInput( state.startTime ) ),
 				] ),
@@ -352,7 +355,7 @@ describe( 'RSVP shared block sagas', () => {
 			);
 			expect( gen.next( state.endDate ).value ).toMatchSnapshot();
 			expect( gen.next( {
-				moment: state.endDate,
+				moment: endMomentMock,
 				date: state.endDate,
 				dateInput: state.endDate,
 				time: state.endTime,
@@ -361,17 +364,46 @@ describe( 'RSVP shared block sagas', () => {
 				all( [
 					put( actions.setRSVPEndDate( state.endDate ) ),
 					put( actions.setRSVPEndDateInput( state.endDate ) ),
-					put( actions.setRSVPEndDateMoment( state.endDate ) ),
+					put( actions.setRSVPEndDateMoment( endMomentMock ) ),
 					put( actions.setRSVPEndTime( state.endTime ) ),
 					put( actions.setRSVPEndTimeInput( state.endTime ) ),
 					put( actions.setRSVPTempEndDate( state.endDate ) ),
 					put( actions.setRSVPTempEndDateInput( state.endDate ) ),
-					put( actions.setRSVPTempEndDateMoment( state.endDate ) ),
+					put( actions.setRSVPTempEndDateMoment( endMomentMock ) ),
 					put( actions.setRSVPTempEndTime( state.endTime ) ),
 					put( actions.setRSVPTempEndTimeInput( state.endTime ) ),
 				] ),
 			);
 			expect( gen.next().value ).toEqual(
+				call( sagas.handleRSVPDurationError ),
+			);
+			expect( gen.next().done ).toEqual( true );
+		} );
+
+		it( 'should not sync the end date when the event starts before the RSVP start time', () => {
+			endMomentMock.isAfter.mockReturnValue( false );
+			const gen = sagas.initializeRSVP();
+
+			gen.next();
+			gen.next( state.startDate );
+			gen.next( {
+				moment: startMomentMock,
+				date: state.startDate,
+				dateInput: state.startDate,
+				time: state.startTime,
+				timeInput: state.startTime,
+			} );
+			gen.next();
+			gen.next( true );
+			gen.next( state.endDate );
+
+			expect( gen.next( {
+				moment: endMomentMock,
+				date: state.endDate,
+				dateInput: state.endDate,
+				time: state.endTime,
+				timeInput: state.endTime,
+			} ).value ).toEqual(
 				call( sagas.handleRSVPDurationError ),
 			);
 			expect( gen.next().done ).toEqual( true );

--- a/src/modules/data/blocks/rsvp-shared/sagas.js
+++ b/src/modules/data/blocks/rsvp-shared/sagas.js
@@ -148,26 +148,33 @@ export function* initializeRSVP() {
 		if ( yield call( isTribeEventPostType ) ) {
 			// NOTE: This requires TEC to be installed, if not installed, do not set an end date
 			const eventStart = yield select( window.tec.events.app.main.data.blocks.datetime.selectors.getStart ); // RSVP window should end when event starts... ideally
-			const {
-				moment: endMoment,
-				date: endDate,
-				dateInput: endDateInput,
-				time: endTime,
-				timeInput: endTimeInput,
-			} = yield call( createDates, eventStart );
+			const endData = yield call( createDates, eventStart );
 
-			yield all( [
-				put( actions.setRSVPEndDate( endDate ) ),
-				put( actions.setRSVPEndDateInput( endDateInput ) ),
-				put( actions.setRSVPEndDateMoment( endMoment ) ),
-				put( actions.setRSVPEndTime( endTime ) ),
-				put( actions.setRSVPEndTimeInput( endTimeInput ) ),
-				put( actions.setRSVPTempEndDate( endDate ) ),
-				put( actions.setRSVPTempEndDateInput( endDateInput ) ),
-				put( actions.setRSVPTempEndDateMoment( endMoment ) ),
-				put( actions.setRSVPTempEndTime( endTime ) ),
-				put( actions.setRSVPTempEndTimeInput( endTimeInput ) ),
-			] );
+			// Only sync the RSVP end to the event start when the event starts after the
+			// RSVP start time. Syncing to an earlier event start would invert the window
+			// (end before start), which blocks RSVP persistence with a duration error.
+			if ( endData.moment.isAfter( startMoment ) ) {
+				const {
+					moment: endMoment,
+					date: endDate,
+					dateInput: endDateInput,
+					time: endTime,
+					timeInput: endTimeInput,
+				} = endData;
+
+				yield all( [
+					put( actions.setRSVPEndDate( endDate ) ),
+					put( actions.setRSVPEndDateInput( endDateInput ) ),
+					put( actions.setRSVPEndDateMoment( endMoment ) ),
+					put( actions.setRSVPEndTime( endTime ) ),
+					put( actions.setRSVPEndTimeInput( endTimeInput ) ),
+					put( actions.setRSVPTempEndDate( endDate ) ),
+					put( actions.setRSVPTempEndDateInput( endDateInput ) ),
+					put( actions.setRSVPTempEndDateMoment( endMoment ) ),
+					put( actions.setRSVPTempEndTime( endTime ) ),
+					put( actions.setRSVPTempEndTimeInput( endTimeInput ) ),
+				] );
+			}
 		}
 	} catch ( error ) {
 		// ¯\_(ツ)_/¯


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3334](https://linear.app/nexcess/issue/SOFT-3334)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - RSVP block-editor persistence)

Resolved an issue where creating a new RSVP in the block editor failed to persist after save, causing the block to revert to the "Add an RSVP" prompt and blocking the IAC/ARF "Attendee Information" modal from being reached. On event post types the RSVP end date was synced to the event start time even when the event started before the RSVP start time, inverting the sales window (end before start), which triggered a duration error and silently aborted ticket creation. The end date is now only synced to the event start when the window stays valid, so the RSVP ticket saves and the IAC/ARF attendee-information UI is reachable on sites with Event Tickets Plus.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/9994dfc164834571b696ca2018974c66

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
