### PR TITLE
[SOFT-4179] My Tickets page UI changes missing on migrated sites

### DIFF
--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -3,7 +3,7 @@
 namespace TEC\Tickets\Commerce;
 
 use TEC\Tickets\Commerce;
-use TEC\Tickets\Commerce\Communications\Email;
+use TEC\Tickets\Commerce\Communication\Email;
 use TEC\Tickets\Commerce\Status\Status_Handler;
 use \Tribe__Tickets__Ticket_Object as Ticket_Object;
 use Tribe__Cache_Listener;

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Attendee_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Attendee_Test.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TEC\Tickets\Commerce;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Attendee;
+use TEC\Tickets\Commerce\Module;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+
+class Attendee_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Order_Maker;
+
+	/**
+	 * Updating an attendee from the RSVP reservation page after the RSVP to Tickets
+	 * Commerce migration should not fatal while trying to resolve the Commerce Email class.
+	 *
+	 * @since TBD
+	 */
+	public function test_maybe_send_tickets_after_status_change_does_not_fatal() {
+		$post      = self::factory()->post->create( [ 'post_type' => 'page' ] );
+		$ticket_id = $this->create_tc_ticket( $post, 10 );
+		$order     = $this->create_order( [ $ticket_id => 1 ] );
+
+		$this->assertNotFalse( $order );
+
+		// Simulate a migrated RSVP attendee: the RSVP to Tickets Commerce migration
+		// sets the order relation meta on the attendee. Mark attendees as already
+		// having received their tickets so no email is dispatched.
+		foreach ( tribe( Module::class )->get_event_attendees( $post ) as $attendee ) {
+			update_post_meta( $attendee['attendee_id'], Attendee::$order_relation_meta_key, $order->ID );
+			update_post_meta( $attendee['attendee_id'], Attendee::$ticket_sent_meta_key, 1 );
+		}
+
+		// This used to throw a Not_Bound_Exception for the Tickets Commerce Email class.
+		tribe( Attendee::class )->maybe_send_tickets_after_status_change( $post );
+
+		$this->addToAssertionCount( 1 );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4179](https://linear.app/nexcess/issue/SOFT-4179/my-tickets-page-ui-changes-missing-on-migrated-sites)

### 🗒️ Description

**Fix** (bug fix - fatal error on the RSVP reservation page after RSVP-to-TC migration)

Fixed a fatal error thrown when updating a migrated RSVP from the My Tickets reservation page. `Attendee::maybe_send_tickets_after_status_change()` referenced `TEC\Tickets\Commerce\Communications\Email` — a typo for the singular `Communication\Email` class that has never existed — so `tribe( Email::class )` threw a `Not_Bound_Exception` on every RSVP update once the RSVP-to-Tickets Commerce migration created attendees carrying the order-relation meta. Corrected the class reference and added a regression test for the attendee-update flow.


### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/a7b484a0dd4c4868ba4a83c16f41cc5d

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
