### PR TITLE
Add token to checkout step in release workflow

### DIFF
--- a/.github/workflows/release-prepare-branch.yml
+++ b/.github/workflows/release-prepare-branch.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.GHA_BOT_TOKEN_MANAGER }}
 
       - name: Set Variables
         id: vars


### PR DESCRIPTION
Fixes the release workflow to use `GHA_BOT_TOKEN_MANAGER` during checkout, ensuring subsequent `git push` commands have the required permissions.

### 🎫 Ticket

[N/A]

### 🗒️ Description

This PR updates the release workflow to use `GHA_BOT_TOKEN_MANAGER` in the `actions/checkout` step.

Previously, subsequent `git push` commands were using the default GitHub Actions token (`github-actions[bot]`), which did not have the required permissions and resulted in a `403` error.

Using the existing bot token during checkout ensures that Git credentials are persisted with the appropriate permissions for branch creation and pushes.

**Type of change:** Bug fix (non-breaking change).

### 🎥 Artifacts

N/A

### ✔️ Checklist

* [ ] Ran `npm run changelog` to add changelog file(s). More info [[here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
* [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
* [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
* [ ] Are all the **required** tests passing?
* [ ] Automated code review comments are addressed.
* [ ] Have you added Artifacts?
* [ ] Check the base branch for your PR.
* [ ] Add your PR to the project board for the release.