### PR TITLE
SOFT-3340 - start date cannot be after end date

### DIFF
--- a/src/Tickets/RSVP/V2/Assets.php
+++ b/src/Tickets/RSVP/V2/Assets.php
@@ -37,7 +37,7 @@ class Assets {
 			$plugin,
 			'tribe-tickets-admin-tickets',
 			'commerce/tickets.js',
-			[ 'jquery', 'tec-api' ],
+			[ 'jquery', 'tec-api', 'jquery-ui-datepicker', 'tribe-validation' ],
 			'admin_enqueue_scripts',
 			[
 				'conditionals' => [ $this, 'should_enqueue_classic_editor_assets' ],

--- a/src/Tickets/RSVP/V2/Metabox.php
+++ b/src/Tickets/RSVP/V2/Metabox.php
@@ -142,6 +142,12 @@ class Metabox {
 		$rsvp_id = $tc_rsvp instanceof Tribe__Tickets__Ticket_Object ? $tc_rsvp->ID : null;
 		$context = array_merge( $context, ( new Ticket_Panel_Data( $post->ID, $rsvp_id ) )->to_array() );
 
+		// The panel data speaks in ticket sale dates; the RSVP metabox labels them Open/Close RSVP.
+		$context['start_date_errors'] = [
+			'is-required'         => __( 'Open RSVP date cannot be empty.', 'event-tickets' ),
+			'is-less-or-equal-to' => __( 'Open RSVP date cannot be later than the Close RSVP date.', 'event-tickets' ),
+		];
+
 		// Add the data required by each panel to render correctly.
 		$context['rsvp_id']        = 0;
 		$context['show_not_going'] = '';

--- a/src/admin-views/editor/panel/fields/rsvp/dates.php
+++ b/src/admin-views/editor/panel/fields/rsvp/dates.php
@@ -46,7 +46,7 @@ $default_end_time = '00:00:00';
 				id="rsvp_start_date"
 				value="<?php echo esc_attr( $tc_rsvp ? $ticket_start_date : $default_start_date ); ?>"
 				data-validation-type="datepicker"
-
+				data-validation-is-less-or-equal-to="#rsvp_end_date"
 				data-validation-error="<?php echo esc_attr( wp_json_encode( $start_date_errors ) ); ?>"
 			/>
 			<span class="helper-text hide-if-js"><?php esc_html_e( 'YYYY-MM-DD', 'event-tickets' ); ?></span>

--- a/src/resources/js/commerce/tickets.js
+++ b/src/resources/js/commerce/tickets.js
@@ -1,4 +1,4 @@
-/* global tribe, jQuery, tecTicketsCommerceTickets, tribe_timepickers, wp */
+/* global tribe, jQuery, tecTicketsCommerceTickets, tribe_timepickers, tribe_l10n_datatables, wp */
 import { registerMiddlewares } from '@tec/common/tecApi';
 import apiFetch from '@wordpress/api-fetch';
 import { doAction } from '@wordpress/hooks';
@@ -60,8 +60,34 @@ tribe.tickets.commerce.tickets = {};
 		hiddenElement: 'tribe-common-a11y-hidden',
 		rsvpMetabox: '#tec-tickets-commerce-rsvp',
 		timepicker: '.tribe-timepicker:not(.ui-timepicker-input)',
+		startDate: '#rsvp_start_date',
+		endDate: '#rsvp_end_date',
+		datepickerFormat: '[data-datepicker_format]',
 		postForm: '#post',
 	};
+
+	/**
+	 * jQuery UI datepicker formats, indexed to match the format index stored by
+	 * `Tribe__Date_Utils::get_datepicker_format_index()`.
+	 *
+	 * @since TBD
+	 *
+	 * @type {string[]}
+	 */
+	obj.datepickerFormats = [
+		'yy-mm-dd',
+		'm/d/yy',
+		'mm/dd/yy',
+		'd/m/yy',
+		'dd/mm/yy',
+		'm-d-yy',
+		'mm-dd-yy',
+		'd-m-yy',
+		'dd-mm-yy',
+		'yy.mm.dd',
+		'mm.dd.yy',
+		'dd.mm.yy',
+	];
 
 	/**
 	 * Starts the process to delete an RSVP ticket.
@@ -116,6 +142,73 @@ tribe.tickets.commerce.tickets = {};
 			const $timepickers = $rsvpMetabox.find( obj.selectors.timepicker );
 			tribe_timepickers.setup_timepickers( $timepickers );
 		}
+	};
+
+	/**
+	 * Setup datepickers for the RSVP metabox.
+	 *
+	 * The Events Calendar initializes every `.tribe-datepicker` on the screen, but its
+	 * handler only knows about the event start/end fields, so the RSVP dates would be
+	 * left without the constraint that keeps the window valid. Re-initializing them here
+	 * mirrors what `tickets.js` does for the Tickets metabox: picking an Open RSVP date
+	 * sets it as the minimum on Close RSVP, and jQuery UI moves Close forward to match.
+	 *
+	 * @since TBD
+	 */
+	obj.setupDatepickers = () => {
+		const $metabox = $( obj.selectors.rsvpMetabox );
+		const $startDate = $metabox.find( obj.selectors.startDate );
+		const $endDate = $metabox.find( obj.selectors.endDate );
+
+		if ( ! $startDate.length || ! $endDate.length || 'function' !== typeof $.fn.datepicker ) {
+			return;
+		}
+
+		const formatIndex = parseInt( $metabox.find( obj.selectors.datepickerFormat ).data( 'datepicker_format' ), 10 );
+		const dateFormat = obj.datepickerFormats[ formatIndex ] || obj.datepickerFormats[ 0 ];
+
+		const datepickerOpts = {
+			dateFormat,
+			showAnim: 'fadeIn',
+			changeMonth: true,
+			changeYear: true,
+			numberOfMonths: 3,
+			showButtonPanel: false,
+			onSelect( dateText, inst ) {
+				const date = $.datepicker.parseDate( dateFormat, dateText );
+
+				// Setting the option re-clamps the sibling field's value, keeping the window valid.
+				if ( inst.id === $startDate.attr( 'id' ) ) {
+					$endDate.datepicker( 'option', 'minDate', date );
+				} else {
+					$startDate.datepicker( 'option', 'maxDate', date );
+				}
+			},
+		};
+
+		if ( 'undefined' !== typeof tribe_l10n_datatables && tribe_l10n_datatables.datepicker ) {
+			$.extend( datepickerOpts, tribe_l10n_datatables.datepicker );
+		}
+
+		$startDate.add( $endDate ).datepicker( datepickerOpts );
+	};
+
+	/**
+	 * Setup validation for the RSVP metabox.
+	 *
+	 * Without this the `validation.tribe` event fired by `validateBeforePostSave` has no
+	 * listener, so every constraint in the panel is silently ignored on save.
+	 *
+	 * @since TBD
+	 */
+	obj.setupValidation = () => {
+		const $metabox = $( obj.selectors.rsvpMetabox );
+
+		if ( ! $metabox.length || 'undefined' === typeof tribe || ! tribe.validation ) {
+			return;
+		}
+
+		$metabox.find( tribe.validation.selectors.item ).validation();
 	};
 
 	/**
@@ -267,6 +360,8 @@ tribe.tickets.commerce.tickets = {};
 		registerMiddlewares();
 		obj.bindEvents();
 		obj.setupTimepickers();
+		obj.setupDatepickers();
+		obj.setupValidation();
 	};
 
 	$( obj.ready );

--- a/src/resources/js/commerce/tickets.js
+++ b/src/resources/js/commerce/tickets.js
@@ -174,6 +174,15 @@ tribe.tickets.commerce.tickets = {};
 			changeYear: true,
 			numberOfMonths: 3,
 			showButtonPanel: false,
+			beforeShow( element, object ) {
+				// The datepicker stylesheet is scoped to this class, and `#ui-datepicker-div` is
+				// shared with every other picker on the page, so it is added on open and removed
+				// on close rather than left behind to style someone else's calendar.
+				$( object.dpDiv ).addClass( 'tribe-ui-datepicker' );
+			},
+			onClose() {
+				$( '#ui-datepicker-div' ).removeClass( 'tribe-ui-datepicker' );
+			},
 			onSelect( dateText, inst ) {
 				const date = $.datepicker.parseDate( dateFormat, dateText );
 

--- a/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
@@ -126,6 +126,25 @@ class Metabox_Test extends WPTestCase {
 	}
 
 	/**
+	 * The Open RSVP field constrains itself against Close RSVP; without the attribute the
+	 * panel saves an impossible window and the RSVP silently vanishes from the front end.
+	 *
+	 * @test
+	 */
+	public function it_should_constrain_the_open_date_against_the_close_date(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$this->create_tc_rsvp_ticket( $post_id );
+
+		$html = tribe( Metabox::class )->render( $post_id );
+
+		$this->assertStringContainsString(
+			'data-validation-is-less-or-equal-to="#rsvp_end_date"',
+			$html,
+			'The Open RSVP date field must be constrained against the Close RSVP date field.'
+		);
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_render_same_output_for_post_id_and_wp_post_object(): void {

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and capacity__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and capacity__0.snapshot.html
@@ -111,8 +111,8 @@
 				id="rsvp_start_date"
 				value="1/2/2020"
 				data-validation-type="datepicker"
-
-				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+				data-validation-is-less-or-equal-to="#rsvp_end_date"
+				data-validation-error="{&quot;is-required&quot;:&quot;Open RSVP date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Open RSVP date cannot be later than the Close RSVP date.&quot;}"
 			/>
 			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
 			<span class="datetime_seperator"> at </span>

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and show not going enabled__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and show not going enabled__0.snapshot.html
@@ -111,8 +111,8 @@
 				id="rsvp_start_date"
 				value="1/2/2020"
 				data-validation-type="datepicker"
-
-				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+				data-validation-is-less-or-equal-to="#rsvp_end_date"
+				data-validation-error="{&quot;is-required&quot;:&quot;Open RSVP date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Open RSVP date cannot be later than the Close RSVP date.&quot;}"
 			/>
 			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
 			<span class="datetime_seperator"> at </span>

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP__0.snapshot.html
@@ -111,8 +111,8 @@
 				id="rsvp_start_date"
 				value="1/2/2020"
 				data-validation-type="datepicker"
-
-				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+				data-validation-is-less-or-equal-to="#rsvp_end_date"
+				data-validation-error="{&quot;is-required&quot;:&quot;Open RSVP date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Open RSVP date cannot be later than the Close RSVP date.&quot;}"
 			/>
 			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
 			<span class="datetime_seperator"> at </span>

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post without RSVP__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post without RSVP__0.snapshot.html
@@ -111,8 +111,8 @@
 				id="rsvp_start_date"
 				value="{START_DATE}"
 				data-validation-type="datepicker"
-
-				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+				data-validation-is-less-or-equal-to="#rsvp_end_date"
+				data-validation-error="{&quot;is-required&quot;:&quot;Open RSVP date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Open RSVP date cannot be later than the Close RSVP date.&quot;}"
 			/>
 			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
 			<span class="datetime_seperator"> at </span>


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3340]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This PR is in response to a QA catch where the RSVP V2 you could choose a start date after the end date. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
After:
<img width="800" height="517" alt="CleanShot 2026-08-31 at 09 27 29" src="https://github.com/user-attachments/assets/bd838ff2-de2a-4248-84b9-74eaf87438a6" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here] (https://docs.theeventscalendar.com/developer/git/changelogs/#process) [skip-changelog]
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
This adds a set of methods required to enable the decoupling of the
current RSVP Ticket and Attendee logic from their data implementation.