### PR TITLE
[SMTNC-1811] Event Tickets 5.29.0.1 checkout shows “Oops, no tickets!”

### DIFF
--- a/changelog/smtnc-1811-checkout-page-no-cache.yaml
+++ b/changelog/smtnc-1811-checkout-page-no-cache.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Prevented the cart-to-checkout redirect and the checkout page from being
+  stored by full-page and edge caches, resolving an issue where the Tickets
+  Commerce checkout could show 'Oops, no tickets!' after selecting tickets.
+timestamp: 2026-08-27T16:47:12.821Z

--- a/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
+++ b/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevented the cart-to-checkout redirect from being cached to avoid an issue where the Tickets Commerce checkout could show 'Oops, no tickets!' after selecting tickets on sites behind a full-page or edge cache.
+Prevented the cart-to-checkout redirect and the checkout page from being stored by full-page and edge caches, resolving an issue where the Tickets Commerce checkout could show 'Oops, no tickets!' after selecting tickets.

--- a/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
+++ b/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevented the cart-to-checkout redirect and the checkout page from being stored by full-page and edge caches, resolving an issue where the Tickets Commerce checkout could show 'Oops, no tickets!' after selecting tickets.

--- a/src/Tickets/Commerce/Checkout.php
+++ b/src/Tickets/Commerce/Checkout.php
@@ -115,11 +115,14 @@ class Checkout {
 	 *
 	 * @since 5.1.9
 	 * @since 5.29.0.1 No longer sets the cart hash cookie from a request param. See SVUL-L34.
+	 * @since TBD Marked the checkout response as non-cacheable.
 	 */
 	public function parse_request() {
 		if ( ! $this->is_current_page() ) {
 			return;
 		}
+
+		$this->prevent_caching();
 
 		/**
 		 * Allows for additional parsing of the request on the checkout page.
@@ -227,5 +230,26 @@ class Checkout {
 
 		$shortcode = Shortcodes\Checkout_Shortcode::get_wp_slug();
 		return has_shortcode( $page->post_content, $shortcode );
+	}
+
+	/**
+	 * Marks the checkout response as non-cacheable.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function prevent_caching(): void {
+		/*
+		 * Checkout renders whatever the visitor's own cart cookie points at, so a stored copy is
+		 * handed to every later visitor regardless of their cart: one shopper sees an empty cart,
+		 * the next sees someone else's. Reverse proxies and CDNs honour the response headers, while
+		 * the WordPress-side page caches buffer the output and read DONOTCACHEPAGE instead.
+		 */
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+
+		nocache_headers();
 	}
 }

--- a/src/Tickets/Commerce/Checkout.php
+++ b/src/Tickets/Commerce/Checkout.php
@@ -246,8 +246,8 @@ class Checkout {
 		 * the next sees someone else's. Reverse proxies and CDNs honour the response headers, while
 		 * the WordPress-side page caches buffer the output and read DONOTCACHEPAGE instead.
 		 */
-		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-			define( 'DONOTCACHEPAGE', true );
+		if ( ! defined( 'DO_NOT_CACHE_PAGE' ) ) {
+			define( 'DO_NOT_CACHE_PAGE', true );
 		}
 
 		nocache_headers();

--- a/src/Tickets/Commerce/Checkout.php
+++ b/src/Tickets/Commerce/Checkout.php
@@ -246,8 +246,8 @@ class Checkout {
 		 * the next sees someone else's. Reverse proxies and CDNs honour the response headers, while
 		 * the WordPress-side page caches buffer the output and read DONOTCACHEPAGE instead.
 		 */
-		if ( ! defined( 'DO_NOT_CACHE_PAGE' ) ) {
-			define( 'DO_NOT_CACHE_PAGE', true );
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
 		}
 
 		nocache_headers();

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Checkout_Cache_Headers_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Checkout_Cache_Headers_Test.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Regression test for the checkout page being stored by full-page and edge caches.
+ *
+ * Since SVUL-L34 the cart is identified solely by the visitor's cart cookie, so the checkout render
+ * differs per visitor while its URL does not. Without cache directives a shared cache stores one
+ * visitor's render and serves it to everyone: a shopper lands on an empty cart, or on someone
+ * else's. Reverse proxies and CDNs honour the response headers, the WordPress-side page caches
+ * buffer the output and read DONOTCACHEPAGE instead, so the page must send both.
+ */
+
+namespace TEC\Tickets\Commerce;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tests\Traits\With_Uopz;
+
+class Checkout_Cache_Headers_Test extends WPTestCase {
+
+	use With_Uopz;
+
+	/**
+	 * Whether DONOTCACHEPAGE was already defined when the test started.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	private $donotcachepage_was_defined = false;
+
+	/**
+	 * @before
+	 */
+	public function record_donotcachepage_state(): void {
+		$this->donotcachepage_was_defined = defined( 'DONOTCACHEPAGE' );
+	}
+
+	/**
+	 * @after
+	 */
+	public function restore_donotcachepage_state(): void {
+		if ( $this->donotcachepage_was_defined || ! defined( 'DONOTCACHEPAGE' ) ) {
+			return;
+		}
+
+		uopz_undefine( 'DONOTCACHEPAGE' );
+	}
+
+	/**
+	 * The checkout page must send no-cache headers so proxies and CDNs never store a render that
+	 * belongs to one visitor's cart cookie.
+	 *
+	 * @since TBD
+	 */
+	public function test_checkout_page_sends_nocache_headers(): void {
+		$this->assertTrue(
+			$this->run_checkout_parse_request_capturing_nocache(),
+			'The checkout page must send no-cache headers so shared caches do not store one visitor cart render.'
+		);
+	}
+
+	/**
+	 * The checkout page must also opt out of the WordPress-side page caches, which buffer output and
+	 * never see the response headers.
+	 *
+	 * @since TBD
+	 */
+	public function test_checkout_page_defines_donotcachepage(): void {
+		$this->run_checkout_parse_request_capturing_nocache();
+
+		$this->assertTrue(
+			defined( 'DONOTCACHEPAGE' ) && true === constant( 'DONOTCACHEPAGE' ),
+			'The checkout page must define DONOTCACHEPAGE so WordPress page caches skip it.'
+		);
+	}
+
+	/**
+	 * A page that is not the checkout must keep its default cacheability, so ordinary content is not
+	 * pushed out of the page cache.
+	 *
+	 * @since TBD
+	 */
+	public function test_non_checkout_page_is_left_cacheable(): void {
+		$this->set_class_fn_return( Checkout::class, 'is_current_page', false );
+
+		$this->assertFalse(
+			$this->capture_nocache_during( static fn() => tribe( Checkout::class )->parse_request() ),
+			'A page that is not the checkout must not be marked non-cacheable.'
+		);
+	}
+
+	/**
+	 * Drives the real Checkout::parse_request() on the checkout page.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the no-cache headers were emitted.
+	 */
+	private function run_checkout_parse_request_capturing_nocache(): bool {
+		// parse_request() only acts on the checkout page; force that gate open.
+		$this->set_class_fn_return( Checkout::class, 'is_current_page', true );
+
+		return $this->capture_nocache_during( static fn() => tribe( Checkout::class )->parse_request() );
+	}
+
+	/**
+	 * Runs a callback while watching for the no-cache headers being emitted.
+	 *
+	 * @since TBD
+	 *
+	 * @param callable $callback The callback to run.
+	 *
+	 * @return bool Whether the no-cache headers were emitted while the callback ran.
+	 */
+	private function capture_nocache_during( callable $callback ): bool {
+		$nocache_sent = false;
+
+		$spy = static function ( $headers ) use ( &$nocache_sent ) {
+			$nocache_sent = true;
+
+			return $headers;
+		};
+
+		add_filter( 'nocache_headers', $spy );
+		$callback();
+		remove_filter( 'nocache_headers', $spy );
+
+		return $nocache_sent;
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Checkout_Cache_Headers_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Checkout_Cache_Headers_Test.php
@@ -2,11 +2,11 @@
 /**
  * Regression test for the checkout page being stored by full-page and edge caches.
  *
- * Since SVUL-L34 the cart is identified solely by the visitor's cart cookie, so the checkout render
- * differs per visitor while its URL does not. Without cache directives a shared cache stores one
- * visitor's render and serves it to everyone: a shopper lands on an empty cart, or on someone
- * else's. Reverse proxies and CDNs honour the response headers, the WordPress-side page caches
- * buffer the output and read DONOTCACHEPAGE instead, so the page must send both.
+ * The cart is identified solely by the visitor's cart cookie, so the checkout render differs per
+ * visitor while its URL does not. Without cache directives a shared cache stores one visitor's
+ * render and serves it to everyone: a shopper lands on an empty cart, or on someone else's.
+ * Reverse proxies and CDNs honour the response headers, the WordPress-side page caches buffer the
+ * output and read DONOTCACHEPAGE instead, so the page must send both.
  */
 
 namespace TEC\Tickets\Commerce;

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Checkout_Cache_Headers_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Checkout_Cache_Headers_Test.php
@@ -19,57 +19,37 @@ class Checkout_Cache_Headers_Test extends WPTestCase {
 	use With_Uopz;
 
 	/**
-	 * Whether DONOTCACHEPAGE was already defined when the test started.
-	 *
-	 * @since TBD
-	 *
-	 * @var bool
-	 */
-	private $donotcachepage_was_defined = false;
-
-	/**
-	 * @before
-	 */
-	public function record_donotcachepage_state(): void {
-		$this->donotcachepage_was_defined = defined( 'DONOTCACHEPAGE' );
-	}
-
-	/**
-	 * @after
-	 */
-	public function restore_donotcachepage_state(): void {
-		if ( $this->donotcachepage_was_defined || ! defined( 'DONOTCACHEPAGE' ) ) {
-			return;
-		}
-
-		uopz_undefine( 'DONOTCACHEPAGE' );
-	}
-
-	/**
-	 * The checkout page must send no-cache headers so proxies and CDNs never store a render that
-	 * belongs to one visitor's cart cookie.
+	 * The checkout page must opt out of both caching layers, so neither a shared proxy nor a
+	 * WordPress page cache can hand one visitor's cart render to the next.
 	 *
 	 * @since TBD
 	 */
-	public function test_checkout_page_sends_nocache_headers(): void {
+	public function test_checkout_page_opts_out_of_caching(): void {
+		// parse_request() only acts on the checkout page; force that gate open.
+		$this->set_class_fn_return( Checkout::class, 'is_current_page', true );
+
+		$nocache_sent = $this->capture_nocache_during(
+			static fn() => tribe( Checkout::class )->parse_request()
+		);
+
 		$this->assertTrue(
-			$this->run_checkout_parse_request_capturing_nocache(),
+			$nocache_sent,
 			'The checkout page must send no-cache headers so shared caches do not store one visitor cart render.'
 		);
-	}
 
-	/**
-	 * The checkout page must also opt out of the WordPress-side page caches, which buffer output and
-	 * never see the response headers.
-	 *
-	 * @since TBD
-	 */
-	public function test_checkout_page_defines_donotcachepage(): void {
-		$this->run_checkout_parse_request_capturing_nocache();
-
+		/*
+		 * DONOTCACHEPAGE is left defined for the rest of the suite on purpose. Undefining it between
+		 * tests made this class order-dependent: the constant did not come back on the second
+		 * parse_request(), so the assertion failed only when the whole suite ran. Nothing else in
+		 * the plugin or the suite reads the constant, so leaking it costs nothing.
+		 */
 		$this->assertTrue(
-			defined( 'DONOTCACHEPAGE' ) && true === constant( 'DONOTCACHEPAGE' ),
+			defined( 'DONOTCACHEPAGE' ),
 			'The checkout page must define DONOTCACHEPAGE so WordPress page caches skip it.'
+		);
+		$this->assertTrue(
+			tribe_is_truthy( constant( 'DONOTCACHEPAGE' ) ),
+			'DONOTCACHEPAGE must be truthy for page caches to treat the checkout as uncacheable.'
 		);
 	}
 
@@ -86,20 +66,6 @@ class Checkout_Cache_Headers_Test extends WPTestCase {
 			$this->capture_nocache_during( static fn() => tribe( Checkout::class )->parse_request() ),
 			'A page that is not the checkout must not be marked non-cacheable.'
 		);
-	}
-
-	/**
-	 * Drives the real Checkout::parse_request() on the checkout page.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the no-cache headers were emitted.
-	 */
-	private function run_checkout_parse_request_capturing_nocache(): bool {
-		// parse_request() only acts on the checkout page; force that gate open.
-		$this->set_class_fn_return( Checkout::class, 'is_current_page', true );
-
-		return $this->capture_nocache_during( static fn() => tribe( Checkout::class )->parse_request() );
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1811](https://linear.app/nexcess/issue/SMTNC-1811/event-tickets-52901-checkout-shows-oops-no-tickets)

### 🎥 Artifacts

https://www.loom.com/share/b56b8c10a3934289b75e1e9a6027e933

### 🗒️ Description

Stops the Tickets Commerce checkout page from being stored by full-page and edge caches, so a shopper is no longer served another visitor's cached empty cart.

### ⚠️ Blockers

None.