### PR TITLE
[SOFT-3337] Attendees page

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -763,8 +763,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param int $post_id The post ID.
 		 */
 		public function clear_ticket_cache_for_post( $post_id ) {
-			// No post context (e.g. deleting an attendee) means there is nothing to clear.
-			if ( empty( $post_id ) ) {
+			// No post context (e.g. deleting an attendee) or a non-numeric value means there is nothing to clear.
+			if ( empty( $post_id ) || ! is_numeric( $post_id ) ) {
 				return;
 			}
 
@@ -774,7 +774,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$class = __CLASS__;
 
 			// Clear the request-scoped get_tickets() cache, sharing its key format via get_tickets_cache_key().
-			unset( $cache[ self::get_tickets_cache_key( $this->orm_provider, $post_id ) ] );
+			unset( $cache[ self::get_tickets_cache_key( $this->orm_provider, (int) $post_id ) ] );
 
 			$static_methods = [
 				'get_all_event_tickets',
@@ -807,10 +807,15 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return Tribe__Tickets__Ticket_Object[] List of ticket objects.
 		 */
 		public function get_tickets( $post_id, ?string $context = null ) {
+			// A non-numeric post ID (e.g. the `all` keyword of the "all attendees" CSV export) can never
+			// resolve to tickets; bail before reaching the strictly-typed cache key builder.
+			if ( ! is_numeric( $post_id ) ) {
+				return [];
+			}
 
 			/** @var Tribe__Cache $cache */
 			$cache = tribe( 'cache' );
-			$key   = self::get_tickets_cache_key( $this->orm_provider, $post_id );
+			$key   = self::get_tickets_cache_key( $this->orm_provider, (int) $post_id );
 
 			// Only the context-less list is cached: a context can change which tickets are returned.
 			$use_cache = null === $context;

--- a/tests/wpunit/Tribe/Tickets/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/TicketsTest.php
@@ -564,11 +564,12 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function empty_post_id_provider(): array {
 		return [
-			'null'         => [ null ],
-			'zero int'     => [ 0 ],
-			'zero string'  => [ '0' ],
-			'empty string' => [ '' ],
-			'false'        => [ false ],
+			'null'               => [ null ],
+			'zero int'           => [ 0 ],
+			'zero string'        => [ '0' ],
+			'empty string'       => [ '' ],
+			'false'              => [ false ],
+			'non-numeric string' => [ 'all' ],
 		];
 	}
 
@@ -655,5 +656,23 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 			Tickets::get_tickets_cache_key( 'rsvp', $post_id ),
 			Tickets::get_tickets_cache_key( 'tribe-commerce', $post_id )
 		);
+	}
+
+	/**
+	 * It should bail for the `all` keyword used by the "all attendees" CSV export.
+	 *
+	 * The export passes `all` as the event ID down to get_event_tickets(); the strictly-typed
+	 * cache key builder must never see it. Fetching tickets for `all` yields none, and the
+	 * builder itself stays strict.
+	 *
+	 * @test
+	 */
+	public function should_bail_for_the_all_keyword(): void {
+		// The full export path must not throw and should yield no tickets.
+		$this->assertSame( [], Tickets::get_event_tickets( 'all' ) );
+
+		// The cache key builder stays strictly typed: `all` is not a post ID.
+		$this->expectException( \TypeError::class );
+		Tickets::get_tickets_cache_key( 'rsvp', 'all' );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3337](https://linear.app/nexcess/issue/SOFT-3337/attendees-page)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - fatal error on the "all attendees" CSV export)
Fixed a fatal TypeError thrown when exporting attendees for all events (`event_id=all`): the export path passes the `all` keyword down to `get_event_tickets()`, which reached the strictly-typed `get_tickets_cache_key()` and crashed. `get_tickets()` and `clear_ticket_cache_for_post()` now bail on non-numeric post IDs before touching the typed cache key builder, restoring the pre-regression behavior where `all` yields no tickets instead of a fatal.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/587a7228476b4282b0021dabca272f95

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
