### PR TITLE
[SOFT-3324] Remove Ticket Header image setting

### DIFF
--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\RSVP\V2;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Tickets\RSVP\RSVP_Controller_Methods;
+use Tribe__Template as Template;
 
 /**
  * Class Controller
@@ -97,6 +98,14 @@ class Controller extends Controller_Contract {
 			'save_post',
 			$this->container->callback( Classic_Editor::class, 'save_rsvp_on_post_save' ),
 			20
+		);
+
+		// Hide the ticket header image option from the settings panel for posts with TC-RSVP tickets.
+		add_filter(
+			'tribe_template_pre_html:tickets/admin-views/editor/panel/header-image',
+			[ $this, 'hide_header_image_from_ticket_settings' ],
+			10,
+			5
 		);
 
 		// Block Editor.
@@ -313,6 +322,11 @@ class Controller extends Controller_Contract {
 			'save_post',
 			$this->container->callback( Classic_Editor::class, 'save_rsvp_on_post_save' ),
 			20
+		);
+		remove_filter(
+			'tribe_template_pre_html:tickets/admin-views/editor/panel/header-image',
+			[ $this, 'hide_header_image_from_ticket_settings' ],
+			10
 		);
 		remove_filter(
 			'tribe_editor_config',
@@ -609,6 +623,30 @@ class Controller extends Controller_Contract {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Hides the ticket header image option from the settings panel when the post has TC-RSVP tickets.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|string         $html     The initial HTML.
+	 * @param string              $file     Complete path to include the PHP File.
+	 * @param string[]            $name     Template name.
+	 * @param ?Template           $template Current instance of the Tribe__Template.
+	 * @param array<string,mixed> $context  The context data passed to the template.
+	 *
+	 * @return null|string|false The initial HTML, or `false` to prevent the template from rendering.
+	 */
+	public function hide_header_image_from_ticket_settings( ?string $html = null, string $file = '', array $name = [], ?Template $template = null, array $context = [] ) {
+		if ( ! isset( $context['post_id'] ) ) {
+			return $html;
+		}
+
+		$repository = tribe( 'tickets.ticket-repository.rsvp' );
+		$has_rsvp   = $repository->by( 'event', (int) $context['post_id'] )->found();
+
+		return $has_rsvp ? false : $html;
 	}
 
 	/**

--- a/tests/rsvp_v2_integration/RSVP/V2/Controller_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Controller_Test.php
@@ -4,8 +4,49 @@ namespace TEC\Tickets\RSVP\V2;
 
 use TEC\Common\Tests\Provider\Controller_Test_Case;
 use TEC\Tickets\RSVP\RSVP_Disabled;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 
 class Controller_Test extends Controller_Test_Case {
 
+	use Ticket_Maker;
+
 	protected string $controller_class = Controller::class;
+
+	/**
+	 * @test
+	 */
+	public function it_should_hide_the_header_image_option_for_posts_with_tc_rsvp_tickets(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$this->create_tc_rsvp_ticket( $post_id );
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$html = tribe( 'tickets.admin.views' )->template(
+			'editor/panel/header-image',
+			[ 'post_id' => $post_id ],
+			false
+		);
+
+		$this->assertFalse( $html );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_the_header_image_option_for_posts_without_tc_rsvp_tickets(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$html = tribe( 'tickets.admin.views' )->template(
+			'editor/panel/header-image',
+			[ 'post_id' => $post_id ],
+			false
+		);
+
+		$this->assertIsString( $html );
+		$this->assertStringContainsString( 'tribe-tickets-image', $html );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3324](https://linear.app/nexcess/issue/SOFT-3324/remove-ticket-header-image-setting)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Tweak** (removed option)

Removed the Ticket Header image setting from the ticket settings panel for posts using RSVP V2, as the option is no longer relevant now that images are configured in the Email settings. The setting remains available for non-RSVP tickets.

### 🎥 Artifacts <!-- if applicable-->
<img width="1426" height="547" alt="Screenshot 2026-08-21 at 12 45 50" src="https://github.com/user-attachments/assets/97caf1fd-f6d0-48a4-99c9-7ef87f20a706" />

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
