### PR TITLE
[SMTNC-1248] Fatal error triggered in Tickets Commerce cart

### DIFF
--- a/changelog/smtnc-1248-fatal-error-triggered-in-tickets-commerce-cart-php-fatal.yaml
+++ b/changelog/smtnc-1248-fatal-error-triggered-in-tickets-commerce-cart-php-fatal.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved a fatal error that could be triggered in the Tickets Commerce
+  cart when the decoded ticket data was null.
+timestamp: 2026-08-27T02:22:29.266Z

--- a/src/Tribe/Commerce/Cart.php
+++ b/src/Tribe/Commerce/Cart.php
@@ -42,7 +42,13 @@ class Tribe__Tickets__Commerce__Cart {
 				$data = json_decode( $data, true );
 			}
 
-			$data = array_merge( $_POST, $data );
+			if ( is_array( $data ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified upstream by tec_tickets_ar action handler.
+				$data = array_merge( $_POST, $data );
+			} else {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified upstream by tec_tickets_ar action handler.
+				$data = $_POST;
+			}
 		}
 
 		$post_id  = isset( $data['tribe_tickets_post_id'] ) ? absint( $data['tribe_tickets_post_id'] ) : null;


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1248](https://linear.app/nexcess/issue/SMTNC-1248/fatal-error-triggered-in-tickets-commerce-cart-php-fatal)

### 🗒️ Description

Guards `array_merge()` with an `is_array()` check so that a `null` return from `json_decode()` no longer triggers a PHP 8 TypeError in the Tickets Commerce cart.

### ⚠️ Blockers

None.