### PR TITLE
[SMTNC-1507] Stop PayPal SCA card payments stranding the buyer on the checkout loader

### DIFF
--- a/changelog/smtnc-1507-paypal-sca-checkout-stall
+++ b/changelog/smtnc-1507-paypal-sca-checkout-stall
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixed PayPal card payments that go through SCA/3DS, such as Swedish BankID, leaving the buyer on a spinning loader with no error: every failure now clears the loader and shows a message, the capture is recorded as soon as PayPal answers it, an approved order nothing captured is captured on the recheck, and the client token no longer reloads checkout out from under a card authentication.
+Fixed PayPal card payments that go through SCA/3DS, such as Swedish BankID, leaving the buyer on a spinning loader with no error: every failure now clears the loader and shows a message, the capture is recorded as soon as PayPal answers it, an approved order with nothing captured is captured on the recheck, and the client token no longer reloads checkout from under a card authentication.

--- a/changelog/smtnc-1507-paypal-sca-checkout-stall
+++ b/changelog/smtnc-1507-paypal-sca-checkout-stall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed PayPal card payments that go through SCA/3DS, such as Swedish BankID, leaving the buyer on a spinning loader with no error: every failure now clears the loader and shows a message, the capture is recorded as soon as PayPal answers it, an approved order nothing captured is captured on the recheck, and the client token no longer reloads checkout out from under a card authentication.

--- a/changelog/smtnc-1507-paypal-sca-checkout-stall
+++ b/changelog/smtnc-1507-paypal-sca-checkout-stall
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixed PayPal card payments that go through SCA/3DS, such as Swedish BankID, leaving the buyer on a spinning loader with no error: every failure now clears the loader and shows a message, the capture is recorded as soon as PayPal answers it, an approved order with nothing captured is captured on the recheck, and the client token no longer reloads checkout from under a card authentication.
+Resolved an issue where PayPal card payments that go through SCA/3DS, such as Swedish BankID, left the buyer on a spinning loader with no error: every failure now clears the loader and shows a message, the capture is recorded as soon as PayPal answers it, an approved order with nothing captured is captured on the recheck, and the client token no longer reloads checkout from under a card authentication.

--- a/src/Tickets/Commerce/Gateways/PayPal/Assets.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Assets.php
@@ -106,7 +106,7 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 					'data' => static function () {
 						return [
 							'orderEndpoint'        => tribe( Order_Endpoint::class )->get_route_url(),
-							'requestFailedMessage' => esc_html__( 'We could not confirm your payment. Check your PayPal account before trying again, so that you are not charged twice.', 'event-tickets' ),
+							'requestFailedMessage' => tribe( Order_Endpoint::class )->get_error_messages()['unconfirmed-capture'],
 							'advancedPayments'     => [
 								'fieldPlaceholders' => [
 									'cvv' => esc_html__( 'E.g.: 123', 'event-tickets' ),

--- a/src/Tickets/Commerce/Gateways/PayPal/Assets.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Assets.php
@@ -105,8 +105,9 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 					'name' => 'tecTicketsCommerceGatewayPayPalCheckout',
 					'data' => static function () {
 						return [
-							'orderEndpoint' => tribe( Order_Endpoint::class )->get_route_url(),
-							'advancedPayments' => [
+							'orderEndpoint'        => tribe( Order_Endpoint::class )->get_route_url(),
+							'requestFailedMessage' => esc_html__( 'We could not confirm your payment. Check your PayPal account before trying again, so that you are not charged twice.', 'event-tickets' ),
+							'advancedPayments'     => [
 								'fieldPlaceholders' => [
 									'cvv' => esc_html__( 'E.g.: 123', 'event-tickets' ),
 									'expirationDate' => esc_html__( 'E.g.: 03/26', 'event-tickets' ),

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -14,6 +14,7 @@ use TEC\Tickets\Commerce\Status\Denied;
 use TEC\Tickets\Commerce\Status\Not_Completed;
 use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Status\Status_Handler;
+use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\Status\Voided;
 use TEC\Tickets\Commerce\Success;
 use TEC\Tickets\Commerce\Values\Legacy_Value_Factory;
@@ -287,6 +288,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 	 *
 	 * @since 5.1.9
 	 * @since 5.27.6.1 Removed order data from response for failed orders.
+	 * @since TBD Records what PayPal answered and fails when it did not acknowledge a capture.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
@@ -301,13 +303,19 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 
 		$paypal_order_id = $request->get_param( 'order_id' );
 
-		$order = tec_tc_orders()->by_args( [
-			'status'           => tribe( Pending::class )->get_wp_slug(),
-			'gateway_order_id' => $paypal_order_id,
-		] )->first();
+		$order = tec_tc_orders()->by_args(
+			[
+				'status'           => 'any',
+				'gateway_order_id' => $paypal_order_id,
+			]
+		)->first();
 
 		if ( ! $order ) {
-			return new WP_Error( 'tec-tc-gateway-paypal-nonexistent-order-id', $messages['nonexistent-order-id'] );
+			return new WP_Error(
+				'tec-tc-gateway-paypal-nonexistent-order-id',
+				$messages['nonexistent-order-id'],
+				[ 'status' => 404 ]
+			);
 		}
 
 		$recheck = $request->get_param( 'recheck' );
@@ -316,18 +324,30 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			return $this->handle_recheck_order( $paypal_order_id, $order );
 		}
 
+		// An earlier request already captured this order, and capturing twice is an error at PayPal.
+		// Send the buyer to the order rather than asking them to pay for it again.
+		if ( ! $this->order_is_in_flight( $order ) ) {
+			return $this->settled_response( $order, $paypal_order_id );
+		}
+
 		$payer_id = $request->get_param( 'payer_id' );
 
 		$paypal_capture_response = tribe( Client::class )->capture_order( $paypal_order_id, $payer_id );
+
+		if ( ! $this->is_paypal_payload( $paypal_capture_response ) ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-failed-capture',
+				$messages['failed-capture'],
+				[ 'status' => 502 ]
+			);
+		}
 
 		$debug_header = tribe( Client::class )->get_debug_header();
 		if ( ! empty( $debug_header ) ) {
 			$paypal_capture_response['debug_id'] = $debug_header;
 		}
 
-		if (
-			'UNPROCESSABLE_ENTITY' === Arr::get( $paypal_capture_response, 'name' )
-		) {
+		if ( 'UNPROCESSABLE_ENTITY' === Arr::get( $paypal_capture_response, 'name' ) ) {
 			// Flag the order as Denied.
 			tribe( Order::class )->modify_status( $order->ID, Denied::SLUG, [
 				'gateway_payload' => $paypal_capture_response,
@@ -337,16 +357,33 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 				'tec-tc-gateway-paypal-failed-capture',
 				$messages['failed-capture'],
 				[
+					'status'  => 400,
 					'name'    => Arr::get( $paypal_capture_response, 'name' ),
-					'details' => Arr::get( $paypal_capture_response, 'details', [] ),
+					'details' => (array) Arr::get( $paypal_capture_response, 'details', [] ),
 				]
 			);
 		}
 
-		$response['success']  = true;
-		$response['order_id'] = $paypal_order_id;
+		// Record the capture before answering. The browser may never receive this response, and until
+		// the capture is on the order nothing on the site knows the money was taken.
+		$status = $this->settle_order_status( $order, $paypal_capture_response );
 
-		return new WP_REST_Response( $response );
+		if ( is_wp_error( $status ) ) {
+			return $status;
+		}
+
+		if ( null === $status ) {
+			// PayPal took the money but has not settled the order, which an authentication such as
+			// BankID finishes on its own side. The recheck is what waits for that.
+			$response['success']  = true;
+			$response['order_id'] = $paypal_order_id;
+
+			return new WP_REST_Response( $response );
+		}
+
+		// The capture answered, so the buyer has somewhere to go without a second round trip. A
+		// blocked or delayed recheck can no longer be what strands them.
+		return $this->settled_response( $order, $paypal_order_id, $status );
 	}
 
 	/**
@@ -354,73 +391,228 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 	 *
 	 * @since 5.4.0.2
 	 * @since 5.27.6.1 Removed order data from response for failed orders.
+	 * @since TBD Captures an approved order nothing captured yet, and stops writing unsettled PayPal
+	 *        states over the order.
 	 *
-	 * @param string   $order_id The PayPal order ID.
+	 * @param string  $order_id The PayPal order ID.
 	 * @param WP_Post $order    The TC Order object.
 	 *
-	 * @return bool|WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function handle_recheck_order( $order_id, $order ) {
+		$messages = $this->get_error_messages();
 
-		$paypal_order_response       = tribe( Client::class )->get_order( $order_id );
-		$paypal_order_status         = Arr::get( $paypal_order_response, [ 'status' ] );
-		$paypal_order_purchase_units = Arr::get( $paypal_order_response, [ 'purchase_units' ], [] );
-		$paypal_order_captures       = [];
-		$messages                    = $this->get_error_messages();
+		$paypal_order_response = tribe( Client::class )->get_order( $order_id );
 
-		foreach( $paypal_order_purchase_units as $unit ) {
-			if ( ! empty( $unit['payments']['captures'] ) ) {
-				$paypal_order_captures[] = $unit['payments']['captures'];
+		if ( ! $this->is_paypal_payload( $paypal_order_response ) ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-invalid-capture-status',
+				$messages['invalid-capture-status'],
+				[ 'status' => 502 ]
+			);
+		}
+
+		// The payer approved and nothing was captured, so either the capture request never reached
+		// PayPal or its answer never got back. Capturing here is what keeps a delayed or blocked round
+		// trip from leaving an approved order unpaid.
+		if (
+			Status::APPROVED === Arr::get( $paypal_order_response, 'status' )
+			&& null === $this->get_deciding_capture( $paypal_order_response )
+		) {
+			$paypal_capture_response = tribe( Client::class )->capture_order( $order_id );
+
+			if ( $this->is_paypal_payload( $paypal_capture_response ) ) {
+				$paypal_order_response = $paypal_capture_response;
 			}
 		}
 
-		if ( Status::CREATED === $paypal_order_status && ! empty( $paypal_order_captures ) ) {
-			$paypal_order_captures = array_shift( $paypal_order_captures );
-			if ( count( $paypal_order_captures ) > 1 ) {
-				// Sort the captures array by the update timestamp
-				usort( $paypal_order_captures, function( $a, $b ) {
-					return strtotime( $a['update_time'] ) <=> strtotime( $b['update_time'] );
-				} );
-			}
+		$status = $this->settle_order_status( $order, $paypal_order_response );
 
-			foreach( $paypal_order_captures as $capture ) {
-				$paypal_order_status = $capture['status'];
-				$final = $capture['final_capture'] ?? false;
+		if ( is_wp_error( $status ) ) {
+			return $status;
+		}
 
-				if ( $final ) {
-					break;
+		// The buyer leaves checkout either way. A payment PayPal has not settled yet keeps the order
+		// pending for the PAYMENT.CAPTURE.COMPLETED webhook to finish; what must not happen is holding
+		// the buyer on the loader over money they have already handed over.
+		return $this->settled_response( $order, $order_id, $status );
+	}
+
+	/**
+	 * Writes the state PayPal settled on onto the Tickets Commerce order.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post $order    The Tickets Commerce order.
+	 * @param array   $response A PayPal order or capture response.
+	 *
+	 * @return Status_Interface|WP_Error|null The status written, an error the buyer has to be told
+	 *                                        about, or null while PayPal has settled nothing.
+	 */
+	protected function settle_order_status( $order, array $response ) {
+		$messages      = $this->get_error_messages();
+		$paypal_status = $this->get_settled_status( $response );
+
+		if ( null === $paypal_status ) {
+			return null;
+		}
+
+		$status = tribe( Status::class )->convert_to_commerce_status( $paypal_status );
+
+		if ( ! $status ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-invalid-capture-status',
+				$messages['invalid-capture-status'],
+				[ 'status' => 500 ]
+			);
+		}
+
+		tribe( Order::class )->modify_status(
+			$order->ID,
+			$status->get_slug(),
+			[ 'gateway_payload' => $response ]
+		);
+
+		if ( in_array( $paypal_status, [ Status::FAILED, Status::DECLINED ], true ) ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-capture-declined',
+				$messages['capture-declined'],
+				[ 'status' => 402 ]
+			);
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Builds the response that takes the buyer off checkout and on to their order.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post               $order           The Tickets Commerce order.
+	 * @param string                $paypal_order_id The PayPal order ID.
+	 * @param Status_Interface|null $status          The status PayPal settled on, if it settled.
+	 *
+	 * @return WP_REST_Response
+	 */
+	protected function settled_response( $order, string $paypal_order_id, ?Status_Interface $status = null ): WP_REST_Response {
+		// When we have success we clear the cart.
+		tribe( Cart::class )->clear_cart();
+
+		return new WP_REST_Response(
+			[
+				'success'      => true,
+				'status'       => $status ? $status->get_slug() : Pending::SLUG,
+				'order_id'     => $order->ID,
+				'redirect_url' => add_query_arg( [ 'tc-order-id' => $paypal_order_id ], tribe( Success::class )->get_url() ),
+			]
+		);
+	}
+
+	/**
+	 * Resolves the status a PayPal response has settled on, if it has settled on one.
+	 *
+	 * The order status on its own is not an answer: an order reads COMPLETED as soon as a capture
+	 * exists, whatever that capture's own status is, and reads CREATED or APPROVED while the payer
+	 * finishes an authentication such as BankID. The capture, when there is one, is the authority.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $response A PayPal order or capture response.
+	 *
+	 * @return string|null The settled PayPal status, or null while the payment is still in flight.
+	 */
+	protected function get_settled_status( array $response ): ?string {
+		$capture = $this->get_deciding_capture( $response );
+		$status  = null !== $capture ? Arr::get( $capture, 'status' ) : Arr::get( $response, 'status' );
+
+		if ( ! is_string( $status ) || in_array( $status, $this->get_in_flight_statuses(), true ) ) {
+			return null;
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Picks the capture that decides a PayPal order out of its purchase units.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $response A PayPal order or capture response.
+	 *
+	 * @return array|null The deciding capture, or null when nothing has been captured.
+	 */
+	protected function get_deciding_capture( array $response ): ?array {
+		$captures = [];
+
+		foreach ( (array) Arr::get( $response, 'purchase_units', [] ) as $unit ) {
+			foreach ( (array) Arr::get( $unit, [ 'payments', 'captures' ], [] ) as $capture ) {
+				if ( ! empty( $capture['status'] ) ) {
+					$captures[] = $capture;
 				}
 			}
 		}
 
-		$status = tribe( Status::class )->convert_to_commerce_status( $paypal_order_status );
-
-		if ( ! $status ) {
-			return new WP_Error( 'tec-tc-gateway-paypal-invalid-capture-status', $messages['invalid-capture-status'] );
+		if ( empty( $captures ) ) {
+			return null;
 		}
 
-		$updated = tribe( Order::class )->modify_status( $order->ID, $status->get_slug(), [
-			'gateway_payload' => $paypal_order_response,
-		] );
+		usort(
+			$captures,
+			static function ( $a, $b ) {
+				return strtotime( Arr::get( $a, 'update_time', '' ) ) <=> strtotime( Arr::get( $b, 'update_time', '' ) );
+			}
+		);
 
-		if ( is_wp_error( $updated ) ) {
-			return $updated;
+		foreach ( $captures as $capture ) {
+			if ( ! empty( $capture['final_capture'] ) ) {
+				return $capture;
+			}
 		}
 
-		if ( in_array( $paypal_order_status, [ Status::FAILED, Status::DECLINED ], true ) ) {
-			return new WP_Error( 'tec-tc-gateway-paypal-capture-declined', $messages['capture-declined'] );
+		return end( $captures );
+	}
+
+	/**
+	 * PayPal statuses that mean the payment has not resolved yet.
+	 *
+	 * None of these may be written over the order. They map to Tickets Commerce statuses that generate
+	 * attendees or walk the order backwards out of pending, and reaching one of them means the money
+	 * has not been taken.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	protected function get_in_flight_statuses(): array {
+		return [
+			Status::CREATED,
+			Status::SAVED,
+			Status::APPROVED,
+			Status::PAYER_ACTION_REQUIRED,
+			Status::PENDING,
+		];
+	}
+
+	/**
+	 * Whether a Client response is a payload PayPal produced.
+	 *
+	 * A transport failure comes back as a WP_Error and a body the Client could not decode comes back
+	 * as the raw wp_remote_* response. Neither says anything about the payment, and treating either as
+	 * an answer is how a blocked request ends up reported as a successful capture.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $response A Client response.
+	 *
+	 * @return bool
+	 */
+	protected function is_paypal_payload( $response ): bool {
+		if ( is_wp_error( $response ) || ! is_array( $response ) ) {
+			return false;
 		}
 
-		$response['success']  = true;
-		$response['status']   = $status->get_slug();
-		$response['order_id'] = $order->ID;
-
-		// When we have success we clear the cart.
-		tribe( Cart::class )->clear_cart();
-
-		$response['redirect_url'] = add_query_arg( [ 'tc-order-id' => $order_id ], tribe( Success::class )->get_url() );
-
-		return new WP_REST_Response( $response );
+		return ! isset( $response['response'], $response['headers'] );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -325,21 +325,36 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 		}
 
 		// An earlier request already captured this order, and capturing twice is an error at PayPal.
-		// Send the buyer to the order rather than asking them to pay for it again.
+		// Report the status the order actually carries rather than asking the buyer to pay again.
 		if ( ! $this->order_is_in_flight( $order ) ) {
-			return $this->settled_response( $order, $paypal_order_id );
+			$settled = tribe( Status_Handler::class )->get_by_wp_slug( (string) get_post_status( $order->ID ) );
+
+			if ( ! $settled ) {
+				return new WP_Error(
+					'tec-tc-gateway-paypal-invalid-capture-status',
+					$messages['invalid-capture-status'],
+					[ 'status' => 500 ]
+				);
+			}
+
+			return $this->settled_response( $order, $paypal_order_id, $settled );
 		}
 
 		$payer_id = $request->get_param( 'payer_id' );
 
 		$paypal_capture_response = tribe( Client::class )->capture_order( $paypal_order_id, $payer_id );
 
+		// The capture got back nothing we can read: a transport failure, the five second default
+		// timeout, or a body PayPal did not fill in. PayPal may still have taken the money, so this is
+		// an unknown outcome and not a failed one. The recheck reads the order back and settles it
+		// either way, and captures it when nothing did. Ending the payment here instead tells the
+		// buyer to try again for a charge that may already have landed, and when the second order
+		// completes, end_duplicated_pending_orders archives the one that was actually paid.
 		if ( ! $this->is_paypal_payload( $paypal_capture_response ) ) {
-			return new WP_Error(
-				'tec-tc-gateway-paypal-failed-capture',
-				$messages['failed-capture'],
-				[ 'status' => 502 ]
-			);
+			$response['success']  = true;
+			$response['order_id'] = $paypal_order_id;
+
+			return new WP_REST_Response( $response );
 		}
 
 		$debug_header = tribe( Client::class )->get_debug_header();
@@ -420,10 +435,13 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 
 		$paypal_order_response = tribe( Client::class )->get_order( $order_id );
 
+		// Neither request reached PayPal, so whether the money moved is still unknown. This is the one
+		// error the buyer must not read as "try again": that is how an unconfirmed capture turns into
+		// a second charge.
 		if ( ! $this->is_paypal_payload( $paypal_order_response ) ) {
 			return new WP_Error(
-				'tec-tc-gateway-paypal-invalid-capture-status',
-				$messages['invalid-capture-status'],
+				'tec-tc-gateway-paypal-unconfirmed-capture',
+				$messages['unconfirmed-capture'],
 				[ 'status' => 502 ]
 			);
 		}
@@ -448,9 +466,18 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			return $status;
 		}
 
-		// The buyer leaves checkout either way. A payment PayPal has not settled yet keeps the order
-		// pending for the PAYMENT.CAPTURE.COMPLETED webhook to finish; what must not happen is holding
-		// the buyer on the loader over money they have already handed over.
+		// PayPal has taken no decision we can record. There is no webhook for this gateway, so nothing
+		// will finish the order later: sending the buyer to "Order Received" would promise a receipt
+		// and tickets that never arrive, and clearing the cart would remove their only way back. An
+		// error they can act on beats a success page that is not true.
+		if ( null === $status ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-unconfirmed-capture',
+				$messages['unconfirmed-capture'],
+				[ 'status' => 502 ]
+			);
+		}
+
 		return $this->settled_response( $order, $order_id, $status );
 	}
 
@@ -505,20 +532,20 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 	 *
 	 * @since TBD
 	 *
-	 * @param WP_Post               $order           The Tickets Commerce order.
-	 * @param string                $paypal_order_id The PayPal order ID.
-	 * @param Status_Interface|null $status          The status PayPal settled on, if it settled.
+	 * @param WP_Post          $order           The Tickets Commerce order.
+	 * @param string           $paypal_order_id The PayPal order ID.
+	 * @param Status_Interface $status          The status PayPal settled on.
 	 *
 	 * @return WP_REST_Response
 	 */
-	protected function settled_response( $order, string $paypal_order_id, ?Status_Interface $status = null ): WP_REST_Response {
+	protected function settled_response( $order, string $paypal_order_id, Status_Interface $status ): WP_REST_Response {
 		// When we have success we clear the cart.
 		tribe( Cart::class )->clear_cart();
 
 		return new WP_REST_Response(
 			[
 				'success'      => true,
-				'status'       => $status ? $status->get_slug() : Pending::SLUG,
+				'status'       => $status->get_slug(),
 				'order_id'     => $order->ID,
 				'redirect_url' => add_query_arg( [ 'tc-order-id' => $paypal_order_id ], tribe( Success::class )->get_url() ),
 			]
@@ -825,6 +852,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			'nonexistent-order-id'    => __( 'Provided Order id is not valid.', 'event-tickets' ),
 			'failed-capture'          => __( 'There was a problem while processing your payment, please try again.', 'event-tickets' ),
 			'capture-declined'        => __( 'Your payment was declined.', 'event-tickets' ),
+			'unconfirmed-capture'     => __( 'We could not confirm your payment. Check your PayPal account before trying again, so that you are not charged twice.', 'event-tickets' ),
 			'invalid-capture-status'  => __( 'There was a problem with the Order status change, please try again.', 'event-tickets' ),
 		];
 

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -518,7 +518,19 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			);
 		}
 
-		tribe( Order::class )->modify_status(
+		$updated = tribe( Order::class )->modify_status(
+			$order->ID,
+			$status->get_slug(),
+			[ 'gateway_payload' => $response ]
+		);
+
+		if ( ! $updated ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-unconfirmed-capture',
+				$messages['unconfirmed-capture'],
+				[ 'status' => 502 ]
+			);
+		}
 			$order->ID,
 			$status->get_slug(),
 			[ 'gateway_payload' => $response ]

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -524,17 +524,16 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			[ 'gateway_payload' => $response ]
 		);
 
-		if ( ! $updated ) {
+		// modify_status refuses a transition to the status the order already carries, so a recheck of
+		// an order an earlier request settled reports a failure that did not happen. Only a status
+		// that never made it onto the order is an unconfirmed capture.
+		if ( ! $updated && $status->get_wp_slug() !== get_post_status( $order->ID ) ) {
 			return new WP_Error(
 				'tec-tc-gateway-paypal-unconfirmed-capture',
 				$messages['unconfirmed-capture'],
 				[ 'status' => 502 ]
 			);
 		}
-			$order->ID,
-			$status->get_slug(),
-			[ 'gateway_payload' => $response ]
-		);
 
 		if ( ! $this->status_is_paid( $status ) ) {
 			return new WP_Error(

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -324,7 +324,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			return $this->handle_recheck_order( $paypal_order_id, $order );
 		}
 
-		// An earlier request already captured this order, and capturing twice is an error at PayPal.
+		// An earlier request already resolved this order, and capturing twice is an error at PayPal.
 		// Report the status the order actually carries rather than asking the buyer to pay again.
 		if ( ! $this->order_is_in_flight( $order ) ) {
 			$settled = tribe( Status_Handler::class )->get_by_wp_slug( (string) get_post_status( $order->ID ) );
@@ -334,6 +334,14 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 					'tec-tc-gateway-paypal-invalid-capture-status',
 					$messages['invalid-capture-status'],
 					[ 'status' => 500 ]
+				);
+			}
+
+			if ( ! $this->status_is_paid( $settled ) ) {
+				return new WP_Error(
+					'tec-tc-gateway-paypal-capture-declined',
+					$messages['capture-declined'],
+					[ 'status' => 402 ]
 				);
 			}
 
@@ -516,7 +524,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			[ 'gateway_payload' => $response ]
 		);
 
-		if ( in_array( $paypal_status, [ Status::FAILED, Status::DECLINED ], true ) ) {
+		if ( ! $this->status_is_paid( $status ) ) {
 			return new WP_Error(
 				'tec-tc-gateway-paypal-capture-declined',
 				$messages['capture-declined'],
@@ -525,6 +533,23 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Whether a status means the buyer paid and has tickets waiting for them.
+	 *
+	 * Only a paid order may be answered with the success page. Denied, Voided and anything else a
+	 * settled PayPal response maps to took no money and generated no attendees, so sending the buyer
+	 * there would promise a receipt that does not exist.
+	 *
+	 * @since TBD
+	 *
+	 * @param Status_Interface $status The status the order settled on.
+	 *
+	 * @return bool
+	 */
+	protected function status_is_paid( Status_Interface $status ): bool {
+		return $status->has_flags( [ 'complete' ] );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/REST/Order_Endpoint.php
@@ -364,6 +364,22 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			);
 		}
 
+		// PayPal answered with an error object rather than an order. RESOURCE_NOT_FOUND,
+		// PERMISSION_DENIED and the rest land here, and none of them mean the payment is still in
+		// flight. Without this they read as unsettled and the buyer is sent into a recheck that has
+		// nothing to find.
+		if ( ! isset( $paypal_capture_response['status'] ) && ! empty( $paypal_capture_response['name'] ) ) {
+			return new WP_Error(
+				'tec-tc-gateway-paypal-failed-capture',
+				$messages['failed-capture'],
+				[
+					'status'  => 400,
+					'name'    => Arr::get( $paypal_capture_response, 'name' ),
+					'details' => (array) Arr::get( $paypal_capture_response, 'details', [] ),
+				]
+			);
+		}
+
 		// Record the capture before answering. The browser may never receive this response, and until
 		// the capture is on the order nothing on the site knows the money was taken.
 		$status = $this->settle_order_status( $order, $paypal_capture_response );

--- a/src/Tickets/Commerce/Gateways/PayPal/Status.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Status.php
@@ -86,6 +86,18 @@ class Status {
 	CONST DECLINED = 'DECLINED';
 
 	/**
+	 * Order Capture Status in PayPal for captures PayPal has taken but not settled yet.
+	 *
+	 * Deliberately absent from the status map below: it is not an outcome, and a Tickets Commerce
+	 * status standing in for it would say the payment resolved when it has not.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const PENDING = 'PENDING';
+
+	/**
 	 * Default mapping from PayPal Status to Tickets Commerce
 	 *
 	 * @since 5.1.9

--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -76,6 +76,25 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	obj.isGenericError = true;
 
 	/**
+	 * Whether a payment is currently waiting on PayPal or on our endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @type {boolean}
+	 */
+	obj.paymentInFlight = false;
+
+	/**
+	 * Whether the client token expired while a payment was in flight, so the reload it asked for was
+	 * deferred until the buyer is idle again.
+	 *
+	 * @since TBD
+	 *
+	 * @type {boolean}
+	 */
+	obj.reloadWhenIdle = false;
+
+	/**
 	 * PayPal Checkout Selectors.
 	 *
 	 * @since 5.1.9
@@ -102,6 +121,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * Handles the creation of the orders via PayPal.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Marks the payment as no longer in flight.
 	 *
 	 * @param {Object} data       PayPal data passed to this method.
 	 * @param {jQuery} $container jQuery object of the tickets container.
@@ -110,6 +130,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleCancel = function ( data, $container ) {
 		tribe.tickets.debug.log( 'handleCancel', arguments );
+		obj.paymentInFlight = false;
 		$container.removeClass( obj.selectors.activePayment.className() );
 		obj.triggerCancelOrder( $container, data.orderID, null, null );
 	};
@@ -118,6 +139,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * Handles the creation of the orders via PayPal.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Clears the loader, which nothing else does when PayPal itself reports the error.
 	 *
 	 * @param {Object} error      PayPal data passed to this method.
 	 * @param {jQuery} $container jQuery object of the tickets container.
@@ -125,6 +147,8 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * @return {void}
 	 */
 	obj.handleGenericError = function ( error, $container ) {
+		obj.paymentInFlight = false;
+
 		// Bail out if there were other errors.
 		if ( ! obj.isGenericError ) {
 			// reset the flag.
@@ -133,6 +157,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 		}
 		tribe.tickets.debug.log( 'handleGenericError', arguments );
 		$container.removeClass( obj.selectors.activePayment.className() );
+		tribe.tickets.loader.hide( $container );
 
 		obj.showNotice( $container, error.title, error.content );
 	};
@@ -141,6 +166,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * Handles the click when one of the buttons were clicked.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Takes a reload the client token deferred while a payment was in flight.
 	 *
 	 * @param {jQuery} $container jQuery object of the tickets container.
 	 *
@@ -148,6 +174,11 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleClick = function ( $container ) {
 		tribe.tickets.debug.log( 'handleClick', arguments );
+
+		if ( obj.takeDeferredReload() ) {
+			return;
+		}
+
 		$container.addClass( obj.selectors.activePayment.className() );
 		obj.hideNotice( $container );
 	};
@@ -165,6 +196,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleCreateOrder = function ( data, actions, $container ) {
 		tribe.tickets.debug.log( 'handleCreateOrder', arguments );
+		obj.paymentInFlight = true;
 
 		return fetch( obj.orderEndpointUrl, {
 			method: 'POST',
@@ -210,6 +242,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 *
 	 * @since 5.1.9
 	 * @since 5.2.0 $container Param added.
+	 * @since TBD Ends the payment rather than leaving the loader up.
 	 *
 	 * @param {jQuery} $container To which container this handling is for.
 	 * @param {Object} data       Data returning from our endpoint.
@@ -218,7 +251,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleCreateOrderFail = function ( $container, data ) {
 		tribe.tickets.debug.log( 'handleCreateOrderFail', arguments );
-		obj.showNotice( $container, data.message, '' );
+		obj.endPayment( $container, obj.getFailureMessage( data ) );
 		obj.isGenericError = false;
 	};
 
@@ -227,6 +260,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 *
 	 * @since 5.1.9
 	 * @since 5.2.0 $container Param added.
+	 * @since TBD Ends the payment with a message instead of returning silently.
 	 *
 	 * @param {jQuery} $container To which container this handling is for.
 	 * @param {Object} error      Which error the fetch() threw on requesting our endpoints.
@@ -235,6 +269,8 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleCreateOrderError = function ( $container, error ) {
 		tribe.tickets.debug.log( 'handleCreateOrderError', arguments );
+		obj.endPayment( $container, tecTicketsCommerceGatewayPayPalCheckout.requestFailedMessage );
+		obj.isGenericError = false;
 	};
 
 	/**
@@ -270,7 +306,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 				}
 				return obj.handleApproveFail( data, actions, $container );
 			} )
-			.catch( obj.handleApproveError );
+			.catch( ( error ) => obj.handleApproveError( error, $container ) );
 	};
 
 	/**
@@ -305,18 +341,26 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 		} )
 			.then( ( response ) => response.json() )
 			.then( ( data ) => {
-				if ( data.success ) {
-					return obj.handleCheckSuccess( data, actions, $container );
+				if ( ! data.success ) {
+					return obj.handleApproveFail( data, actions, $container );
 				}
-				return obj.handleApproveFail( data, actions, $container );
+
+				// The capture settled the order, so there is nothing left for the recheck to wait on
+				// and no second round trip to be blocked on.
+				if ( data.redirect_url ) {
+					return obj.handleApproveSuccess( data, actions, $container );
+				}
+
+				return obj.handleCheckSuccess( data, actions, $container );
 			} )
-			.catch( obj.handleApproveError );
+			.catch( ( error ) => obj.handleApproveError( error, $container ) );
 	};
 
 	/**
 	 * When a successful request is completed to our Approval endpoint.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Ends the payment when the response carries no destination.
 	 *
 	 * @param         actions
 	 * @param         $container
@@ -326,6 +370,12 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleApproveSuccess = ( data, actions, $container ) => {
 		tribe.tickets.debug.log( 'handleApproveSuccess', data, actions );
+
+		if ( ! data.redirect_url ) {
+			obj.endPayment( $container, tecTicketsCommerceGatewayPayPalCheckout.requestFailedMessage );
+			return;
+		}
+
 		// If the Token has expired we refresh the browser.
 		window.location.replace( data.redirect_url );
 	};
@@ -334,6 +384,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * When a failed request is completed to our Approval endpoint.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Stopped reading the error shape unguarded.
 	 *
 	 * @param         actions
 	 * @param         $container
@@ -343,34 +394,87 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleApproveFail = ( data, actions, $container ) => {
 		tribe.tickets.debug.log( 'handleApproveFail', data, actions );
-
-		if ( 'UNPROCESSABLE_ENTITY' === data.data.name ) {
-			if ( 'INSTRUMENT_DECLINED' === data.data.details[ 0 ].issue ) {
-				obj.showNotice( $container, '', data.data.details[ 0 ].description );
-				// Recoverable state, per:
-				// return actions.restart();
-				// https://developer.paypal.com/docs/checkout/integration-features/funding-failure/
-			} else {
-				obj.showNotice( $container, '', data.message );
-			}
-		} else {
-			obj.showNotice( $container, '', data.message );
-		}
-
-		tribe.tickets.loader.hide( $container );
+		obj.endPayment( $container, obj.getFailureMessage( data ) );
 	};
 
 	/**
 	 * When a error happens on the fetch request to our Approval endpoint.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Ends the payment with a message instead of returning silently.
 	 *
-	 * @param {Object} error Which error the fetch() threw on requesting our endpoints.
+	 * @param {Object} error      Which error the fetch() threw on requesting our endpoints.
+	 * @param {jQuery} $container jQuery object of the tickets container.
 	 *
 	 * @return {void}
 	 */
-	obj.handleApproveError = function ( error ) {
+	obj.handleApproveError = function ( error, $container ) {
 		tribe.tickets.debug.log( 'handleApproveError', arguments );
+		obj.endPayment( $container, tecTicketsCommerceGatewayPayPalCheckout.requestFailedMessage );
+	};
+
+	/**
+	 * Takes the buyer off the loader and tells them where the payment ended.
+	 *
+	 * Every path out of a payment has to come through here. A handler that returns without clearing
+	 * the loader leaves the buyer watching a spinner with no way to tell whether they were charged.
+	 *
+	 * @since TBD
+	 *
+	 * @param {jQuery} $container jQuery object of the tickets container.
+	 * @param {string} message    What to tell the buyer.
+	 *
+	 * @return {void}
+	 */
+	obj.endPayment = ( $container, message ) => {
+		obj.paymentInFlight = false;
+
+		if ( ! $container || ! $container.length ) {
+			$container = $( tribe.tickets.commerce.selectors.checkoutContainer );
+		}
+
+		$container.removeClass( obj.selectors.activePayment.className() );
+		tribe.tickets.loader.hide( $container );
+		obj.showNotice( $container, '', message );
+	};
+
+	/**
+	 * Reads the message for a rejected payment out of whichever shape the endpoint answered with.
+	 *
+	 * @since TBD
+	 *
+	 * @param {Object} data Data returning from our endpoint.
+	 *
+	 * @return {string} The message to show the buyer.
+	 */
+	obj.getFailureMessage = ( data ) => {
+		const details = data?.data?.details;
+		const declined = Array.isArray( details ) ? details[ 0 ] : null;
+
+		// Recoverable state, per:
+		// https://developer.paypal.com/docs/checkout/integration-features/funding-failure/
+		if ( 'INSTRUMENT_DECLINED' === declined?.issue && declined?.description ) {
+			return declined.description;
+		}
+
+		return data?.message || tecTicketsCommerceGatewayPayPalCheckout.requestFailedMessage;
+	};
+
+	/**
+	 * Performs a reload the client token asked for while a payment was in flight.
+	 *
+	 * @since TBD
+	 *
+	 * @return {boolean} Whether the browser is now navigating away.
+	 */
+	obj.takeDeferredReload = () => {
+		if ( ! obj.reloadWhenIdle ) {
+			return false;
+		}
+
+		window.location.replace( window.location.href );
+
+		return true;
 	};
 
 	/**
@@ -494,12 +598,17 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * Redirect the user back to the checkout page when the Token is expired so it gets refreshed properly.
 	 *
 	 * @since 5.1.9
+	 * @since TBD Defers the reload while a payment is in flight.
 	 *
 	 * @param {jQuery} $container jQuery Object.
 	 */
 	obj.timeoutRedirect = ( $container ) => {
-		// Prevent redirecting when a payment is engaged.
-		if ( $container.is( obj.selectors.activePayment.className() ) ) {
+		// Prevent redirecting when a payment is engaged. The active payment class only covers the
+		// buttons flow, and a card authentication such as BankID is exactly the payment long enough to
+		// outlast the token: reloading through it abandons the PayPal order the buyer is authenticating
+		// against, and their retry leaves a second pending order behind.
+		if ( obj.paymentInFlight || $container.is( obj.selectors.activePayment.className() ) ) {
+			obj.reloadWhenIdle = true;
 			return;
 		}
 
@@ -780,6 +889,11 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	obj.onHostedSubmit = ( event, cardFields, $container ) => {
 		event.preventDefault();
 
+		if ( obj.takeDeferredReload() ) {
+			return;
+		}
+
+		obj.paymentInFlight = true;
 		tribe.tickets.loader.show( $container );
 
 		cardFields
@@ -803,6 +917,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleHostedCaptureError = ( error, $container ) => {
 		tribe.tickets.debug.log( 'handleHostedCaptureError', error );
+		obj.paymentInFlight = false;
 		tribe.tickets.loader.hide( $container );
 
 		if ( ! obj.isGenericError ) {
@@ -865,10 +980,16 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 			.then( ( response ) => response.json() )
 			.then( ( data ) => {
 				tribe.tickets.debug.log( data );
-				if ( data.success ) {
-					return obj.handleCheckSuccess( data, actions, $container );
+
+				if ( ! data.success ) {
+					return obj.handleHostedApproveFail( data, actions, $container );
 				}
-				return obj.handleHostedApproveFail( data, actions, $container );
+
+				if ( data.redirect_url ) {
+					return obj.handleApproveSuccess( data, actions, $container );
+				}
+
+				return obj.handleCheckSuccess( data, actions, $container );
 			} )
 			.catch( ( error ) => {
 				obj.handleHostedApproveError( error, $container );
@@ -897,6 +1018,7 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * When a failed request is completed to our Approval endpoint.
 	 *
 	 * @since 5.2.0
+	 * @since TBD Stopped reading the error shape unguarded.
 	 *
 	 * @param         actions
 	 * @param         $container
@@ -906,26 +1028,14 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 */
 	obj.handleHostedApproveFail = ( data, actions, $container ) => {
 		tribe.tickets.debug.log( 'handleHostedApproveFail', data, actions, $container );
-		if ( 'UNPROCESSABLE_ENTITY' === data.data.name ) {
-			if ( 'INSTRUMENT_DECLINED' === data.data.details[ 0 ].issue ) {
-				obj.showNotice( $container, '', data.data.details[ 0 ].description );
-				// Recoverable stawte, per:
-				// return actions.restart();
-				// https://developer.paypal.com/docs/checkout/integration-features/funding-failure/
-			} else {
-				obj.showNotice( $container, '', data.message );
-			}
-		} else {
-			obj.showNotice( $container, '', data.message );
-		}
-
-		tribe.tickets.loader.hide( $container );
+		obj.endPayment( $container, obj.getFailureMessage( data ) );
 	};
 
 	/**
 	 * When a error happens on the fetch request to our Approval endpoint.
 	 *
 	 * @since 5.2.0
+	 * @since TBD Ends the payment with a message instead of only hiding the loader.
 	 *
 	 * @param         $container
 	 * @param {...any} rest
@@ -934,8 +1044,8 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * @return {void}
 	 */
 	obj.handleHostedApproveError = ( error, $container, ...rest ) => {
-		tribe.tickets.loader.hide( $container );
 		tribe.tickets.debug.log( 'handleHostedApproveError', error, rest );
+		obj.endPayment( $container, tecTicketsCommerceGatewayPayPalCheckout.requestFailedMessage );
 	};
 
 	/**

--- a/src/resources/js/commerce/gateway/paypal/checkout.js
+++ b/src/resources/js/commerce/gateway/paypal/checkout.js
@@ -603,11 +603,12 @@ window.tribe.tickets.commerce.gateway.paypal.checkout = {};
 	 * @param {jQuery} $container jQuery Object.
 	 */
 	obj.timeoutRedirect = ( $container ) => {
-		// Prevent redirecting when a payment is engaged. The active payment class only covers the
-		// buttons flow, and a card authentication such as BankID is exactly the payment long enough to
-		// outlast the token: reloading through it abandons the PayPal order the buyer is authenticating
-		// against, and their retry leaves a second pending order behind.
-		if ( obj.paymentInFlight || $container.is( obj.selectors.activePayment.className() ) ) {
+		// Prevent redirecting when a payment is engaged. A card authentication such as BankID is
+		// exactly the payment long enough to outlast the token: reloading through it abandons the
+		// PayPal order the buyer is authenticating against, and their retry leaves a second pending
+		// order behind. The class is matched with the dotted selector because className() strips the
+		// dot for hasClass, and is() reads the bare name as a tag, which never matches.
+		if ( obj.paymentInFlight || $container.is( obj.selectors.activePayment ) ) {
 			obj.reloadWhenIdle = true;
 			return;
 		}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1507]

### 🗒️ Description

Card payments that go through SCA/3DS, Swedish BankID among them, left the buyer on a spinning
loader with no error and no way forward. Reported against 5.28.2 on a site behind a platform
firewall and edge cache, where roughly a third of transactions failed during an on-sale.

**The problem.** Checkout took two requests. The first captured the money, the second returned where
to send the buyer. When that second request was blocked or slow, the buyer waited forever. The
handler meant to report the failure read `data.data.name` on a `WP_Error` that serializes with
`data: null`, threw, and was swallowed by a `.catch()` that only logged, so nothing surfaced at all.

**The fix.** The capture now records the payment and returns the destination itself, so checkout
finishes in one request. When PayPal's answer is unreadable the outcome is treated as unknown rather
than failed: there is no PayPal webhook to settle it later, and telling the buyer to retry risks
charging them twice.

**Also fixed.** Unsettled PayPal states such as `CREATED` and `APPROVED` were written over the
order, walking it out of pending for money that was never captured. And `timeoutRedirect` compared a
class using `is( className() )`, which never matches, so an expiring client token could reload
checkout in the middle of a payment.

### 🎥 Artifacts

https://www.loom.com/share/08f89f9d1dc548a2be98830a55aa6805

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
