### PR TITLE
[SOFT-4173] Add regression tests for the Remove RSVP container

### DIFF
--- a/src/modules/blocks/rsvp-v2/remove-rsvp/__tests__/container.test.js
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/__tests__/container.test.js
@@ -1,0 +1,150 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+jest.mock( 'react-redux', () => {
+	const React = require( 'react' );
+
+	return {
+		connect: ( mapStateToProps, mapDispatchToProps, mergeProps ) => ( Component ) => ( ownProps ) =>
+			React.createElement(
+				Component,
+				mergeProps( mapStateToProps( {} ), { dispatch: jest.fn() }, ownProps )
+			),
+	};
+} );
+
+jest.mock( '@moderntribe/common/hoc', () => ( {
+	withStore: () => ( Component ) => Component,
+} ) );
+
+jest.mock( '../../../../data/blocks/rsvp-v2', () => ( {
+	actions: {
+		deleteRSVP: jest.fn( () => ( { type: 'DELETE_RSVP' } ) ),
+		setRSVPIsInitializing: jest.fn( ( isInitializing ) => ( {
+			type: 'SET_RSVP_IS_INITIALIZING',
+			payload: { isInitializing },
+		} ) ),
+	},
+	selectors: {
+		getRSVPCreated: jest.fn(),
+		getRSVPIsLoading: jest.fn(),
+		getRSVPSettingsOpen: jest.fn(),
+		getRSVPId: jest.fn(),
+	},
+	thunks: {
+		deleteRSVP: jest.fn( ( id ) => ( { type: 'DELETE_RSVP_THUNK', id } ) ),
+	},
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import RSVPRemoveRsvpContainer, { mapStateToProps, mergeProps } from '../container';
+import { actions, selectors, thunks } from '../../../../data/blocks/rsvp-v2';
+
+describe( 'RSVP V2 Remove RSVP', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.confirm = jest.fn();
+	} );
+
+	describe( 'mapStateToProps', () => {
+		it( 'should map the RSVP state to props', () => {
+			selectors.getRSVPCreated.mockReturnValue( true );
+			selectors.getRSVPSettingsOpen.mockReturnValue( false );
+			selectors.getRSVPIsLoading.mockReturnValue( true );
+			selectors.getRSVPId.mockReturnValue( 42 );
+
+			expect( mapStateToProps( {} ) ).toEqual( {
+				created: true,
+				isDisabled: false,
+				isLoading: true,
+				rsvpId: 42,
+			} );
+		} );
+	} );
+
+	describe( 'mergeProps onRemove', () => {
+		const createOnRemove = ( { created = false, rsvpId = null } = {} ) => {
+			selectors.getRSVPCreated.mockReturnValue( created );
+			selectors.getRSVPId.mockReturnValue( rsvpId );
+
+			const dispatch = jest.fn();
+			const { onRemove } = mergeProps(
+				{ created, isDisabled: false, isLoading: false, rsvpId },
+				{ dispatch },
+				{}
+			);
+
+			return { dispatch, onRemove };
+		};
+
+		it( 'should not dispatch anything when the user declines the confirmation', async () => {
+			window.confirm.mockReturnValue( false );
+			const { dispatch, onRemove } = createOnRemove( { created: true, rsvpId: 42 } );
+
+			await onRemove();
+
+			expect( thunks.deleteRSVP ).not.toHaveBeenCalled();
+			expect( dispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should delete the RSVP via thunk when created and then reset the state', async () => {
+			window.confirm.mockReturnValue( true );
+			const { dispatch, onRemove } = createOnRemove( { created: true, rsvpId: 42 } );
+
+			await onRemove();
+
+			expect( thunks.deleteRSVP ).toHaveBeenCalledWith( 42 );
+			expect( dispatch.mock.calls.map( ( [ action ] ) => action.type ) ).toEqual( [
+				'DELETE_RSVP_THUNK',
+				'DELETE_RSVP',
+				'SET_RSVP_IS_INITIALIZING',
+			] );
+		} );
+
+		it( 'should reset the state without deleting when the RSVP is not created yet', async () => {
+			window.confirm.mockReturnValue( true );
+			const { dispatch, onRemove } = createOnRemove();
+
+			await onRemove();
+
+			expect( thunks.deleteRSVP ).not.toHaveBeenCalled();
+			expect( dispatch ).toHaveBeenCalledWith( actions.deleteRSVP() );
+			expect( dispatch ).toHaveBeenCalledWith( actions.setRSVPIsInitializing( false ) );
+		} );
+
+		it( 'should reset the state without deleting when there is no RSVP ID', async () => {
+			window.confirm.mockReturnValue( true );
+			const { dispatch, onRemove } = createOnRemove( { created: true, rsvpId: null } );
+
+			await onRemove();
+
+			expect( thunks.deleteRSVP ).not.toHaveBeenCalled();
+			expect( dispatch ).toHaveBeenCalledWith( actions.deleteRSVP() );
+			expect( dispatch ).toHaveBeenCalledWith( actions.setRSVPIsInitializing( false ) );
+		} );
+	} );
+
+	describe( 'RSVPRemoveRsvpContainer', () => {
+		const render = ( props ) =>
+			renderer.create( <RSVPRemoveRsvpContainer clientId="client-1" { ...props } /> );
+
+		it( 'should render nothing when the RSVP is not created', () => {
+			expect( render( { created: false, isSelected: true } ).toJSON() ).toBeNull();
+		} );
+
+		it( 'should render nothing when the block is not selected', () => {
+			expect( render( { created: true, isSelected: false } ).toJSON() ).toBeNull();
+		} );
+
+		it( 'should render the remove button when created and selected', () => {
+			selectors.getRSVPSettingsOpen.mockReturnValue( false );
+			selectors.getRSVPIsLoading.mockReturnValue( false );
+
+			expect( render( { created: true, isSelected: true } ).toJSON() ).not.toBeNull();
+		} );
+	} );
+} );

--- a/src/modules/blocks/rsvp-v2/remove-rsvp/container.js
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/container.js
@@ -12,14 +12,14 @@ import { withStore } from '@moderntribe/common/hoc';
 import { actions, selectors, thunks } from '../../../data/blocks/rsvp-v2';
 import RSVPRemoveRsvp from './template';
 
-const mapStateToProps = ( state ) => ( {
+export const mapStateToProps = ( state ) => ( {
 	created: selectors.getRSVPCreated( state ),
 	isDisabled: selectors.getRSVPSettingsOpen( state ),
 	isLoading: selectors.getRSVPIsLoading( state ),
 	rsvpId: selectors.getRSVPId( state ),
 } );
 
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+export const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const { dispatch } = dispatchProps;
 
 	return {


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4173](https://linear.app/nexcess/issue/SOFT-4173/remove-rsvp-option-should-not-remove-the-entire-block)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Tweak** (test coverage - missing regression tests for the remove RSVP fix)

Added the jest coverage that was missing from the original SOFT-4173 fix in PR #4394. The new suite covers the container's state mapping, the onRemove confirmation flow (declined confirm, deletion via thunk, and the not-yet-created reset path), and the null guard that keeps the option from removing the entire block. Exported `mapStateToProps` and `mergeProps` to make the container logic testable, matching the sibling `attendee-registration-link` container.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/9a0d603cefb14a8b8d92807547729d86

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
