### PR TITLE
[SMTNC-1237] Enabling the 'Advanced Responsive Video Embedder' causes a fatal error when moving attendees.

### DIFF
--- a/changelog/smtnc-1237-enabling-the-advanced-responsive-video-embedder-causes-a.yaml
+++ b/changelog/smtnc-1237-enabling-the-advanced-responsive-video-embedder-causes-a.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved a fatal error that could occur while rendering the Move
+  Attendees dialog when another plugin listened on the admin_enqueue_scripts
+  action.
+timestamp: 2026-08-30T00:41:28.974Z

--- a/src/Tribe/Admin/Move_Ticket_Types.php
+++ b/src/Tribe/Admin/Move_Ticket_Types.php
@@ -10,7 +10,7 @@ class Tribe__Tickets__Admin__Move_Ticket_Types extends Tribe__Tickets__Admin__Mo
 	protected $dialog_name = 'move_ticket_types';
 
 	public function setup() {
-		add_action( 'admin_init', array( $this, 'dialog' ) );
+		add_action( 'current_screen', array( $this, 'dialog' ) );
 		add_action( 'wp_ajax_move_ticket_types_post_list', array( $this, 'update_post_choices' ) );
 		add_action( 'wp_ajax_move_ticket_type', array( $this, 'move_ticket_type_requests' ) );
 		add_action( 'tribe_tickets_ticket_type_moved', array( $this, 'notify_event_attendees' ), 100, 3 );

--- a/src/Tribe/Admin/Move_Ticket_Types.php
+++ b/src/Tribe/Admin/Move_Ticket_Types.php
@@ -9,8 +9,13 @@
 class Tribe__Tickets__Admin__Move_Ticket_Types extends Tribe__Tickets__Admin__Move_Tickets {
 	protected $dialog_name = 'move_ticket_types';
 
+	/**
+	 * Registers the move ticket types hooks.
+	 *
+	 * @since TBD Moved the dialog off `admin_init`, which fires before WordPress resolves the admin screen.
+	 */
 	public function setup() {
-		add_action( 'current_screen', array( $this, 'dialog' ) );
+		add_action( 'current_screen', [ $this, 'dialog' ] );
 		add_action( 'wp_ajax_move_ticket_types_post_list', array( $this, 'update_post_choices' ) );
 		add_action( 'wp_ajax_move_ticket_type', array( $this, 'move_ticket_type_requests' ) );
 		add_action( 'tribe_tickets_ticket_type_moved', array( $this, 'notify_event_attendees' ), 100, 3 );

--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -29,7 +29,7 @@ class Tribe__Tickets__Admin__Move_Tickets {
 	public function setup() {
 		$this->ticket_history();
 
-		add_action( 'admin_init', [ $this, 'dialog' ] );
+		add_action( 'current_screen', [ $this, 'dialog' ] );
 		add_filter( 'tribe_events_tickets_attendees_table_bulk_actions', [ $this, 'bulk_actions' ] );
 		add_action( 'wp_ajax_move_tickets', [ $this, 'move_tickets_request' ] );
 		add_action( 'tribe_tickets_ticket_type_moved', [ $this, 'move_all_tickets_for_type' ], 10, 4 );
@@ -52,6 +52,10 @@ class Tribe__Tickets__Admin__Move_Tickets {
 
 	/**
 	 * Sets up the move tickets dialog.
+	 *
+	 * Hooked to `current_screen` rather than `admin_init`: `iframe_header()` hands the `$hook_suffix`
+	 * global to `admin_enqueue_scripts`, and wp-admin/admin.php only assigns it once `admin_init` has
+	 * finished.
 	 */
 	public function dialog() {
 		if ( ! $this->is_move_tickets_dialog() ) {
@@ -90,7 +94,6 @@ class Tribe__Tickets__Admin__Move_Tickets {
 			'multiple_providers' => $this->has_multiple_providers,
 		) );
 
-		set_current_screen();
 		define( 'IFRAME_REQUEST', true );
 		$this->dialog_assets();
 		iframe_header( $template_vars['title'] );

--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -26,6 +26,11 @@ class Tribe__Tickets__Admin__Move_Tickets {
 	 */
 	protected $attendees = [];
 
+	/**
+	 * Registers the move attendees hooks.
+	 *
+	 * @since TBD Moved the dialog off `admin_init`, which fires before WordPress resolves the admin screen.
+	 */
 	public function setup() {
 		$this->ticket_history();
 

--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -55,7 +55,10 @@ class Tribe__Tickets__Admin__Move_Tickets {
 	 *
 	 * Hooked to `current_screen` rather than `admin_init`: `iframe_header()` hands the `$hook_suffix`
 	 * global to `admin_enqueue_scripts`, and wp-admin/admin.php only assigns it once `admin_init` has
-	 * finished.
+	 * finished. WordPress has resolved the screen by then, so calling `set_current_screen()` here
+	 * would re-enter this method until the request times out.
+	 *
+	 * @since TBD Moved off `admin_init` so the admin screen is resolved before the iframe renders.
 	 */
 	public function dialog() {
 		if ( ! $this->is_move_tickets_dialog() ) {

--- a/tests/wpunit/Tribe/Tickets/Admin/Move_TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/Admin/Move_TicketsTest.php
@@ -5,6 +5,7 @@ namespace Tribe\Tickets\Admin;
 use Closure;
 use Codeception\TestCase\WPTestCase;
 use Generator;
+use RuntimeException;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Tickets__Main as Main;
 use Tribe__Events__Main as TEC;
@@ -16,6 +17,7 @@ use Tribe__Tickets__RSVP__Attendance_Totals as Tickets_Attendance;
 use Tribe__Tickets__Admin__Move_Tickets as Move_Tickets;
 use TEC\Tickets\Commerce\Module as Commerce;
 use TEC\Tickets\Commerce\Provider as Commerce_Provider;
+use WP_Hook;
 
 
 class Move_TicketsTest extends WPTestCase {
@@ -387,5 +389,59 @@ class Move_TicketsTest extends WPTestCase {
 		// Confirm the attendee counts are as expected after the move.
 		$this->assertEquals( 0, count( $src_attendance ) );
 		$this->assertEquals( 5, count( $trg_attendance ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_the_dialog_with_a_resolved_admin_screen(): void {
+		$event_id = $this->factory()->event->create();
+
+		$get_backup         = $_GET;
+		$hook_suffix_backup = $GLOBALS['hook_suffix'] ?? null;
+		$_GET               = [
+			'dialog'   => 'move_tickets',
+			'check'    => wp_create_nonce( 'move_tickets' ),
+			'event_id' => $event_id,
+		];
+
+		/* Isolate the hooks admin.php fires around its `$hook_suffix` assignment. */
+		$GLOBALS['wp_filter']['admin_init']     = new WP_Hook();
+		$GLOBALS['wp_filter']['current_screen'] = new WP_Hook();
+
+		( new Move_Tickets() )->setup();
+
+		$received = [];
+		add_action(
+			'admin_enqueue_scripts',
+			static function ( $hook_suffix ) use ( &$received ) {
+				$received[] = $hook_suffix;
+
+				/* iframe_header() has been reached; stop before dialog() exits the process. */
+				throw new RuntimeException( 'Dialog rendered.' );
+			},
+			1
+		);
+
+		/*
+		 * admin.php dispatches `admin_init` while `$hook_suffix` is still null, assigns it, and only
+		 * then calls set_current_screen(). Replay that order.
+		 */
+		$GLOBALS['hook_suffix'] = null;
+		ob_start();
+
+		try {
+			do_action( 'admin_init' );
+			$GLOBALS['hook_suffix'] = 'edit.php';
+			set_current_screen();
+		} catch ( RuntimeException $e ) {
+			/* Expected: the listener above interrupts the dialog mid-render. */
+		} finally {
+			ob_end_clean();
+			$_GET                   = $get_backup;
+			$GLOBALS['hook_suffix'] = $hook_suffix_backup;
+		}
+
+		$this->assertSame( [ 'edit.php' ], $received );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1237](https://linear.app/nexcess/issue/SMTNC-1237/enabling-the-advanced-responsive-video-embedder-causes-a-fatal-error)

### 🎥 Artifacts

https://www.loom.com/share/52ede7b29ab44e3f85dbae399a23a7e0

### 🗒️ Description

Renders the Move Attendees and Move Ticket dialogs once WordPress has resolved the admin screen, so `admin_enqueue_scripts` listeners receive the real hook suffix instead of `null`.

### ⚠️ Blockers

None.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
