### PR TITLE
[SOFT-3894] RSVP V2: hidden TC order not transitioned to Removed/Voided when admin deletes attendee

### DIFF
--- a/src/Tickets/RSVP/V2/Repositories/Attendee_Repository.php
+++ b/src/Tickets/RSVP/V2/Repositories/Attendee_Repository.php
@@ -248,7 +248,16 @@ class Attendee_Repository extends Base_Repository implements Attendee_Repository
 	 */
 	public function delete_attendee( int $attendee_id ): array {
 		$event_id = get_post_meta( $attendee_id, Attendee::$event_relation_meta_key, true );
-		$deleted  = wp_delete_post( $attendee_id, true );
+
+		/*
+		 * Fire the same hooks as Attendee::delete() so listeners keep running — e.g. voiding the
+		 * hidden RSVP order once its last attendee is gone and restoring stock — while keeping the
+		 * force delete (bypass trash) that privacy erasure requires. Attendee::delete() cannot be
+		 * reused as-is because it does not forward its $force argument to wp_delete_post().
+		 */
+		do_action( 'tec_tickets_commerce_attendee_before_delete', $attendee_id, true );
+		$deleted = wp_delete_post( $attendee_id, true );
+		do_action( 'tec_tickets_commerce_attendee_after_delete', $attendee_id, $deleted, true );
 
 		return [
 			'success'  => (bool) $deleted,

--- a/tests/rsvp_v2_integration/RSVP/V2/Repositories/Attendee_Repository_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Repositories/Attendee_Repository_Test.php
@@ -4,7 +4,15 @@ namespace TEC\Tickets\RSVP\V2\Repositories;
 
 use Codeception\TestCase\WPTestCase;
 use TEC\Tickets\Commerce\Attendee;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Gateways\Free\Gateway;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\Commerce\Status\Voided;
 use TEC\Tickets\RSVP\Contracts\Attendee_Repository_Interface;
+use TEC\Tickets\RSVP\V2\Cart\RSVP_Cart;
 use TEC\Tickets\RSVP\V2\Constants;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Attendee_Maker;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
@@ -356,6 +364,104 @@ class Attendee_Repository_Test extends WPTestCase {
 
 		$this->assertArrayHasKey( 'event_id', $result );
 		$this->assertSame( $post_id, $result['event_id'] );
+	}
+
+	/**
+	 * Builds a real TC-RSVP order through the cart flow and returns its ID plus the attendee IDs.
+	 *
+	 * Mirrors the helper in RSVP\V2\Attendees_Test so the order line items are typed `tc-rsvp` and
+	 * the generated attendees carry the RSVP status meta the RSVP attendee repository requires.
+	 *
+	 * @param int $ticket_id The RSVP ticket ID.
+	 * @param int $quantity  The number of attendees to put on the order.
+	 *
+	 * @return array{0:int,1:int[]} The order ID and the attendee IDs.
+	 */
+	private function create_rsvp_order_with_attendees( int $ticket_id, int $quantity ): array {
+		/** @var RSVP_Cart $cart */
+		$cart = tribe( RSVP_Cart::class );
+		$cart->clear();
+		$cart->upsert_item(
+			$ticket_id,
+			$quantity,
+			[
+				'type'         => Constants::TC_RSVP_TYPE,
+				'order_status' => 'yes',
+			]
+		);
+		$cart->save();
+
+		$purchaser = [
+			'purchaser_user_id'    => 0,
+			'purchaser_full_name'  => 'Test Purchaser',
+			'purchaser_first_name' => 'Test',
+			'purchaser_last_name'  => 'Purchaser',
+			'purchaser_email'      => 'attendee@example.com',
+		];
+
+		/** @var Order $orders */
+		$orders = tribe( Order::class );
+		$order  = $orders->create_from_cart( tribe( Gateway::class ), $purchaser, Constants::TC_RSVP_TYPE );
+
+		$orders->modify_status( $order->ID, Pending::SLUG );
+		$orders->modify_status( $order->ID, Completed::SLUG );
+
+		$cart->clear();
+		tribe( Cart::class )->clear_cart();
+
+		$attendees    = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
+		$attendee_ids = array_column( $attendees, 'attendee_id' );
+		array_map(
+			static fn( $attendee_id ) => update_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, 'yes' ),
+			$attendee_ids
+		);
+
+		return [ $order->ID, $attendee_ids ];
+	}
+
+	public function test_delete_attendee_voids_rsvp_order_when_last_attendee_deleted(): void {
+		$post_id   = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		[ $order_id, $attendee_ids ] = $this->create_rsvp_order_with_attendees( $ticket_id, 1 );
+		$this->assertCount( 1, $attendee_ids );
+
+		$repo   = new Attendee_Repository();
+		$result = $repo->delete_attendee( $attendee_ids[0] );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame(
+			tribe( Voided::class )->get_wp_slug(),
+			get_post_status( $order_id ),
+			'Deleting the last attendee should void the parent RSVP order'
+		);
+		$this->assertNull(
+			get_post( $attendee_ids[0] ),
+			'Privacy erasure must remove the attendee post, not trash it'
+		);
+	}
+
+	public function test_delete_attendee_keeps_rsvp_order_completed_when_other_attendees_remain(): void {
+		$post_id   = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		[ $order_id, $attendee_ids ] = $this->create_rsvp_order_with_attendees( $ticket_id, 2 );
+		$this->assertCount( 2, $attendee_ids );
+
+		$repo   = new Attendee_Repository();
+		$result = $repo->delete_attendee( $attendee_ids[0] );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame(
+			tribe( Completed::class )->get_wp_slug(),
+			get_post_status( $order_id ),
+			'The order should stay completed while another attendee remains'
+		);
+		$this->assertInstanceOf(
+			WP_Post::class,
+			get_post( $attendee_ids[1] ),
+			'The remaining attendee should still exist'
+		);
 	}
 
 	public function test_get_ticket_id_returns_correct_product_id(): void {

--- a/tests/rsvp_v2_integration/RSVP/V2/Repositories/Attendee_Repository_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Repositories/Attendee_Repository_Test.php
@@ -402,6 +402,7 @@ class Attendee_Repository_Test extends WPTestCase {
 		/** @var Order $orders */
 		$orders = tribe( Order::class );
 		$order  = $orders->create_from_cart( tribe( Gateway::class ), $purchaser, Constants::TC_RSVP_TYPE );
+		$this->assertInstanceOf( WP_Post::class, $order, 'Order creation from cart should return a WP_Post' );
 
 		$orders->modify_status( $order->ID, Pending::SLUG );
 		$orders->modify_status( $order->ID, Completed::SLUG );


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3894](https://linear.app/nexcess/issue/SOFT-3894/rsvp-v2-hidden-tc-order-not-transitioned-to-removedvoided-when-admin)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - RSVP order left orphaned on privacy erasure)

Resolved an issue where erasing an RSVP V2 attendee through WordPress's Erase Personal Data tool left the hidden Tickets Commerce order backing it orphaned in Completed: the erasure path deleted the attendee post directly, bypassing the `tec_tickets_commerce_attendee_before_delete` hook that voids the order once its last attendee is gone. The privacy deletion now fires the same attendee delete hooks as the regular admin deletion path, so the parent RSVP order transitions to Voided (and stock is restored) while keeping the force-delete that privacy erasure requires.


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
