### PR TITLE
[SMTNC-2280] Event Ticket Sale End Date Reverts to Event Date in Block Editor

### DIFF
--- a/changelog/fix-smtnc-2280-event-ticket-sale-end-date-reverts-to-event-date-in-block.yaml
+++ b/changelog/fix-smtnc-2280-event-ticket-sale-end-date-reverts-to-event-date-in-block.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Fixed an issue where a custom ticket sale end date set during ticket
+  creation in the block editor reverted to the event start date after saving the
+  event.
+timestamp: 2026-08-28T03:41:09.843Z

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -4121,7 +4121,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					}
 				}
 
-				if ( ! $is_default ) {
+				if ( ! $is_default && ! $tickets_handler->has_manual_update( $ticket->ID, $tickets_handler->key_end_date ) ) {
 					add_post_meta( $ticket->ID, $tickets_handler->key_manual_updated, $tickets_handler->key_end_date );
 				}
 			}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -4121,7 +4121,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					}
 				}
 
-				if ( ! $is_default && ! $tickets_handler->has_manual_update( $ticket->ID, $tickets_handler->key_end_date ) ) {
+				if ( ! $is_default ) {
 					add_post_meta( $ticket->ID, $tickets_handler->key_manual_updated, $tickets_handler->key_end_date );
 				}
 			}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -4090,6 +4090,42 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			// Pass the control to the child object.
 			$save_ticket = $this->save_ticket( $post_id, $ticket, $data );
 
+			/*
+			 * The sale end date is added, not updated, on ticket creation, so the usual
+			 * manual-update flag does not fire. Flag explicitly supplied custom sale end
+			 * dates so later event start changes do not overwrite them.
+			 */
+			if (
+				! $update
+				&& ! empty( $ticket->ID )
+				&& ! empty( $data['ticket_end_date'] )
+				&& ! empty( $ticket->end_date )
+				&& ! $tickets_handler->has_manual_update( $ticket->ID, $tickets_handler->key_end_date )
+			) {
+				$event_start = get_post_meta( $post_id, '_EventStartDate', true );
+				$is_default  = false;
+
+				if ( $event_start ) {
+					$event_ts = strtotime( $event_start );
+
+					// Some providers normalize the ticket end date to a full datetime; rebuild it
+					// from the date part so the end time is not appended twice below.
+					$end_date_ts = strtotime( $ticket->end_date );
+					$end_date    = gmdate( Tribe__Date_Utils::DBDATEFORMAT, $end_date_ts );
+
+					if ( ! empty( $ticket->end_time ) ) {
+						$ticket_ts  = strtotime( $end_date . ' ' . $ticket->end_time );
+						$is_default = false !== $event_ts && false !== $end_date_ts && false !== $ticket_ts && $event_ts === $ticket_ts;
+					} else {
+						$is_default = false !== $event_ts && false !== $end_date_ts && $end_date === gmdate( Tribe__Date_Utils::DBDATEFORMAT, $event_ts );
+					}
+				}
+
+				if ( ! $is_default ) {
+					add_post_meta( $ticket->ID, $tickets_handler->key_manual_updated, $tickets_handler->key_end_date );
+				}
+			}
+
 			// Set the ticket type before the module saves the ticket.
 			$ticket_type = 'default';
 			if ( $update ) {

--- a/src/modules/data/blocks/rsvp/__tests__/__snapshots__/actions.test.js.snap
+++ b/src/modules/data/blocks/rsvp/__tests__/__snapshots__/actions.test.js.snap
@@ -409,6 +409,12 @@ exports[`RSVP block actions RSVP thunk & saga actions delete RSVP 1`] = `
 }
 `;
 
+exports[`RSVP block actions RSVP thunk & saga actions delete RSVP header image 1`] = `
+{
+  "type": "@@MT/TICKETS/DELETE_RSVP_HEADER_IMAGE",
+}
+`;
+
 exports[`RSVP block actions RSVP thunk & saga actions fetch RSVP header image 1`] = `
 {
   "payload": {
@@ -468,5 +474,14 @@ exports[`RSVP block actions RSVP thunk & saga actions handle RSVP start time 1`]
 exports[`RSVP block actions RSVP thunk & saga actions initialize RSVP 1`] = `
 {
   "type": "@@MT/TICKETS/INITIALIZE_RSVP",
+}
+`;
+
+exports[`RSVP block actions RSVP thunk & saga actions update RSVP header image 1`] = `
+{
+  "payload": {
+    "image": {},
+  },
+  "type": "@@MT/TICKETS/UPDATE_RSVP_HEADER_IMAGE",
 }
 `;

--- a/src/modules/data/blocks/ticket/__tests__/sagas.test.js
+++ b/src/modules/data/blocks/ticket/__tests__/sagas.test.js
@@ -661,39 +661,9 @@ describe( 'Ticket Block sagas', () => {
 			expect( gen.next().value ).toEqual(
 				call( isTribeEventPostType ),
 			);
+			// Existing tickets do not default their end date to the event start;
+			// the saved end date is loaded via fetchTicket below.
 			expect( gen.next( true ).value ).toEqual(
-				select( window.tec.events.app.main.data.blocks.datetime.selectors.getStart ),
-			);
-			expect( gen.next( eventStart ).value ).toEqual(
-				call( momentUtil.toMoment, eventStart ),
-			);
-			expect( gen.next( endMoment ).value ).toEqual(
-				call( momentUtil.toDatabaseDate, endMoment ),
-			);
-			expect( gen.next( endDate ).value ).toEqual(
-				call( momentUtil.toDate, endMoment ),
-			);
-			expect( gen.next( endDateInput ).value ).toEqual(
-				call( momentUtil.toDatabaseTime, endMoment ),
-			);
-			expect( gen.next( endTime ).value ).toEqual(
-				call( momentUtil.toTime, endMoment ),
-			);
-			expect( gen.next( endTime ).value ).toEqual(
-				all( [
-					put( actions.setTicketEndDate( action.payload.clientId, endDate ) ),
-					put( actions.setTicketEndDateInput( action.payload.clientId, endDateInput ) ),
-					put( actions.setTicketEndDateMoment( action.payload.clientId, endMoment ) ),
-					put( actions.setTicketEndTime( action.payload.clientId, endTime ) ),
-					put( actions.setTicketEndTimeInput( action.payload.clientId, endTime ) ),
-					put( actions.setTicketTempEndDate( action.payload.clientId, endDate ) ),
-					put( actions.setTicketTempEndDateInput( action.payload.clientId, endDateInput ) ),
-					put( actions.setTicketTempEndDateMoment( action.payload.clientId, endMoment ) ),
-					put( actions.setTicketTempEndTime( action.payload.clientId, endTime ) ),
-					put( actions.setTicketTempEndTimeInput( action.payload.clientId, endTime ) ),
-				] ),
-			);
-			expect( gen.next().value ).toEqual(
 				select( plugins.selectors.hasPlugin, plugins.constants.TICKETS_PLUS ),
 			);
 			expect( gen.next( false ).value ).toEqual(
@@ -972,6 +942,139 @@ describe( 'Ticket Block sagas', () => {
 				fork( sagas.saveTicketWithPostSave, CLIENT_ID ),
 			);
 			expect( gen.next( '' ).done ).toEqual( true );
+		} );
+	} );
+
+	describe( 'syncTicketSaleEndWithEventStart', () => {
+		beforeEach( () => {
+			global.window = global.window || {};
+			window.tec = {
+				events: {
+					app: {
+						main: {
+							data: {
+								blocks: {
+									datetime: {
+										selectors: {
+											getStart: jest.fn(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			};
+		} );
+
+		afterEach( () => {
+			delete window.tec;
+		} );
+
+		it( 'should not sync a custom sale end date with the event start', () => {
+			const CLIENT_ID = 'modern-tribe';
+			const prevStartDate = 'November 20, 2018 12:30:00';
+			const tempEndMoment = { local: jest.fn(), isSame: jest.fn() };
+			const endMoment = { local: jest.fn() };
+			const prevEventStartMoment = { local: jest.fn() };
+
+			const gen = cloneableGenerator(
+				sagas.syncTicketSaleEndWithEventStart
+			)( prevStartDate, CLIENT_ID );
+
+			expect( gen.next().value ).toEqual(
+				select( selectors.getTicketTempEndDateMoment, { clientId: CLIENT_ID } ),
+			);
+			expect( gen.next( tempEndMoment ).value ).toEqual(
+				select( selectors.getTicketEndDateMoment, { clientId: CLIENT_ID } ),
+			);
+			expect( gen.next( endMoment ).value ).toEqual(
+				call( createDates, prevStartDate ),
+			);
+			expect( gen.next( { moment: prevEventStartMoment } ).value ).toEqual(
+				all( [
+					call( [ tempEndMoment, 'local' ] ),
+					call( [ endMoment, 'local' ] ),
+					call( [ prevEventStartMoment, 'local' ] ),
+				] ),
+			);
+			expect( gen.next().value ).toEqual(
+				call( [ tempEndMoment, 'isSame' ], endMoment, 'minute' ),
+			);
+			expect( gen.next( true ).value ).toEqual(
+				call( [ tempEndMoment, 'isSame' ], prevEventStartMoment, 'minute' ),
+			);
+			expect( gen.next( false ).value ).toEqual( call( isTribeEventPostType ) );
+			expect( gen.next( true ).done ).toEqual( true );
+		} );
+
+		it( 'should sync the sale end date with the event start when it follows the event', () => {
+			const CLIENT_ID = 'modern-tribe';
+			const prevStartDate = 'November 20, 2018 12:30:00';
+			const eventStart = 'November 25, 2018 12:30:00';
+			const tempEndMoment = { local: jest.fn(), isSame: jest.fn() };
+			const endMoment = { local: jest.fn() };
+			const prevEventStartMoment = { local: jest.fn() };
+			const endDateMoment = { local: jest.fn() };
+
+			const gen = cloneableGenerator(
+				sagas.syncTicketSaleEndWithEventStart
+			)( prevStartDate, CLIENT_ID );
+
+			expect( gen.next().value ).toEqual(
+				select( selectors.getTicketTempEndDateMoment, { clientId: CLIENT_ID } ),
+			);
+			expect( gen.next( tempEndMoment ).value ).toEqual(
+				select( selectors.getTicketEndDateMoment, { clientId: CLIENT_ID } ),
+			);
+			expect( gen.next( endMoment ).value ).toEqual(
+				call( createDates, prevStartDate ),
+			);
+			expect( gen.next( { moment: prevEventStartMoment } ).value ).toEqual(
+				all( [
+					call( [ tempEndMoment, 'local' ] ),
+					call( [ endMoment, 'local' ] ),
+					call( [ prevEventStartMoment, 'local' ] ),
+				] ),
+			);
+			expect( gen.next().value ).toEqual(
+				call( [ tempEndMoment, 'isSame' ], endMoment, 'minute' ),
+			);
+			expect( gen.next( true ).value ).toEqual(
+				call( [ tempEndMoment, 'isSame' ], prevEventStartMoment, 'minute' ),
+			);
+			expect( gen.next( true ).value ).toEqual( call( isTribeEventPostType ) );
+			expect( gen.next( true ).value ).toEqual(
+				select( window.tec.events.app.main.data.blocks.datetime.selectors.getStart ),
+			);
+			expect( gen.next( eventStart ).value ).toEqual(
+				call( createDates, eventStart ),
+			);
+			expect(
+				gen.next( {
+					moment: endDateMoment,
+					date: '2018-11-25',
+					dateInput: 'November 25, 2018',
+					time: '12:30:00',
+					timeInput: '12:30 pm',
+				} ).value
+			).toEqual(
+				all( [
+					put( actions.setTicketTempEndDate( CLIENT_ID, '2018-11-25' ) ),
+					put( actions.setTicketTempEndDateInput( CLIENT_ID, 'November 25, 2018' ) ),
+					put( actions.setTicketTempEndDateMoment( CLIENT_ID, endDateMoment ) ),
+					put( actions.setTicketTempEndTime( CLIENT_ID, '12:30:00' ) ),
+					put( actions.setTicketTempEndTimeInput( CLIENT_ID, '12:30 pm' ) ),
+					put( actions.setTicketEndDate( CLIENT_ID, '2018-11-25' ) ),
+					put( actions.setTicketEndDateInput( CLIENT_ID, 'November 25, 2018' ) ),
+					put( actions.setTicketEndDateMoment( CLIENT_ID, endDateMoment ) ),
+					put( actions.setTicketEndTime( CLIENT_ID, '12:30:00' ) ),
+					put( actions.setTicketEndTimeInput( CLIENT_ID, '12:30 pm' ) ),
+					put( actions.setTicketHasChanges( CLIENT_ID, true ) ),
+					call( sagas.handleTicketDurationError, CLIENT_ID ),
+				] ),
+			);
+			expect( gen.next().done ).toEqual( true );
 		} );
 	} );
 

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -313,8 +313,9 @@ export function* setTicketInitialState( action ) {
 
 	const isEvent = yield call( isTribeEventPostType );
 
-	// Only run this on events post type.
-	if ( isEvent && window.tec.events ) {
+	// Only run this on events post type and for new tickets; existing tickets
+	// load their saved sale end date from the server via fetchTicket below.
+	if ( isEvent && window.tec.events && ticketId === 0 ) {
 		// This try-catch may be redundant given the above if statement.
 		try {
 			// NOTE: This requires TEC to be installed, if not installed, do not set an end date

--- a/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
@@ -124,6 +124,78 @@ class Tickets_Sale_End_DateTest extends WPBrowserTestCase {
 	}
 
 	/**
+	 * It should only add the manual update flag once per ticket creation.
+	 *
+	 * @test
+	 */
+	public function should_only_add_manual_update_flag_once() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_EventStartDate', '2026-08-28 08:00:00' );
+
+		$ticket_id = $this->create_ticket(
+			$post_id,
+			[
+				'ticket_end_date' => '2026-09-15',
+				'ticket_end_time' => '08:00:00',
+			]
+		);
+
+		$manual_updates = get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' );
+		$this->assertCount( 1, $manual_updates, 'Manual update flag should only be added once' );
+		$this->assertContains( '_ticket_end_date', $manual_updates );
+	}
+
+	/**
+	 * It demonstrates that a raw add_post_meta() call allows duplicate meta entries.
+	 *
+	 * add_post_meta() does not check for existing values by default, so calling it
+	 * directly (bypassing the has_manual_update() guard) multiple times with the same
+	 * key/value will keep appending entries. This is why the flag must always be
+	 * added through a has_manual_update() check, never with a bare add_post_meta() call.
+	 *
+	 * @test
+	 */
+	public function demonstrates_raw_add_post_meta_allows_duplicates() {
+		$ticket_id = $this->factory->post->create( [ 'post_type' => 'tribe_rsvp_tickets' ] );
+
+		add_post_meta( $ticket_id, '_tribe_ticket_manual_updated', '_ticket_end_date' );
+		add_post_meta( $ticket_id, '_tribe_ticket_manual_updated', '_ticket_end_date' );
+
+		$manual_updates = get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' );
+		$this->assertCount( 2, $manual_updates, 'A bare add_post_meta() call allows duplicate entries with the same key and value' );
+		$this->assertEquals( [ '_ticket_end_date', '_ticket_end_date' ], $manual_updates );
+	}
+
+	/**
+	 * It should not duplicate the manual update flag if the guarded add is run more than once.
+	 *
+	 * Mirrors the fixed code path in Tribe__Tickets__Tickets::ticket_add(): the flag is only
+	 * added when has_manual_update() is false for that key, so re-running the same guarded
+	 * logic against a ticket that already carries the flag is a no-op.
+	 *
+	 * @test
+	 */
+	public function should_not_duplicate_manual_update_flag_when_guarded_add_runs_twice() {
+		/** @var \Tribe__Tickets__Handler $tickets_handler */
+		$tickets_handler = tribe( 'tickets.handler' );
+
+		$ticket_id = $this->factory->post->create( [ 'post_type' => 'tribe_rsvp_tickets' ] );
+
+		$add_flag_if_missing = static function () use ( $tickets_handler, $ticket_id ) {
+			if ( ! $tickets_handler->has_manual_update( $ticket_id, $tickets_handler->key_end_date ) ) {
+				add_post_meta( $ticket_id, $tickets_handler->key_manual_updated, $tickets_handler->key_end_date );
+			}
+		};
+
+		$add_flag_if_missing();
+		$add_flag_if_missing();
+		$add_flag_if_missing();
+
+		$manual_updates = get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' );
+		$this->assertCount( 1, $manual_updates, 'The has_manual_update() guard must prevent duplicate entries across repeated calls' );
+	}
+
+	/**
 	 * Creates a ticket through the RSVP provider using the shared ticket_add() path.
 	 *
 	 * @param int   $post_id   The ticket-able post ID.

--- a/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
@@ -151,7 +151,7 @@ class Tickets_Sale_End_DateTest extends WPBrowserTestCase {
 
 		$ticket_id = $rsvp->ticket_add( $post_id, $data );
 
-		$this->assertNotEmpty( $ticket_id );
+		$this->assertIsInt( $ticket_id );
 
 		return $ticket_id;
 	}

--- a/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
@@ -43,6 +43,11 @@ class Tickets_Sale_End_DateTest extends WPBrowserTestCase {
 		);
 
 		$this->assertContains( '_ticket_end_date', get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' ) );
+
+		$ticket = tribe( 'tickets.rsvp' )->get_ticket( $post_id, $ticket_id );
+
+		$this->assertEquals( '2026-09-15', $ticket->end_date );
+		$this->assertEquals( strtotime( '2026-09-15 08:00:00' ), $ticket->end_date() );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets_Sale_End_DateTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tribe\Tickets;
+
+use lucatume\WPBrowser\TestCase\WPTestCase as WPBrowserTestCase;
+
+/**
+ * Covers the sale end date manual update flag set when a ticket is created.
+ *
+ * The block editor always submits a sale end date, so the flag must only be
+ * added when that date differs from the event start date; otherwise a default
+ * ticket stops following event start changes.
+ */
+class Tickets_Sale_End_DateTest extends WPBrowserTestCase {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Enable posts as ticket-able posts.
+		add_filter( 'tribe_tickets_post_types', function () {
+			return [ 'post' ];
+		} );
+	}
+
+	/**
+	 * It should flag a custom sale end date on ticket creation.
+	 *
+	 * @test
+	 */
+	public function should_flag_custom_sale_end_date_on_creation() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_EventStartDate', '2026-08-28 08:00:00' );
+
+		$ticket_id = $this->create_ticket(
+			$post_id,
+			[
+				'ticket_end_date' => '2026-09-15',
+				'ticket_end_time' => '08:00:00',
+			]
+		);
+
+		$this->assertContains( '_ticket_end_date', get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' ) );
+	}
+
+	/**
+	 * It should not flag a default sale end date on ticket creation.
+	 *
+	 * @test
+	 */
+	public function should_not_flag_default_sale_end_date_on_creation() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_EventStartDate', '2026-08-28 08:00:00' );
+
+		$ticket_id = $this->create_ticket(
+			$post_id,
+			[
+				'ticket_end_date' => '2026-08-28',
+				'ticket_end_time' => '08:00:00',
+			]
+		);
+
+		$this->assertEmpty( get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' ) );
+	}
+
+	/**
+	 * It should not flag a ticket created without a sale end date.
+	 *
+	 * @test
+	 */
+	public function should_not_flag_ticket_created_without_end_date() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_EventStartDate', '2026-08-28 08:00:00' );
+
+		$ticket_id = $this->create_ticket( $post_id, [ 'ticket_end_date' => '' ] );
+
+		$this->assertEmpty( get_post_meta( $ticket_id, '_tribe_ticket_manual_updated' ) );
+	}
+
+	/**
+	 * It should keep a custom sale end date when the event start date changes.
+	 *
+	 * @test
+	 */
+	public function should_keep_custom_sale_end_date_when_event_start_changes() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_EventStartDate', '2026-08-28 08:00:00' );
+
+		$ticket_id = $this->create_ticket(
+			$post_id,
+			[
+				'ticket_end_date' => '2026-09-15',
+				'ticket_end_time' => '08:00:00',
+			]
+		);
+
+		update_post_meta( $post_id, '_EventStartDate', '2026-10-01 08:00:00' );
+
+		$this->assertEquals( '2026-09-15 08:00:00', get_post_meta( $ticket_id, '_ticket_end_date', true ) );
+	}
+
+	/**
+	 * It should sync a default sale end date when the event start date changes.
+	 *
+	 * @test
+	 */
+	public function should_sync_default_sale_end_date_when_event_start_changes() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_EventStartDate', '2026-08-28 08:00:00' );
+
+		$ticket_id = $this->create_ticket(
+			$post_id,
+			[
+				'ticket_end_date' => '2026-08-28',
+				'ticket_end_time' => '08:00:00',
+			]
+		);
+
+		update_post_meta( $post_id, '_EventStartDate', '2026-10-01 08:00:00' );
+
+		$this->assertEquals( '2026-10-01 08:00:00', get_post_meta( $ticket_id, '_ticket_end_date', true ) );
+	}
+
+	/**
+	 * Creates a ticket through the RSVP provider using the shared ticket_add() path.
+	 *
+	 * @param int   $post_id   The ticket-able post ID.
+	 * @param array $overrides Data overrides, mirroring the block editor REST payload keys.
+	 *
+	 * @return int The created ticket ID.
+	 */
+	private function create_ticket( $post_id, array $overrides = [] ) {
+		/** @var \Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		$data = array_merge(
+			[
+				'ticket_name'             => 'Test ticket',
+				'ticket_description'      => 'Test ticket description',
+				'ticket_price'            => 0,
+				'ticket_show_description' => 'yes',
+				'ticket_start_date'       => '2026-08-01',
+				'ticket_start_time'       => '08:00:00',
+				'ticket_end_date'         => '2026-09-15',
+				'ticket_end_time'         => '08:00:00',
+			],
+			$overrides
+		);
+
+		$ticket_id = $rsvp->ticket_add( $post_id, $data );
+
+		$this->assertNotEmpty( $ticket_id );
+
+		return $ticket_id;
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2280](https://linear.app/nexcess/issue/SMTNC-2280/event-ticket-sale-end-date-reverts-to-event-date-in-block)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (bug fix - custom ticket sale end date reverted to event date in block editor)

Fixed an issue where a custom ticket sale end date set in the block editor was overwritten with the event start date when the event was saved or the page reloaded. Sale end dates that differ from the event start are now flagged as manually set when the ticket is created, so the event-date sync skips them; the block editor no longer defaults existing tickets' sale end to the event start, and the date picker re-syncs to the saved value once the ticket data loads.

Note: the day-picker change ships in the `tribe-common` submodule and is tracked on the matching `fix/smtnc-2280-...` branch in `the-events-calendar/tribe-common`.

https://github.com/the-events-calendar/tribe-common/pull/2984


### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/7ca20b14e1af42d79aaf8c3d1a7cf855

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
