### PR TITLE
[SOFT-3323] RSVP import

### DIFF
--- a/src/Tickets/RSVP/RSVP_Controller_Methods.php
+++ b/src/Tickets/RSVP/RSVP_Controller_Methods.php
@@ -71,10 +71,7 @@ trait RSVP_Controller_Methods {
 			return;
 		}
 
-		$this->callbacks['csv_importer_activity'] = $this->container->callback(
-			RSVP_Importer::class,
-			'register_rsvp_activity' 
-		);
+		$this->callbacks['csv_importer_activity'] = [ RSVP_Importer::class, 'register_rsvp_activity' ];
 		add_action( 'tribe_aggregator_record_activity_wakeup', $this->callbacks['csv_importer_activity'] );
 	}
 

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -517,6 +517,8 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 * @return bool
 	 */
 	public function is_valid_record( array $record ) {
+		$this->row_message = false;
+		
 		$valid = parent::is_valid_record( $record );
 		if ( empty( $valid ) ) {
 			return false;

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -62,15 +62,15 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	}
 
 	/**
-	 * Whether the RSVP->Tickets Commerce migration is currently running or paused, in which
-	 * case neither V1 nor V2 tickets should be imported.
+	 * Whether RSVP is disabled on this site, in which case neither V1 nor V2 ticket
+	 * should be imported.
 	 *
 	 * @since TBD
 	 *
 	 * @return bool
 	 */
 	private function is_rsvp_disabled(): bool {
-		return RSVP_Controller::is_migration_in_progress();
+		return ! tribe( RSVP_Controller::class )->is_rsvp_enabled();
 	}
 
 	/**

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -203,12 +203,12 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 		}
 
 		// Fallback: direct query if repository not available.
-		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off fallback lookup, limited to 1 result.
 		$found = ( new WP_Query(
 			[
 				'post_type'      => 'tec_tc_ticket',
 				'posts_per_page' => 1,
 				'post_status'    => 'any',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off fallback lookup, limited to 1 result.
 				'meta_query'     => [
 					[
 						'key'   => '_type',
@@ -312,11 +312,14 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 * @return int
 	 */
 	private function create_post_v2( array $record, WP_Post $event, array $data ): int {
-		$ticket_id                                     = Commerce_Module::get_instance()->ticket_add( $event->ID, $data );
-		self::$ticket_name_cache[ 'v2-' . $event->ID ] = true;
+		$ticket_id = Commerce_Module::get_instance()->ticket_add( $event->ID, $data );
 
-		$tickets_handler = tribe( 'tickets.handler' );
-		update_post_meta( $event->ID, $tickets_handler->key_provider_field, Commerce_Module::class );
+		if ( $ticket_id ) {
+			self::$ticket_name_cache[ 'v2-' . $event->ID ] = true;
+
+			$tickets_handler = tribe( 'tickets.handler' );
+			update_post_meta( $event->ID, $tickets_handler->key_provider_field, Commerce_Module::class );
+		}
 
 		return (int) $ticket_id;
 	}

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -5,6 +5,10 @@
  * @since 4.7
  */
 
+use TEC\Tickets\Commerce\Module as Commerce_Module;
+use TEC\Tickets\RSVP\Controller as RSVP_Controller;
+use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
+
 // phpcs:disable StellarWP.Classes.ValidClassName.NotSnakeCase
 
 /**
@@ -15,7 +19,7 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	/**
 	 * @var array
 	 */
-	protected $required_fields = [ 'event_name', 'ticket_name' ];
+	protected $required_fields = [ 'event_name' ];
 
 	/**
 	 * @var array
@@ -58,6 +62,30 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	}
 
 	/**
+	 * Whether the site is on RSVP V2 (Commerce) - i.e. the import should produce a TC-RSVP ticket.
+	 *
+	 * Version is hook-verifiable via `tec_tickets_rsvp_version`. Tests can control it
+	 * without touching the real option:
+	 * `add_filter( 'tec_tickets_rsvp_version', fn(): string => get_option( 'test_rsvp_version', RSVP_Controller::VERSION_1 ) );`
+	 * then `update_option( 'test_rsvp_version', RSVP_Controller::VERSION_2 )` to force V2.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	private function is_rsvp_v2(): bool {
+		if ( ! function_exists( 'tec_tickets_commerce_is_enabled' ) || ! tec_tickets_commerce_is_enabled() ) {
+			return false;
+		}
+
+		$default = RSVP_Controller::VERSION_1;
+		$version = tribe_get_option( RSVP_Controller::VERSION_OPTION_KEY, $default );
+		$version = apply_filters( 'tec_tickets_rsvp_version', $version );
+
+		return RSVP_Controller::VERSION_2 === $version;
+	}
+
+	/**
 	 * Tribe__Tickets__CSV_Importer__RSVP_Importer constructor.
 	 *
 	 * @since 5.29.0 Made $featured_image_uploader and $rsvp_tickets explicitly nullable.
@@ -80,6 +108,8 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	/**
 	 * Matches an existing post based on the record.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $record The record data.
 	 *
 	 * @return bool
@@ -91,11 +121,50 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 			return false;
 		}
 
+		return $this->is_rsvp_v2()
+			? $this->match_existing_post_v2( $record, $event )
+			: $this->match_existing_post_v1( $record, $event );
+	}
+
+	/**
+	 * V2: one RSVP per event - match if any TC-RSVP ticket exists for the event.
+	 *
+	 * @since TBD
+	 *
+	 * @param array   $record The record data.
+	 * @param WP_Post $event  The event post.
+	 *
+	 * @return bool
+	 */
+	private function match_existing_post_v2( array $record, WP_Post $event ): bool {
+		$cache_key = 'v2-' . $event->ID;
+		$cached    = $this->get_cached_match( $cache_key );
+		if ( null !== $cached ) {
+			return $cached;
+		}
+
+		$match = $this->has_rsvp_for_event_v2( $event );
+
+		return $this->cache_match( $cache_key, $match );
+	}
+
+	/**
+	 * V1: match by ticket_name + event (legacy).
+	 *
+	 * @since TBD
+	 *
+	 * @param array   $record The record data.
+	 * @param WP_Post $event  The event post.
+	 *
+	 * @return bool
+	 */
+	private function match_existing_post_v1( array $record, WP_Post $event ): bool {
 		$ticket_name = $this->get_value_by_key( $record, 'ticket_name' );
 		$cache_key   = $ticket_name . '-' . $event->ID;
 
-		if ( isset( self::$ticket_name_cache[ $cache_key ] ) ) {
-			return self::$ticket_name_cache[ $cache_key ];
+		$cached = $this->get_cached_match( $cache_key );
+		if ( null !== $cached ) {
+			return $cached;
 		}
 
 		$ticket_post = ( new WP_Query(
@@ -108,17 +177,77 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 		) )->get_posts()[0] ?? false;
 
 		if ( empty( $ticket_post ) ) {
-			return false;
+			return $this->cache_match( $cache_key, false );
 		}
 
 		$ticket = $this->rsvp_tickets->get_ticket( $event->ID, $ticket_post->ID );
 
-		$match = false;
+		$match = $ticket instanceof Tribe__Tickets__Ticket_Object && $ticket->get_event() == $event;
 
-		if ( $ticket instanceof Tribe__Tickets__Ticket_Object && $ticket->get_event() == $event ) {
-			$match = true;
+		return $this->cache_match( $cache_key, $match );
+	}
+
+	/**
+	 * Check if an event already has a V2 TC-RSVP ticket.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post $event The event post.
+	 *
+	 * @return bool
+	 */
+	private function has_rsvp_for_event_v2( WP_Post $event ): bool {
+		$repo = tribe( 'tickets.ticket-repository.rsvp' );
+		if ( $repo && $repo->by( 'event', $event->ID )->found() ) {
+			return true;
 		}
 
+		// Fallback: direct query if repository not available.
+		$found = ( new WP_Query(
+			[
+				'post_type'      => 'tec_tc_ticket',
+				'posts_per_page' => 1,
+				'post_status'    => 'any',
+				'meta_query'     => [
+					[
+						'key'   => '_type',
+						'value' => RSVP_V2_Constants::TC_RSVP_TYPE,
+					],
+					[
+						'key'   => '_tec_tickets_commerce_event',
+						'value' => $event->ID,
+					],
+				],
+			]
+		) )->get_posts();
+
+		return ! empty( $found );
+	}
+
+	/**
+	 * Get a cached match result.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $cache_key Cache key.
+	 *
+	 * @return bool|null Cached value or null if not cached.
+	 */
+	private function get_cached_match( string $cache_key ): ?bool {
+		return self::$ticket_name_cache[ $cache_key ] ?? null;
+	}
+
+	/**
+	 * Cache a match result and return it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $cache_key Cache key.
+	 * @param bool   $match     Match result.
+	 *
+	 * @return bool The same match value (for chaining).
+	 */
+	private function cache_match( string $cache_key, bool $match ): bool {
 		self::$ticket_name_cache[ $cache_key ] = $match;
 
 		return $match;
@@ -140,6 +269,8 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	/**
 	 * Creates a new RSVP ticket post.
 	 *
+	 * @since TBD Added V2 handling via `is_rsvp_v2()` dispatcher.
+	 *
 	 * @param array $record The record data.
 	 *
 	 * @return int|bool Either the new RSVP ticket post ID or `false` on failure.
@@ -155,19 +286,57 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 		 *
 		 * @param array
 		 */
-		$data      = (array) apply_filters( 'tribe_tickets_import_rsvp_data', $data );
-		$ticket_id = $this->rsvp_tickets->ticket_add( $event->ID, $data );
+		$data = (array) apply_filters( 'tribe_tickets_import_rsvp_data', $data );
 
-		$ticket_name = $this->get_value_by_key( $record, 'ticket_name' );
-		$cache_key   = $ticket_name . '-' . $event->ID;
-
-		self::$ticket_name_cache[ $cache_key ] = true;
+		$ticket_id = $this->is_rsvp_v2()
+			? $this->create_post_v2( $record, $event, $data )
+			: $this->create_post_v1( $record, $event, $data );
 
 		if ( $this->is_aggregator && ! empty( $this->aggregator_record ) ) {
 			$this->aggregator_record->meta['activity']->add( 'rsvp_tickets', 'created', $ticket_id );
 		}
 
 		return $ticket_id;
+	}
+
+	/**
+	 * Create via Commerce (V2).
+	 *
+	 * @since TBD
+	 *
+	 * @param array   $record The record data.
+	 * @param WP_Post $event  The event.
+	 * @param array   $data   Ticket data.
+	 *
+	 * @return int
+	 */
+	private function create_post_v2( array $record, WP_Post $event, array $data ): int {
+		$ticket_id = Commerce_Module::get_instance()->ticket_add( $event->ID, $data );
+		self::$ticket_name_cache[ 'v2-' . $event->ID ] = true;
+
+		$tickets_handler = tribe( 'tickets.handler' );
+		update_post_meta( $event->ID, $tickets_handler->key_provider_field, Commerce_Module::class );
+
+		return (int) $ticket_id;
+	}
+
+	/**
+	 * Create via legacy RSVP (V1).
+	 *
+	 * @since TBD
+	 *
+	 * @param array   $record The record data.
+	 * @param WP_Post $event  The event.
+	 * @param array   $data   Ticket data.
+	 *
+	 * @return int
+	 */
+	private function create_post_v1( array $record, WP_Post $event, array $data ): int {
+		$ticket_id   = $this->rsvp_tickets->ticket_add( $event->ID, $data );
+		$ticket_name = $this->get_value_by_key( $record, 'ticket_name' );
+		self::$ticket_name_cache[ $ticket_name . '-' . $event->ID ] = true;
+
+		return (int) $ticket_id;
 	}
 
 	/**
@@ -217,13 +386,93 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	}
 
 	/**
-	 * Gets the ticket data from the record.
+	 * Gets the ticket data from the record - dispatcher.
+	 *
+	 * @since TBD
 	 *
 	 * @param array $record The record data.
 	 *
 	 * @return array
 	 */
 	protected function get_ticket_data_from( array $record ) {
+		return $this->is_rsvp_v2()
+			? $this->get_ticket_data_from_v2( $record )
+			: $this->get_ticket_data_from_v1( $record );
+	}
+
+	/**
+	 * V2 data shape - Commerce TC-RSVP.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $record The record data.
+	 *
+	 * @return array
+	 */
+	private function get_ticket_data_from_v2( array $record ): array {
+		$data = [
+			'ticket_name'        => 'RSVP',
+			'ticket_description' => '',
+			'ticket_price'       => 0,
+			'ticket_type'        => RSVP_V2_Constants::TC_RSVP_TYPE,
+			'ticket_provider'    => Commerce_Module::class,
+			'show_not_going'     => false,
+		];
+
+		$start_date = $this->get_value_by_key( $record, 'ticket_start_sale_date' );
+		$end_date   = $this->get_value_by_key( $record, 'ticket_end_sale_date' );
+
+		if ( ! empty( $start_date ) ) {
+			$data['ticket_start_date'] = $start_date;
+		}
+		if ( ! empty( $end_date ) ) {
+			$data['ticket_end_date'] = $end_date;
+		}
+
+		$ticket_start_sale_time = $this->get_value_by_key( $record, 'ticket_start_sale_time' );
+		if ( ! empty( $start_date ) && ! empty( $ticket_start_sale_time ) ) {
+			$start = new DateTime( $start_date . ' ' . $ticket_start_sale_time );
+			$data['ticket_start_meridian'] = $start->format( 'A' );
+			$data['ticket_start_time']     = $start->format( 'H:i:00' );
+		}
+
+		$ticket_end_sale_time = $this->get_value_by_key( $record, 'ticket_end_sale_time' );
+		if ( ! empty( $end_date ) && ! empty( $ticket_end_sale_time ) ) {
+			$end = new DateTime( $end_date . ' ' . $ticket_end_sale_time );
+			$data['ticket_end_meridian'] = $end->format( 'A' );
+			$data['ticket_end_time']     = $end->format( 'H:i:00' );
+		}
+
+		$stock    = trim( (string) $this->get_value_by_key( $record, 'ticket_stock' ) );
+		$capacity = trim( (string) $this->get_value_by_key( $record, 'ticket_capacity' ) );
+
+		if ( '' === $capacity ) {
+			$capacity = $stock;
+		}
+
+		// Unlimited when blank - keep mode empty (Classic_Editor_Post_Data logic).
+		if ( '' === $capacity || '0' === $capacity ) {
+			$data['tribe-ticket'] = [ 'mode' => '' ];
+		} else {
+			$data['tribe-ticket'] = [
+				'mode'     => \Tribe__Tickets__Global_Stock::OWN_STOCK_MODE,
+				'capacity' => (int) $capacity,
+			];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * V1 data shape - legacy tribe_rsvp_tickets.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $record The record data.
+	 *
+	 * @return array
+	 */
+	private function get_ticket_data_from_v1( array $record ): array {
 		$data                       = [];
 		$data['ticket_name']        = $this->get_value_by_key( $record, 'ticket_name' );
 		$data['ticket_description'] = $this->get_value_by_key( $record, 'ticket_description' );
@@ -306,7 +555,7 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 * @return string
 	 */
 	protected function get_skipped_row_message( $row ) {
-		return $this->row_message === false ? parent::get_skipped_row_message( $row ) : $this->row_message;
+		return false === $this->row_message ? parent::get_skipped_row_message( $row ) : $this->row_message;
 	}
 
 	/**

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -567,7 +567,7 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 *
 	 * @param Tribe__Events__Aggregator__Record__Activity $activity The activity instance.
 	 */
-	public function register_rsvp_activity( $activity ) {
+	public static function register_rsvp_activity( $activity ) {
 		$activity->register( 'tribe_rsvp_tickets', [ 'rsvp', 'rsvp_tickets' ] );
 	}
 }

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -62,6 +62,18 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	}
 
 	/**
+	 * Whether the RSVP->Tickets Commerce migration is currently running or paused, in which
+	 * case neither V1 nor V2 tickets should be imported.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	private function is_rsvp_disabled(): bool {
+		return RSVP_Controller::is_migration_in_progress();
+	}
+
+	/**
 	 * Whether the site is on RSVP V2 (Commerce) - i.e. the import should produce a TC-RSVP ticket.
 	 *
 	 * Version is hook-verifiable via `tec_tickets_rsvp_version`. Tests can control it
@@ -80,6 +92,8 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 
 		$default = RSVP_Controller::VERSION_1;
 		$version = tribe_get_option( RSVP_Controller::VERSION_OPTION_KEY, $default );
+
+		/** This filter is documented in src/Tickets/RSVP/Controller.php. */
 		$version = apply_filters( 'tec_tickets_rsvp_version', $version );
 
 		return RSVP_Controller::VERSION_2 === $version;
@@ -197,32 +211,7 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 * @return bool
 	 */
 	private function has_rsvp_for_event_v2( WP_Post $event ): bool {
-		$repo = tribe( 'tickets.ticket-repository.rsvp' );
-		if ( $repo && $repo->by( 'event', $event->ID )->found() ) {
-			return true;
-		}
-
-		// Fallback: direct query if repository not available.
-		$found = ( new WP_Query(
-			[
-				'post_type'      => 'tec_tc_ticket',
-				'posts_per_page' => 1,
-				'post_status'    => 'any',
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off fallback lookup, limited to 1 result.
-				'meta_query'     => [
-					[
-						'key'   => '_type',
-						'value' => RSVP_V2_Constants::TC_RSVP_TYPE,
-					],
-					[
-						'key'   => '_tec_tickets_commerce_event',
-						'value' => $event->ID,
-					],
-				],
-			]
-		) )->get_posts();
-
-		return ! empty( $found );
+		return (bool) tribe( 'tickets.ticket-repository.rsvp' )->by( 'event', $event->ID )->found();
 	}
 
 	/**
@@ -454,13 +443,14 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 			$capacity = $stock;
 		}
 
-		// Unlimited when blank - keep mode empty (Classic_Editor_Post_Data logic).
-		if ( '' === $capacity || '0' === $capacity ) {
+		// Unlimited when blank or non-positive - mirrors Classic_Editor_Post_Data::from_post_data().
+		$capacity_int = (int) $capacity;
+		if ( '' === $capacity || $capacity_int <= 0 ) {
 			$data['tribe-ticket'] = [ 'mode' => '' ];
 		} else {
 			$data['tribe-ticket'] = [
 				'mode'     => \Tribe__Tickets__Global_Stock::OWN_STOCK_MODE,
-				'capacity' => (int) $capacity,
+				'capacity' => $capacity_int,
 			];
 		}
 
@@ -532,9 +522,22 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 			return false;
 		}
 
+		if ( $this->is_rsvp_disabled() ) {
+			$this->row_message = esc_html__( 'RSVP is temporarily disabled while migrating to Tickets Commerce.', 'event-tickets' );
+
+			return false;
+		}
+
 		$event = $this->get_event_from( $record );
 
 		if ( empty( $event ) ) {
+			return false;
+		}
+
+		if ( ! $this->is_rsvp_v2() && empty( $this->get_value_by_key( $record, 'ticket_name' ) ) ) {
+			// Translators: %s is the event title.
+			$this->row_message = sprintf( esc_html__( 'ticket_name is required, event %s.', 'event-tickets' ), $event->post_title );
+
 			return false;
 		}
 
@@ -563,9 +566,17 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	}
 
 	/**
-	 * Registers the RSVP post type as a trackable activity.
+	 * Registers the legacy `tribe_rsvp_tickets` post type as a trackable Event Aggregator
+	 * activity, so imported/updated RSVP tickets are counted and reported in the import summary.
+	 *
+	 * Hooked to `tribe_aggregator_record_activity_wakeup` by both the V1 and V2 RSVP controllers
+	 * via `RSVP_Controller_Methods::register_csv_importer_hooks()`.
+	 *
+	 * @since TBD
 	 *
 	 * @param Tribe__Events__Aggregator__Record__Activity $activity The activity instance.
+	 *
+	 * @return void
 	 */
 	public static function register_rsvp_activity( $activity ) {
 		$activity->register( 'tribe_rsvp_tickets', [ 'rsvp', 'rsvp_tickets' ] );

--- a/src/Tribe/CSV_Importer/RSVP_Importer.php
+++ b/src/Tribe/CSV_Importer/RSVP_Importer.php
@@ -203,6 +203,7 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 		}
 
 		// Fallback: direct query if repository not available.
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-off fallback lookup, limited to 1 result.
 		$found = ( new WP_Query(
 			[
 				'post_type'      => 'tec_tc_ticket',
@@ -243,14 +244,14 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 * @since TBD
 	 *
 	 * @param string $cache_key Cache key.
-	 * @param bool   $match     Match result.
+	 * @param bool   $is_match  Match result.
 	 *
 	 * @return bool The same match value (for chaining).
 	 */
-	private function cache_match( string $cache_key, bool $match ): bool {
-		self::$ticket_name_cache[ $cache_key ] = $match;
+	private function cache_match( string $cache_key, bool $is_match ): bool {
+		self::$ticket_name_cache[ $cache_key ] = $is_match;
 
-		return $match;
+		return $is_match;
 	}
 
 	/**
@@ -311,7 +312,7 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 	 * @return int
 	 */
 	private function create_post_v2( array $record, WP_Post $event, array $data ): int {
-		$ticket_id = Commerce_Module::get_instance()->ticket_add( $event->ID, $data );
+		$ticket_id                                     = Commerce_Module::get_instance()->ticket_add( $event->ID, $data );
 		self::$ticket_name_cache[ 'v2-' . $event->ID ] = true;
 
 		$tickets_handler = tribe( 'tickets.handler' );
@@ -431,14 +432,14 @@ class Tribe__Tickets__CSV_Importer__RSVP_Importer extends Tribe__Events__Importe
 
 		$ticket_start_sale_time = $this->get_value_by_key( $record, 'ticket_start_sale_time' );
 		if ( ! empty( $start_date ) && ! empty( $ticket_start_sale_time ) ) {
-			$start = new DateTime( $start_date . ' ' . $ticket_start_sale_time );
+			$start                         = new DateTime( $start_date . ' ' . $ticket_start_sale_time );
 			$data['ticket_start_meridian'] = $start->format( 'A' );
 			$data['ticket_start_time']     = $start->format( 'H:i:00' );
 		}
 
 		$ticket_end_sale_time = $this->get_value_by_key( $record, 'ticket_end_sale_time' );
 		if ( ! empty( $end_date ) && ! empty( $ticket_end_sale_time ) ) {
-			$end = new DateTime( $end_date . ' ' . $ticket_end_sale_time );
+			$end                         = new DateTime( $end_date . ' ' . $ticket_end_sale_time );
 			$data['ticket_end_meridian'] = $end->format( 'A' );
 			$data['ticket_end_time']     = $end->format( 'H:i:00' );
 		}

--- a/tests/rsvp_v2_integration/CSV_Importer/RSVP_Importer_Test.php
+++ b/tests/rsvp_v2_integration/CSV_Importer/RSVP_Importer_Test.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace TEC\Tickets\CSV_Importer;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\RSVP\Controller as RSVP_Controller;
+use TEC\Tickets\RSVP\V2\Constants;
+
+/**
+ * TDD: RSVP CSV Import on V2 must create a TC-RSVP ticket.
+ * This test is expected to FAIL until the importer is ported.
+ */
+class RSVP_Importer_Test extends WPTestCase {
+
+	protected $rsvp_module;
+
+	public function setUp(): void {
+		parent::setUp();
+		// Hook-verifiable version: tests control RSVP version via `test_rsvp_version` option.
+		add_filter( 'tec_tickets_rsvp_version', function(): string {
+			return get_option( 'test_rsvp_version', RSVP_Controller::VERSION_1 );
+		}, 20 );
+		update_option( 'test_rsvp_version', RSVP_Controller::VERSION_2 );
+
+		\Tribe__Tickets__CSV_Importer__RSVP_Importer::reset_cache();
+		$this->file_reader    = $this->prophesize( 'Tribe__Events__Importer__File_Reader' );
+		$this->image_uploader = $this->prophesize( 'Tribe__Events__Importer__Featured_Image_Uploader' );
+		$this->rsvp_module    = tribe( Module::class );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'test_rsvp_version' );
+		remove_filter( 'tec_tickets_rsvp_version', '__return_true' ); // noop – ensures next test starts clean
+		// Remove the test filter added in setUp (priority 20).
+		remove_all_filters( 'tec_tickets_rsvp_version' );
+		// Re-add suite bootstrap filter (v2) so remaining tests in suite keep passing.
+		add_filter( 'tec_tickets_rsvp_version', static fn(): string => RSVP_Controller::VERSION_2 );
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_import_an_rsvp_ticket_as_tc_rsvp_on_v2(): void {
+		$overrides = [
+			'event_name'             => 'V2 Event 1',
+			'ticket_name'            => 'Ignored Name',
+			'ticket_description'     => 'Ignored desc',
+			'ticket_start_sale_date' => '2026-05-11',
+			'ticket_start_sale_time' => '9:00 AM',
+			'ticket_end_sale_date'   => '2026-05-19',
+			'ticket_end_sale_time'   => '8:00 PM',
+			'ticket_stock'           => '100',
+		];
+		$record   = $this->make_record( $overrides );
+		$event_id = \Tribe__Events__API::createEvent( [ 'post_title' => 'V2 Event 1' ] );
+
+		$sut       = $this->make_instance();
+		$ticket_id = $sut->create_post( $record );
+
+		$this->assertNotFalse( $ticket_id, 'Importer should create a ticket' );
+		$this->assertIsInt( $ticket_id );
+
+		// Must be a TC ticket, not a legacy tribe_rsvp_tickets post.
+		$ticket_post = get_post( $ticket_id );
+		$this->assertEquals( 'tec_tc_ticket', $ticket_post->post_type, 'V2 RSVP must be a Commerce ticket' );
+		$this->assertEquals( Constants::TC_RSVP_TYPE, get_post_meta( $ticket_id, '_type', true ), 'ticket type must be tc-rsvp' );
+
+		$ticket = $this->rsvp_module->get_ticket( $event_id, $ticket_id );
+		$this->assertNotEmpty( $ticket );
+		$this->assertEquals( $event_id, (int) $ticket->get_event()->ID );
+		// Name is hardcoded to RSVP in V2, legacy name is moot.
+		$this->assertEquals( 'RSVP', $ticket->name );
+		$this->assertEquals( 100, $ticket->capacity() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_map_stock_to_limit_and_support_unlimited_v2(): void {
+		$event_id = \Tribe__Events__API::createEvent( [ 'post_title' => 'V2 Event Unlimited' ] );
+		$record   = $this->make_record( [
+			'event_name'   => 'V2 Event Unlimited',
+			'ticket_stock' => '',
+		] );
+
+		$sut       = $this->make_instance();
+		$ticket_id = $sut->create_post( $record );
+
+		$this->assertNotFalse( $ticket_id );
+		$ticket = $this->rsvp_module->get_ticket( $event_id, $ticket_id );
+		$this->assertNotEmpty( $ticket );
+		// Unlimited: mode should be '' (no own stock). Capacity is handled as -1/'' for unlimited; we just verify it is not a limited value.
+		$mode = get_post_meta( $ticket_id, \Tribe__Tickets__Global_Stock::TICKET_STOCK_MODE, true );
+		$this->assertEquals( '', $mode, 'unlimited RSVP should have empty stock mode' );
+		$this->assertTrue( in_array( $ticket->capacity(), [ -1, '', 0, null ], true ), 'unlimited RSVP capacity should be -1/empty, got ' . var_export( $ticket->capacity(), true ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_only_allow_one_rsvp_per_event_v2(): void {
+		$event_id = \Tribe__Events__API::createEvent( [ 'post_title' => 'V2 Event Single' ] );
+		$record1  = $this->make_record( [ 'event_name' => 'V2 Event Single', 'ticket_name' => 'A' ] );
+		$record2  = $this->make_record( [ 'event_name' => 'V2 Event Single', 'ticket_name' => 'B' ] );
+
+		$sut = $this->make_instance();
+		$sut->create_post( $record1 );
+
+		\Tribe__Tickets__CSV_Importer__RSVP_Importer::reset_cache();
+		$sut2 = $this->make_instance();
+		$this->assertTrue( $sut2->match_existing_post( $record2 ), 'V2 should match existing RSVP regardless of ticket_name – one per event' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_verify_version_via_hook(): void {
+		$sut = $this->make_instance();
+		$ref = new \ReflectionMethod( $sut, 'is_rsvp_v2' );
+		$ref->setAccessible( true );
+
+		update_option( 'test_rsvp_version', RSVP_Controller::VERSION_1 );
+		$this->assertFalse( $ref->invoke( $sut ), 'hook should report V1 when test_rsvp_version=v1' );
+
+		update_option( 'test_rsvp_version', RSVP_Controller::VERSION_2 );
+		$this->assertTrue( $ref->invoke( $sut ), 'hook should report V2 when test_rsvp_version=v2' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_map_legacy_date_fields_to_v2_open_close_dates(): void {
+		$event_id = \Tribe__Events__API::createEvent( [ 'post_title' => 'V2 Event Dates' ] );
+		$record   = $this->make_record( [
+			'event_name'             => 'V2 Event Dates',
+			'ticket_start_sale_date' => '2026-06-01',
+			'ticket_start_sale_time' => '10:00 AM',
+			'ticket_end_sale_date'   => '2026-06-10',
+			'ticket_end_sale_time'   => '5:30 PM',
+		] );
+
+		$sut       = $this->make_instance();
+		$ticket_id = $sut->create_post( $record );
+
+		$ticket = $this->rsvp_module->get_ticket( $event_id, $ticket_id );
+		$this->assertEquals( '2026-06-01', $ticket->start_date );
+		$this->assertEquals( '10:00:00', $ticket->start_time );
+		$this->assertEquals( '2026-06-10', $ticket->end_date );
+		$this->assertEquals( '17:30:00', $ticket->end_time );
+	}
+
+	private function make_instance(): \Tribe__Tickets__CSV_Importer__RSVP_Importer {
+		$instance = new \Tribe__Tickets__CSV_Importer__RSVP_Importer( $this->file_reader->reveal(), $this->image_uploader->reveal() );
+		$map = [
+			'event_name',
+			'ticket_name',
+			'ticket_description',
+			'ticket_start_sale_date',
+			'ticket_start_sale_time',
+			'ticket_end_sale_date',
+			'ticket_end_sale_time',
+			'ticket_stock',
+		];
+		$instance->set_map( $map );
+		return $instance;
+	}
+
+	private function make_record( array $overrides = [] ): array {
+		$defaults = [
+			'event_name'             => 'Some Event',
+			'ticket_name'            => 'Ticket 1',
+			'ticket_description'     => 'Desc',
+			'ticket_start_sale_date' => '2026-05-11',
+			'ticket_start_sale_time' => '9:00 AM',
+			'ticket_end_sale_date'   => '2026-05-19',
+			'ticket_end_sale_time'   => '8:00 PM',
+			'ticket_stock'           => '100',
+		];
+		return array_values( array_merge( $defaults, $overrides ) );
+	}
+}

--- a/tests/rsvp_v2_integration/CSV_Importer/RSVP_Importer_Test.php
+++ b/tests/rsvp_v2_integration/CSV_Importer/RSVP_Importer_Test.php
@@ -15,12 +15,20 @@ class RSVP_Importer_Test extends WPTestCase {
 
 	protected $rsvp_module;
 
+	/**
+	 * @var callable|null Hook callback for `tec_tickets_rsvp_version` added in setUp().
+	 *
+	 * @since TBD
+	 */
+	private $version_filter;
+
 	public function setUp(): void {
 		parent::setUp();
 		// Hook-verifiable version: tests control RSVP version via `test_rsvp_version` option.
-		add_filter( 'tec_tickets_rsvp_version', function(): string {
+		$this->version_filter = function(): string {
 			return get_option( 'test_rsvp_version', RSVP_Controller::VERSION_1 );
-		}, 20 );
+		};
+		add_filter( 'tec_tickets_rsvp_version', $this->version_filter, 20 );
 		update_option( 'test_rsvp_version', RSVP_Controller::VERSION_2 );
 
 		\Tribe__Tickets__CSV_Importer__RSVP_Importer::reset_cache();
@@ -31,11 +39,9 @@ class RSVP_Importer_Test extends WPTestCase {
 
 	public function tearDown(): void {
 		delete_option( 'test_rsvp_version' );
-		remove_filter( 'tec_tickets_rsvp_version', '__return_true' ); // noop – ensures next test starts clean
-		// Remove the test filter added in setUp (priority 20).
-		remove_all_filters( 'tec_tickets_rsvp_version' );
-		// Re-add suite bootstrap filter (v2) so remaining tests in suite keep passing.
-		add_filter( 'tec_tickets_rsvp_version', static fn(): string => RSVP_Controller::VERSION_2 );
+		if ( $this->version_filter ) {
+			remove_filter( 'tec_tickets_rsvp_version', $this->version_filter, 20 );
+		}
 		parent::tearDown();
 	}
 
@@ -94,7 +100,7 @@ class RSVP_Importer_Test extends WPTestCase {
 		// Unlimited: mode should be '' (no own stock). Capacity is handled as -1/'' for unlimited; we just verify it is not a limited value.
 		$mode = get_post_meta( $ticket_id, \Tribe__Tickets__Global_Stock::TICKET_STOCK_MODE, true );
 		$this->assertEquals( '', $mode, 'unlimited RSVP should have empty stock mode' );
-		$this->assertTrue( in_array( $ticket->capacity(), [ -1, '', 0, null ], true ), 'unlimited RSVP capacity should be -1/empty, got ' . var_export( $ticket->capacity(), true ) );
+			$this->assertTrue( in_array( $ticket->capacity(), [ -1, '', null ], true ), 'unlimited RSVP capacity should be -1/empty, got ' . var_export( $ticket->capacity(), true ) );
 	}
 
 	/**

--- a/tests/wpunit/Tickets/RSVP/RSVP_Controller_Methods_Test.php
+++ b/tests/wpunit/Tickets/RSVP/RSVP_Controller_Methods_Test.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TEC\Tickets\RSVP;
+
+use Codeception\TestCase\WPTestCase;
+
+/**
+ * Regression test for the `tribe_aggregator_record_activity_wakeup` wiring.
+ *
+ * `register_csv_importer_hooks()` used to hook `register_rsvp_activity` via
+ * `$container->callback( RSVP_Importer::class, ... )`, which made DI52 try to
+ * auto-wire a fresh `RSVP_Importer` (and, transitively, a `File_Reader` whose
+ * `$file_path` constructor param has no type hint) on every wakeup, fataling
+ * with `ContainerException: auto-wiring is not magic`. The importer is only
+ * ever safe to construct with a real file reader from an in-progress import,
+ * never lazily by the container.
+ *
+ * @since TBD
+ */
+class RSVP_Controller_Methods_Test extends WPTestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_wakeup_activity_without_fataling() {
+		$this->assertNotFalse(
+			has_action( 'tribe_aggregator_record_activity_wakeup' ),
+			'The RSVP controller should have wired up the activity wakeup hook.'
+		);
+
+		// Instantiating fires __wakeup(), which fires the action under test alongside
+		// every other plugin's activity registration - prior to the fix this fatals
+		// with a DI52 ContainerException instead of returning.
+		$activity = new \Tribe__Events__Aggregator__Record__Activity();
+
+		$this->assertTrue( $activity->exists( 'tribe_rsvp_tickets' ), 'RSVP tickets should be a registered activity slug.' );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3323](https://linear.app/nexcess/issue/SOFT-3323/rsvp-import)

<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

**Fix** (CSV import compatibility with RSVP V2)

Fixed RSVP CSV import on RSVP V2 by porting the importer to create Tickets Commerce `tc-rsvp` tickets with version-switched `is_rsvp_v2()` dispatch, hook-verifiable version handling, and shared `match_existing_post` caching. Resolved an issue where V2 imports created legacy `tribe_rsvp_tickets` or `default` Commerce tickets with incorrect name, capacity and duplicate RSVPs per event.

Depends on: https://github.com/the-events-calendar/the-events-calendar/pull/5752

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/1eb893f46e2e44ddb4753c04ce8e51bd

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
