### PR TITLE
Distinguish between RSVP V2 and tickets on Attendees Page

### DIFF
--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -189,6 +189,30 @@ class Attendees {
 	}
 
 	/**
+	 * Keeps TC-RSVP tickets out of the Attendees page ticket sales counts.
+	 *
+	 * Hooked to `tribe_tickets_should_use_ticket_in_sales_counts` and its Event Tickets Plus twin.
+	 * Both Attendance Totals classes exclude RSVPs by provider class alone, and a TC-RSVP ticket
+	 * reports the Tickets Commerce provider whenever its Ticket Object comes back from the shared
+	 * `tec_tickets` cache, so its Going attendees would be counted a second time under "Tickets".
+	 * The ticket type is the same in either case.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $should_count Whether the ticket should be factored into the sales counts.
+	 * @param mixed $ticket       The ticket being counted.
+	 *
+	 * @return bool Whether the ticket should be factored into the sales counts.
+	 */
+	public function exclude_rsvp_from_sales_counts( $should_count, $ticket ): bool {
+		if ( $ticket instanceof Ticket_Object && Constants::TC_RSVP_TYPE === $ticket->type() ) {
+			return false;
+		}
+
+		return (bool) $should_count;
+	}
+
+	/**
 	 * Registers the label and icon the Attendees page Ticket Overview uses for TC-RSVP tickets.
 	 *
 	 * Hooked to `tec_tickets_attendees_page_render_context`. That page groups tickets by

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -254,6 +254,20 @@ class Controller extends Controller_Contract {
 			'tec_tickets_attendees_page_render_context',
 			$this->container->callback( Attendees::class, 'add_ticket_overview_type_labels' )
 		);
+
+		// Both Attendance Totals classes exclude RSVPs by provider class alone; TC-RSVP needs the type.
+		add_filter(
+			'tribe_tickets_should_use_ticket_in_sales_counts',
+			$this->container->callback( Attendees::class, 'exclude_rsvp_from_sales_counts' ),
+			10,
+			2
+		);
+		add_filter(
+			'tribe_tickets_plus_should_use_ticket_in_sales_counts',
+			$this->container->callback( Attendees::class, 'exclude_rsvp_from_sales_counts' ),
+			10,
+			2
+		);
 		add_action(
 			'tec_tickets_commerce_attendee_after_create',
 			$this->container->callback( Attendees::class, 'ensure_rsvp_status_on_create' ),
@@ -435,6 +449,14 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_attendees_page_render_context',
 			$this->container->callback( Attendees::class, 'add_ticket_overview_type_labels' )
+		);
+		remove_filter(
+			'tribe_tickets_should_use_ticket_in_sales_counts',
+			$this->container->callback( Attendees::class, 'exclude_rsvp_from_sales_counts' )
+		);
+		remove_filter(
+			'tribe_tickets_plus_should_use_ticket_in_sales_counts',
+			$this->container->callback( Attendees::class, 'exclude_rsvp_from_sales_counts' )
 		);
 		remove_action(
 			'tec_tickets_commerce_attendee_after_create',

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -9,6 +9,7 @@ use TEC\Tickets\Commerce\Cart;
 use TEC\Tickets\Commerce\Gateways\Free\Gateway;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Reports\Attendance_Totals;
 use TEC\Tickets\Commerce\Status\Completed;
 use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Status\Voided;
@@ -584,5 +585,30 @@ class Attendees_Test extends WPTestCase {
 		tribe( Attendees::class )->void_order_after_last_attendee_deleted( $attendee_ids[0] );
 
 		$this->assertSame( tribe( Completed::class )->get_wp_slug(), get_post_status( $order_id ) );
+	}
+
+	public function test_rsvp_tickets_are_left_out_of_the_ticket_sales_counts(): void {
+		$post_id        = static::factory()->post->create();
+		$rsvp_ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$ticket_id      = $this->create_tc_ticket( $post_id, 10 );
+
+		$this->create_rsvp_order_with_attendees( $rsvp_ticket_id, 2 );
+		$this->create_order( [ $ticket_id => 1 ] );
+
+		// The Attendees page builds its render context first, which leaves the RSVP Ticket Object in the
+		// shared `tec_tickets` cache reporting the Tickets Commerce provider instead of the RSVP one.
+		tribe( 'tickets.attendees' )->get_render_context( $post_id );
+
+		$totals = new Attendance_Totals( $post_id );
+
+		// Only the real ticket: the two Going RSVPs belong to the RSVP totals.
+		$this->assertSame( 1, $totals->get_total_sold() );
+		$this->assertSame( 1, $totals->get_total_complete() );
+
+		// Event Tickets Plus runs its own Attendance Totals off the twin filter.
+		$rsvp_ticket = tribe( Module::class )->get_ticket( $post_id, $rsvp_ticket_id );
+		$this->assertFalse(
+			apply_filters( 'tribe_tickets_plus_should_use_ticket_in_sales_counts', true, $rsvp_ticket )
+		);
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4348](https://linear.app/nexcess/issue/SOFT-4348/attendance-overview-counts-rsvp-v2-attendees-as-tickets)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The Attendance Overview box on the Attendees page was counting RSVP V2 "Going" responses under **Tickets** as well as under **RSVPs** — showing a ticket attendee on an event with no tickets, and inflating the totals on events that do sell tickets.

Both Attendance Totals classes (ET's and ET+'s) decided whether to count a ticket by its provider class, excluding only the legacy `Tribe__Tickets__RSVP` provider. That answer isn't stable for a TC-RSVP ticket: once the page's Ticket Overview panel puts the ticket in the shared `tec_tickets` cache, it comes back reporting the Tickets Commerce provider and slips past the check. This keys the exclusion on the ticket *type* (`tc-rsvp`) instead, which doesn't change, and hooks both ET's and ET+'s sales-count filters so the ET+ totals get the same treatment.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="3434" height="1946" alt="SOFT-4348-Before" src="https://github.com/user-attachments/assets/93e3ea01-1e33-4c5e-a270-5bec268ae068" />

After:
<img width="3426" height="1906" alt="SOFT-4348-After" src="https://github.com/user-attachments/assets/abe7d1f6-a0db-4f88-9e25-703b7996fd40" />


### ✔️ Checklist
- [-] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) [skip-changelog]
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

