### PR TITLE
[SOFT-4170] Block editor: RSVP block not rendering right

### DIFF
--- a/src/Tickets/RSVP/V2/Block_Editor.php
+++ b/src/Tickets/RSVP/V2/Block_Editor.php
@@ -161,9 +161,9 @@ class Block_Editor {
 			self::EDITOR_MIRROR_STYLE,
 		];
 
-		$existing = isset( $args['editorStyle'] ) ? (array) $args['editorStyle'] : [];
+		$existing = isset( $args['editor_style_handles'] ) ? (array) $args['editor_style_handles'] : [];
 
-		$args['editorStyle'] = array_values( array_unique( array_merge( $existing, $canvas_styles ) ) );
+		$args['editor_style_handles'] = array_values( array_unique( array_merge( $existing, $canvas_styles ) ) );
 
 		return $args;
 	}

--- a/src/modules/blocks/rsvp-v2/frontend-mirror/style.pcss
+++ b/src/modules/blocks/rsvp-v2/frontend-mirror/style.pcss
@@ -2,6 +2,11 @@
 	width: 100%;
 }
 
+/* The frontend card border is not needed in the block editor canvas. */
+.tribe-editor__rsvp-frontend-mirror .tribe-tickets__rsvp-wrapper {
+	border: none;
+}
+
 /* Going count row: number + View Attendees link side by side. */
 .tribe-editor__rsvp-frontend-mirror__going-row {
 	align-items: center;

--- a/tests/rsvp_v2_integration/RSVP/V2/Block_Editor_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Block_Editor_Test.php
@@ -115,6 +115,37 @@ class Block_Editor_Test extends WPTestCase {
 		$this->assertArrayHasKey( 'rsvpV2', $config['tickets'], 'RSVP V2 config should be added' );
 	}
 
+	public function test_rsvp_block_editor_style_args_should_set_editor_style_handles(): void {
+		$args = apply_filters( 'register_block_type_args', [], 'tribe/rsvp' );
+
+		$this->assertArrayHasKey(
+			'editor_style_handles',
+			$args,
+			'RSVP block registration should include editor_style_handles so styles reach the editor canvas iframe'
+		);
+
+		$this->assertContains(
+			'tec-tickets-commerce-rsvp-style',
+			$args['editor_style_handles'],
+			'RSVP frontend styles should be part of the editor canvas styles'
+		);
+		$this->assertContains(
+			Block_Editor::EDITOR_MIRROR_STYLE,
+			$args['editor_style_handles'],
+			'RSVP editor mirror styles should be part of the editor canvas styles'
+		);
+	}
+
+	public function test_rsvp_block_editor_style_args_should_not_set_camel_case_editor_style(): void {
+		$args = apply_filters( 'register_block_type_args', [], 'tribe/rsvp' );
+
+		$this->assertArrayNotHasKey(
+			'editorStyle',
+			$args,
+			'WP_Block_Type ignores the camelCase editorStyle key; use editor_style_handles instead'
+		);
+	}
+
 	public function test_should_enqueue_tickets_block_assets_for_tickets_block(): void {
 		$parsed_block = [
 			'blockName' => 'tribe/tickets',


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4170](https://linear.app/nexcess/issue/SOFT-4170/block-editor-rsvp-button-too-greyed-out)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - block editor canvas not matching frontend)

Fixed the RSVP block editor canvas so it renders the same as the frontend. The RSVP block's editor styles were being registered under an unsupported `editorStyle` key, which WordPress silently ignored — so the frontend RSVP CSS never loaded in the editor canvas and the RSVP columns stacked full-width. The styles are now registered via `editor_style_handles`, and the frontend card border is removed in the editor-only mirror stylesheet. Added regression tests for the block registration args.


### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/7bef0e9ff88e415885f8b9f2d5e38998

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
