### PR TITLE
[SOFT-3320] Support Virtual Events RSVP options

### DIFF
--- a/src/Tickets/RSVP/V2/Block_Editor.php
+++ b/src/Tickets/RSVP/V2/Block_Editor.php
@@ -97,7 +97,15 @@ class Block_Editor {
 		/** @var Ticket_Endpoint $endpoint */
 		$endpoint = tribe( Ticket_Endpoint::class );
 
+		// get_formatted_entity() runs the ticket through WP_REST_Posts_Controller::prepare_item_for_response(),
+		// which calls setup_postdata() and leaves the global $post pointing at the ticket. Restore it so the
+		// rest of the admin page (e.g. the Virtual Events metabox) keeps rendering the event.
+		global $post;
+		$original_post = $post;
+
 		$initial_ticket = $endpoint->get_formatted_entity( $ticket_post );
+
+		$post = $original_post;
 
 		/**
 		 * Filters the initial RSVP ticket data preloaded into the block editor.

--- a/src/Tickets/RSVP/V2/Block_Editor.php
+++ b/src/Tickets/RSVP/V2/Block_Editor.php
@@ -105,7 +105,7 @@ class Block_Editor {
 
 		$initial_ticket = $endpoint->get_formatted_entity( $ticket_post );
 
-		$post = $original_post;
+		$post = $original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring the global post polluted by WP_REST_Posts_Controller.
 
 		/**
 		 * Filters the initial RSVP ticket data preloaded into the block editor.

--- a/tests/rsvp_v2_integration/RSVP/V2/Block_Editor_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Block_Editor_Test.php
@@ -93,6 +93,35 @@ class Block_Editor_Test extends WPTestCase {
 		wp_set_current_user( 0 );
 	}
 
+	/**
+	 * The preloaded RSVP ticket is formatted through WP_REST_Posts_Controller::prepare_item_for_response(),
+	 * which calls setup_postdata() and leaves the global $post pointing at the ticket. Verify the global post
+	 * is restored to the event so other admin metaboxes (e.g. Virtual Events) keep rendering the event.
+	 */
+	public function test_rsvp_v2_config_preserves_global_post_when_preloading_initial_ticket(): void {
+		wp_set_current_user( 1 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_title'  => 'RSVP Event',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			]
+		);
+
+		$this->create_tc_rsvp_ticket( $post_id );
+
+		global $post;
+		$post = get_post( $post_id );
+
+		apply_filters( 'tribe_editor_config', [] );
+
+		$this->assertSame( $post_id, $post->ID, 'Global $post should still reference the event, not the RSVP ticket' );
+		$this->assertSame( 'page', $post->post_type, 'Global $post post type should be unchanged' );
+
+		wp_set_current_user( 0 );
+	}
+
 	public function test_should_preserve_existing_config_when_adding_rsvp_v2(): void {
 		$existing_config = [
 			'someKey'   => 'someValue',


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3320](https://linear.app/nexcess/issue/SOFT-3320/support-virtual-events-rsvp-options)

### 🗒️ Description

**Fix** (bug fix - broken block editor rendering)

Fixed an issue where the RSVP V2 block editor preload left the global $post pointing at the RSVP ticket instead of the event, causing other admin metaboxes (such as Virtual Events) to render against the wrong post.


### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/9ed6e16fc74e4786ab6194478bdb78a2

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
