### PR TITLE
[SMTNC-1296] tec_kv_cache() returns outdated ticket status/number on calendar views (Sold out vs Remaining tickets)

### DIFF
--- a/changelog/smtnc-1296-tec-kv-cache-returns-outdated-ticket-statusnumber-on.yaml
+++ b/changelog/smtnc-1296-tec-kv-cache-returns-outdated-ticket-statusnumber-on.yaml
@@ -1,6 +1,6 @@
 significance: patch
 type: fix
-entry: Dropped the cached calendar-view ticket data when tickets are sold instead of
-  rebuilding it mid-order, resolving an issue where sold-out events kept showing the
-  remaining ticket count on calendar and list views.
+entry: Dropped the cached calendar-view ticket data when tickets are sold and when the
+  plugin updates, instead of rebuilding it mid-order, resolving an issue where sold-out
+  events kept showing the remaining ticket count on calendar and list views.
 timestamp: 2026-08-27T21:57:28.008Z

--- a/changelog/smtnc-1296-tec-kv-cache-returns-outdated-ticket-statusnumber-on.yaml
+++ b/changelog/smtnc-1296-tec-kv-cache-returns-outdated-ticket-statusnumber-on.yaml
@@ -1,6 +1,6 @@
 significance: patch
 type: fix
-entry: Rebuilt the cached calendar-view ticket data from the current ticket
-  stock after a purchase, resolving an issue where sold-out events kept showing
-  the remaining ticket count on calendar and list views.
+entry: Dropped the cached calendar-view ticket data when tickets are sold instead of
+  rebuilding it mid-order, resolving an issue where sold-out events kept showing the
+  remaining ticket count on calendar and list views.
 timestamp: 2026-08-27T21:57:28.008Z

--- a/changelog/smtnc-1296-tec-kv-cache-returns-outdated-ticket-statusnumber-on.yaml
+++ b/changelog/smtnc-1296-tec-kv-cache-returns-outdated-ticket-statusnumber-on.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Rebuilt the cached calendar-view ticket data from the current ticket
+  stock after a purchase, resolving an issue where sold-out events kept showing
+  the remaining ticket count on calendar and list views.
+timestamp: 2026-08-27T21:57:28.008Z

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -174,10 +174,22 @@ class Tickets implements ArrayAccess {
 					$tribe_cache[ $tickets_cache_key ] = null;
 				}
 
+				/*
+				 * The model reads the aggregate list, not the per-provider one, and that list holds Ticket
+				 * objects carrying the stock they had when it was built.
+				 */
+				$all_tickets_cache_key                 = "{$tickets_class}::get_all_event_tickets-{$connected_event_id}";
+				$tribe_cache[ $all_tickets_cache_key ] = null;
+
+				/*
+				 * Drop the Event model entry before rebuilding it: a model built while its entry is live
+				 * restores that entry's data and stores it back, keeping the pre-purchase stock.
+				 */
+				tec_kv_cache()->delete( self::get_cache_key( $connected_event_id ) );
+
 				$model = new self( $connected_event_id );
 				// The call will trigger a priming of the model cache.
 				$model->exist();
-				$model->prime_cache();
 			}
 		}
 

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -14,6 +14,7 @@ use ArrayAccess;
 use Closure;
 use InvalidArgumentException;
 use ReturnTypeWillChange;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use Tribe\Utils\Lazy_Events;
 use Tribe__Events__Main as TEC;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
@@ -234,6 +235,7 @@ class Tickets implements ArrayAccess {
 			// Refresh stock display from current availability so list/archive views stay correct
 			// when event or ticket model is served from cache (e.g. tribe_get_event memoization).
 			$this->refresh_cached_stock_display();
+			$this->refresh_cached_link();
 			return $this->data;
 		}
 
@@ -583,6 +585,26 @@ class Tickets implements ArrayAccess {
 	}
 
 	/**
+	 * Points the cached link at this model's own post, keeping the anchor it was built with.
+	 *
+	 * Occurrences of a recurring Event share one cached entry but not one permalink, so the link
+	 * has to be rebuilt for whichever Occurrence is being rendered.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function refresh_cached_link(): void {
+		if ( ! isset( $this->data['link'] ) || ! is_object( $this->data['link'] ) ) {
+			return;
+		}
+
+		$anchor = strstr( $this->data['link']->anchor, '#' );
+
+		$this->data['link']->anchor = get_permalink( $this->post_id ) . ( false === $anchor ? '' : $anchor );
+	}
+
+	/**
 	 * Primes the model cache from the key-value cache, if possible.
 	 *
 	 * @since 5.26.1
@@ -617,6 +639,14 @@ class Tickets implements ArrayAccess {
 	 * @return string The model cache key used to store it in the key-value cache.
 	 */
 	public static function get_cache_key( int $post_id ): string {
+		if ( class_exists( Occurrence::class, false ) ) {
+			/*
+			 * Views hand over the Occurrence's provisional ID while the invalidation side only ever
+			 * knows the Event post ID, so the two have to meet on the normalized one.
+			 */
+			$post_id = apply_filters( 'tec_tickets_normalize_occurrence_id', Occurrence::normalize_id( $post_id ) );
+		}
+
 		return 'tec_tickets_views_v2_model_ticket_' . $post_id;
 	}
 

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -634,6 +634,9 @@ class Tickets implements ArrayAccess {
 	/**
 	 * Returns the model cache key used to store it in the key-value cache.
 	 *
+	 * Views hand over the Occurrence's provisional ID while the invalidation side only ever knows the
+	 * Event post ID, so the key is built from the normalized one to make the two meet.
+	 *
 	 * @since 5.26.1
 	 * @since TBD Normalized the Occurrence ID so the views and the invalidation resolve to the same key.
 	 *
@@ -643,9 +646,13 @@ class Tickets implements ArrayAccess {
 	 */
 	public static function get_cache_key( int $post_id ): string {
 		if ( class_exists( Occurrence::class, false ) ) {
-			/*
-			 * Views hand over the Occurrence's provisional ID while the invalidation side only ever
-			 * knows the Event post ID, so the two have to meet on the normalized one.
+			/**
+			 * Filters the post ID to use when fetching tickets for an Occurrence.
+			 *
+			 * @since 5.8.0
+			 *
+			 * @param int $post_id The post ID to use when fetching tickets for an Occurrence; this might
+			 *                     be a real post ID, or a provisional one.
 			 */
 			$post_id = apply_filters( 'tec_tickets_normalize_occurrence_id', Occurrence::normalize_id( $post_id ) );
 		}

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -87,7 +87,10 @@ class Tickets implements ArrayAccess {
 	}
 
 	/**
-	 * Regenerates the caches for the models associated with the post ID.
+	 * Drops the cached models associated with the post ID so the next front-end request rebuilds them.
+	 *
+	 * The models are not rebuilt here. Commerce writes the Attendee posts before it writes the Ticket
+	 * stock, so a model built from this hook would capture a mid-order stock and keep serving it.
 	 *
 	 * @since 5.26.1
 	 *
@@ -119,11 +122,7 @@ class Tickets implements ArrayAccess {
 
 		add_action( 'parse_query', $do_not_cache_results );
 
-		if ( $post->post_type === TEC::POSTTYPE ) {
-			// It's an Event: refresh its cache.
-			$model = new self( $post->ID );
-			$model->exist();
-		} else {
+		if ( $post->post_type !== TEC::POSTTYPE ) {
 			// These are maps from the service slug to the post type, so we keep only the post type.
 			$attendee_post_types = array_values( tribe_attendees()->attendee_types() );
 			$ticket_types        = array_values( tribe_tickets()->ticket_types() );
@@ -181,15 +180,7 @@ class Tickets implements ArrayAccess {
 				$all_tickets_cache_key                 = "{$tickets_class}::get_all_event_tickets-{$connected_event_id}";
 				$tribe_cache[ $all_tickets_cache_key ] = null;
 
-				/*
-				 * Drop the Event model entry before rebuilding it: a model built while its entry is live
-				 * restores that entry's data and stores it back, keeping the pre-purchase stock.
-				 */
 				tec_kv_cache()->delete( self::get_cache_key( $connected_event_id ) );
-
-				$model = new self( $connected_event_id );
-				// The call will trigger a priming of the model cache.
-				$model->exist();
 			}
 		}
 

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -94,6 +94,7 @@ class Tickets implements ArrayAccess {
 	 * stock, so a model built from this hook would capture a mid-order stock and keep serving it.
 	 *
 	 * @since 5.26.1
+	 * @since TBD Dropped the models instead of rebuilding them, so a mid-order stock is never stored.
 	 *
 	 * @param int $post_id The post ID. It could be any post type, not just events.
 	 *
@@ -223,6 +224,7 @@ class Tickets implements ArrayAccess {
 	 * @since 5.6.3 Add support for the updated anchor link from new ticket templates.
 	 * @since 5.26.7 Fixed issue where empty arrays were being returned when data existed but was empty.
 	 * @since 5.27.5 Fixed issue where the stock display was not being refreshed from the current availability.
+	 * @since TBD Rebuilt the link from the model's own post so a shared cache entry keeps per-Occurrence permalinks.
 	 *
 	 * @return array Ticket data or empty array.
 	 */
@@ -633,6 +635,7 @@ class Tickets implements ArrayAccess {
 	 * Returns the model cache key used to store it in the key-value cache.
 	 *
 	 * @since 5.26.1
+	 * @since TBD Normalized the Occurrence ID so the views and the invalidation resolve to the same key.
 	 *
 	 * @param int $post_id The post ID to provide the cache key for.
 	 *

--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -34,6 +34,7 @@ class Tribe__Tickets__Updater extends Tribe__Updater {
 	public function get_constant_update_callbacks() {
 		return [
 			[ $this, 'migrate_4_12_hide_attendees_list' ],
+			[ $this, 'flush_key_value_cache' ],
 		];
 	}
 
@@ -50,6 +51,20 @@ class Tribe__Tickets__Updater extends Tribe__Updater {
 		if ( 'complete' !== $migration->get_current_offset() ) {
 			$migration->register_scheduled_task();
 		}
+	}
+
+	/**
+	 * Drops the key-value cache so nothing an earlier version stored survives the update.
+	 *
+	 * Entries live for a day and are only rewritten when a Ticket is sold, so one holding a stale
+	 * availability would otherwise keep being served on calendar views long after the update.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush_key_value_cache() {
+		tec_kv_cache()->flush();
 	}
 
 }

--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -28,6 +28,7 @@ class Tribe__Tickets__Updater extends Tribe__Updater {
 	 * every time the version is updated.
 	 *
 	 * @since 4.12.0
+	 * @since TBD Added the key-value cache flush.
 	 *
 	 * @return array
 	 */
@@ -63,7 +64,7 @@ class Tribe__Tickets__Updater extends Tribe__Updater {
 	 *
 	 * @return void
 	 */
-	public function flush_key_value_cache() {
+	public function flush_key_value_cache(): void {
 		tec_kv_cache()->flush();
 	}
 

--- a/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
+++ b/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
@@ -3,6 +3,7 @@
 namespace Tribe\Tickets\Events\Views\V2\Models;
 
 use lucatume\WPBrowser\TestCase\WPTestCase;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use TEC\Tickets\Commerce\Module;
 use Tribe\Tickets\Events\Views\V2\Hooks;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
@@ -218,5 +219,27 @@ class Tickets_Test extends WPTestCase {
 		$this->assertTrue( $sold_out_model->sold_out() );
 		$this->assertEquals( 'Sold Out', $sold_out_stock->sold_out );
 		$this->assertEquals( '', $sold_out_stock->available );
+	}
+
+	/**
+	 * @test
+	 * @covers \Tribe\Tickets\Events\Views\V2\Models\Tickets::get_cache_key
+	 */
+	public function should_key_the_cache_on_the_normalized_event_id(): void {
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2023-01-01 09:00:00',
+			'duration'   => 4 * HOUR_IN_SECONDS,
+		] )->create()->ID;
+
+		/* The key only normalizes when Custom Tables is already loaded, as it is on a front-end request. */
+		$this->assertTrue( class_exists( Occurrence::class ) );
+
+		/* Custom Tables hands out no provisional IDs in this suite, so stand in for its normalization. */
+		$provisional_id = static::factory()->post->create();
+		add_filter( 'tec_tickets_normalize_occurrence_id', static fn() => $event_id );
+
+		$this->assertEquals( Tickets::get_cache_key( $event_id ), Tickets::get_cache_key( $provisional_id ) );
 	}
 }

--- a/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
+++ b/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
@@ -4,6 +4,7 @@ namespace Tribe\Tickets\Events\Views\V2\Models;
 
 use lucatume\WPBrowser\TestCase\WPTestCase;
 use TEC\Tickets\Commerce\Module;
+use Tribe\Tickets\Events\Views\V2\Hooks;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
@@ -106,35 +107,34 @@ class Tickets_Test extends WPTestCase {
 		// For each ticket create an Order for 3 Attendees.
 		$this->create_order( [ $ticket_1_id => 3, $ticket_2_id => 3, $ticket_3_id => 3 ] );
 		$event_cache_key = Tickets::get_cache_key( $event_id );
-		$cleanup = function() use ( $event_cache_key ) {
-			tec_kv_cache()->delete( $event_cache_key );
-			$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
+		$warm            = function () use ( $event_cache_key, $event_id ) {
+			( new Tickets( $event_id ) )->exist();
+			$this->assertTrue( tec_kv_cache()->has( $event_cache_key ) );
 		};
 
-		// Post
+		// Post: an unrelated post type leaves the Event entry alone.
+		$warm();
 		Tickets::regenerate_caches( $post_id );
 		$this->assertFalse( tec_kv_cache()->has( Tickets::get_cache_key( $post_id ) ) );
-
-		// Event.
-		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
-		Tickets::regenerate_caches( $event_id );
 		$this->assertTrue( tec_kv_cache()->has( $event_cache_key ) );
 
-		$cleanup();
+		// Event.
+		Tickets::regenerate_caches( $event_id );
+		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
 
 		// Attendee.
+		$warm();
 		$attendee_id = tribe_attendees()->where( 'event', $event_id )->fields( 'ids' )->first();
 		Tickets::regenerate_caches( $attendee_id );
 		$this->assertFalse( tec_kv_cache()->has( Tickets::get_cache_key( $attendee_id ) ) );
-		$this->assertTrue( tec_kv_cache()->has( $event_cache_key ) );
-
-		$cleanup();
+		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
 
 		// Ticket.
+		$warm();
 		$ticket_id = tribe_tickets()->where( 'event', $event_id )->fields( 'ids' )->first();
 		Tickets::regenerate_caches( $ticket_id );
 		$this->assertFalse( tec_kv_cache()->has( Tickets::get_cache_key( $ticket_id ) ) );
-		$this->assertTrue( tec_kv_cache()->has( $event_cache_key ) );
+		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
 	}
 
 	/**
@@ -165,9 +165,8 @@ class Tickets_Test extends WPTestCase {
 		}
 
 		// Event.
-		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
 		Tickets::regenerate_caches( $event_id );
-		$this->assertTrue( tec_kv_cache()->has( $event_cache_key ) );
+		$this->assertFalse( tec_kv_cache()->has( $event_cache_key ) );
 
 		$array_model = ( new Tickets( $event_id ) )->to_array();
 
@@ -176,13 +175,11 @@ class Tickets_Test extends WPTestCase {
 				[
 					'anchor'             => 'http://wordpress.test/?tribe_events=test-event#tribe-tickets__tickets-form',
 					'label'              => 'Get Tickets',
-					'__original_class__' => 'stdClass',
 				],
 			'stock' =>
 				[
 					'available'          => '291 tickets left',
 					'sold_out'           => '',
-					'__original_class__' => 'stdClass',
 				],
 		], $array_model );
 	}
@@ -207,10 +204,13 @@ class Tickets_Test extends WPTestCase {
 		$this->assertEquals( "{$capacity} tickets left", $on_sale_stock->available );
 		$this->assertEquals( '', $on_sale_stock->sold_out );
 
-		$this->create_order( [ $ticket_id => $capacity ] );
+		/*
+		 * The Views V2 hooks do not boot in this suite, so register the production callback: the order
+		 * then fires it on each Attendee insert, which Commerce does before it writes the Ticket stock.
+		 */
+		add_action( 'wp_insert_post', [ tribe( Hooks::class ), 'regenerate_post_kv_caches' ], 100 );
 
-		$attendee_id = tribe_attendees()->where( 'event', $event_id )->fields( 'ids' )->first();
-		Tickets::regenerate_caches( $attendee_id );
+		$this->create_order( [ $ticket_id => $capacity ] );
 
 		$sold_out_model = new Tickets( $event_id );
 		$sold_out_stock = $sold_out_model['stock'];

--- a/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
+++ b/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
@@ -186,4 +186,37 @@ class Tickets_Test extends WPTestCase {
 				],
 		], $array_model );
 	}
+
+	/**
+	 * @test
+	 * @covers \Tribe\Tickets\Events\Views\V2\Models\Tickets::regenerate_caches
+	 */
+	public function should_report_sold_out_after_the_last_available_ticket_is_purchased(): void {
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2023-01-01 09:00:00',
+			'duration'   => 4 * HOUR_IN_SECONDS,
+		] )->create()->ID;
+		$capacity  = 5;
+		$ticket_id = $this->with_capacity( $capacity )->create_tc_ticket( $event_id );
+
+		// Warm the model cache the way a calendar view would, while the ticket is still on sale.
+		$on_sale_stock = ( new Tickets( $event_id ) )['stock'];
+
+		$this->assertEquals( "{$capacity} tickets left", $on_sale_stock->available );
+		$this->assertEquals( '', $on_sale_stock->sold_out );
+
+		$this->create_order( [ $ticket_id => $capacity ] );
+
+		$attendee_id = tribe_attendees()->where( 'event', $event_id )->fields( 'ids' )->first();
+		Tickets::regenerate_caches( $attendee_id );
+
+		$sold_out_model = new Tickets( $event_id );
+		$sold_out_stock = $sold_out_model['stock'];
+
+		$this->assertTrue( $sold_out_model->sold_out() );
+		$this->assertEquals( 'Sold Out', $sold_out_stock->sold_out );
+		$this->assertEquals( '', $sold_out_stock->available );
+	}
 }

--- a/tests/integration/Tribe/Tickets/UpdaterTest.php
+++ b/tests/integration/Tribe/Tickets/UpdaterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tribe\Tickets;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tribe__Tickets__Main;
+use Tribe__Tickets__Updater;
+
+class UpdaterTest extends WPTestCase {
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Updater::flush_key_value_cache
+	 */
+	public function should_flush_the_key_value_cache(): void {
+		$key = 'tec_tickets_updater_test_entry';
+		tec_kv_cache()->set( $key, 'cached value', DAY_IN_SECONDS );
+
+		$this->assertTrue( tec_kv_cache()->has( $key ) );
+
+		( new Tribe__Tickets__Updater( Tribe__Tickets__Main::VERSION ) )->flush_key_value_cache();
+
+		$this->assertFalse( tec_kv_cache()->has( $key ) );
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Updater::get_constant_update_callbacks
+	 */
+	public function should_flush_the_key_value_cache_on_every_version_update(): void {
+		$updater = new Tribe__Tickets__Updater( Tribe__Tickets__Main::VERSION );
+
+		$this->assertContains( 'flush_key_value_cache', array_column( $updater->get_constant_update_callbacks(), 1 ) );
+	}
+}

--- a/tests/integration/Tribe/Tickets/UpdaterTest.php
+++ b/tests/integration/Tribe/Tickets/UpdaterTest.php
@@ -3,33 +3,32 @@
 namespace Tribe\Tickets;
 
 use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tribe__Settings_Manager;
 use Tribe__Tickets__Main;
-use Tribe__Tickets__Updater;
 
 class UpdaterTest extends WPTestCase {
 
 	/**
 	 * @test
 	 * @covers Tribe__Tickets__Updater::flush_key_value_cache
+	 * @covers Tribe__Tickets__Updater::get_constant_update_callbacks
 	 */
-	public function should_flush_the_key_value_cache(): void {
+	public function should_flush_the_key_value_cache_on_update(): void {
 		$key = 'tec_tickets_updater_test_entry';
 		tec_kv_cache()->set( $key, 'cached value', DAY_IN_SECONDS );
 
 		$this->assertTrue( tec_kv_cache()->has( $key ) );
 
-		( new Tribe__Tickets__Updater( Tribe__Tickets__Main::VERSION ) )->flush_key_value_cache();
+		/* Any version below the current one is what makes the updater treat the install as out of date. */
+		Tribe__Settings_Manager::set_option( 'event-tickets-schema-version', '0.1.0' );
+
+		Tribe__Tickets__Main::instance()->run_updates();
 
 		$this->assertFalse( tec_kv_cache()->has( $key ) );
-	}
-
-	/**
-	 * @test
-	 * @covers Tribe__Tickets__Updater::get_constant_update_callbacks
-	 */
-	public function should_flush_the_key_value_cache_on_every_version_update(): void {
-		$updater = new Tribe__Tickets__Updater( Tribe__Tickets__Main::VERSION );
-
-		$this->assertContains( 'flush_key_value_cache', array_column( $updater->get_constant_update_callbacks(), 1 ) );
+		$this->assertEquals(
+			Tribe__Tickets__Main::VERSION,
+			Tribe__Settings_Manager::get_option( 'event-tickets-schema-version' ),
+			'The update should have run to completion, not bailed before the flush.'
+		);
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1296](https://linear.app/nexcess/issue/SMTNC-1296/tec-kv-cache-returns-outdated-ticket-statusnumber-on-calendar-views)

### 🎥 Artifacts

https://www.loom.com/share/805d73040b25463282f89f29e7be43d3

### 🗒️ Description

Keeps the calendar-view ticket model in step with real availability: it is dropped when tickets sell rather than rebuilt mid-order, keyed on the normalized Event ID so invalidation reaches the entry the views actually read, and cleared on plugin update so entries written by an earlier version don't linger.

### ⚠️ Blockers

None

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
