### PR TITLE
[SMTNC-1468] fix: Auto-refresh the Square OAuth access token

### DIFF
--- a/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
+++ b/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
@@ -1,0 +1,7 @@
+significance: patch
+type: fix
+entry: Refreshed the Square OAuth access token automatically before Square API calls and retried once
+  when Square rejects it, so Tickets Commerce checkout no longer stops working about 30 days after
+  connecting. When Square refuses to renew the stored credentials the gateway is now shown as
+  disconnected with an admin notice, instead of reporting a healthy connection while live charges fail.
+timestamp: 2026-08-18T21:46:14.000Z

--- a/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
+++ b/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
@@ -1,7 +1,8 @@
 significance: patch
 type: fix
-entry: Refreshed the Square OAuth access token automatically before Square API calls and retried once
-  when Square rejects it, so Tickets Commerce checkout no longer stops working about 30 days after
-  connecting. When Square refuses to renew the stored credentials the gateway is now shown as
-  disconnected with an admin notice, instead of reporting a healthy connection while live charges fail.
+entry: Refreshed the Square OAuth access token before Square API calls and retried once when Square
+  rejects it, so Tickets Commerce checkout no longer stops working about 30 days after connecting. The
+  refresh request was also being sent as a GET, which the endpoint answers with 405. When Square will
+  neither renew the credentials nor accept the stored token, the gateway is now shown as disconnected
+  with an admin notice instead of reporting a healthy connection while live charges fail.
 timestamp: 2026-08-18T21:46:14.000Z

--- a/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
+++ b/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
@@ -1,8 +1,7 @@
 significance: patch
 type: fix
-entry: Refreshed the Square OAuth access token before Square API calls and retried once when Square
-  rejects it, so Tickets Commerce checkout no longer stops working about 30 days after connecting. The
-  refresh request was also being sent as a GET, which the endpoint answers with 405. When Square will
+entry: Fixed Tickets Commerce checkout failing with Square about 30 days after connecting, by renewing
+  the Square access token before it expires and retrying once when Square rejects it. When Square will
   neither renew the credentials nor accept the stored token, the gateway is now shown as disconnected
   with an admin notice instead of reporting a healthy connection while live charges fail.
 timestamp: 2026-08-18T21:46:14.000Z

--- a/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
+++ b/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
@@ -1,7 +1,8 @@
 significance: patch
 type: fix
-entry: Fixed Tickets Commerce checkout failing with Square about 30 days after connecting, by renewing
-  the Square access token before it expires and retrying once when Square rejects it. When Square will
-  neither renew the credentials nor accept the stored token, the gateway is now shown as disconnected
-  with an admin notice instead of reporting a healthy connection while live charges fail.
+entry: Resolved an issue where Tickets Commerce checkout failed with Square about 30 days after
+  connecting, by renewing the Square access token before it expired and retrying once when Square
+  rejected it. When Square would neither renew the credentials nor accept the stored token, the
+  gateway was shown as disconnected with an admin notice instead of reporting a healthy connection
+  while live charges failed.
 timestamp: 2026-08-18T21:46:14.000Z

--- a/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
+++ b/changelog/fix-smtnc-1468-square-oauth-token-refresh.yaml
@@ -1,8 +1,8 @@
 significance: patch
 type: fix
-entry: Resolved an issue where Tickets Commerce checkout failed with Square about 30 days after
-  connecting, by renewing the Square access token before it expired and retrying once when Square
-  rejected it. When Square would neither renew the credentials nor accept the stored token, the
-  gateway was shown as disconnected with an admin notice instead of reporting a healthy connection
-  while live charges failed.
+entry: Renewed the Square access token ahead of its expiration and retried a rejected request once
+  against the fresh one, which kept Tickets Commerce checkout from failing about 30 days after
+  connecting to Square. Where Square would neither renew the credentials nor accept the stored
+  token, the gateway reported itself as disconnected with an admin notice instead of showing a
+  healthy connection while live charges failed.
 timestamp: 2026-08-18T21:46:14.000Z

--- a/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
@@ -65,7 +65,7 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get( $endpoint, array $query_args ) {
+	public function get( $endpoint, array $query_args ): ?array {
 		$url = $this->get_api_url( $endpoint, $query_args );
 
 		$request = wp_remote_get( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.remote_get_remote_get, WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
@@ -79,7 +79,7 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 		$body = wp_remote_retrieve_body( $request );
 		$body = json_decode( $body, true );
 
-		return $body;
+		return is_array( $body ) ? $body : null;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
@@ -65,7 +65,7 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get( $endpoint, array $query_args ): ?array {
+	public function get( $endpoint, array $query_args ) {
 		$url = $this->get_api_url( $endpoint, $query_args );
 
 		$request = wp_remote_get( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.remote_get_remote_get, WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
@@ -79,7 +79,7 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 		$body = wp_remote_retrieve_body( $request );
 		$body = json_decode( $body, true );
 
-		return is_array( $body ) ? $body : null;
+		return $body;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
@@ -65,10 +65,10 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get( $endpoint, array $query_args ) {
+	public function get( $endpoint, array $query_args, array $request_arguments = [] ) {
 		$url = $this->get_api_url( $endpoint, $query_args );
 
-		$request = wp_remote_get( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.remote_get_remote_get, WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$request = wp_remote_get( $url, $request_arguments ); // phpcs:ignore WordPress.WP.AlternativeFunctions.remote_get_remote_get, WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 
 		if ( is_wp_error( $request ) ) {
 			$this->log_error( 'WhoDat request error:', $request->get_error_message(), $url );

--- a/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/Abstract_WhoDat.php
@@ -65,21 +65,8 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function get( $endpoint, array $query_args, array $request_arguments = [] ) {
-		$url = $this->get_api_url( $endpoint, $query_args );
-
-		$request = wp_remote_get( $url, $request_arguments ); // phpcs:ignore WordPress.WP.AlternativeFunctions.remote_get_remote_get, WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
-
-		if ( is_wp_error( $request ) ) {
-			$this->log_error( 'WhoDat request error:', $request->get_error_message(), $url );
-
-			return null;
-		}
-
-		$body = wp_remote_retrieve_body( $request );
-		$body = json_decode( $body, true );
-
-		return $body;
+	public function get( $endpoint, array $query_args ) {
+		return $this->get_with_request_args( $endpoint, $query_args );
 	}
 
 	/**
@@ -176,5 +163,33 @@ abstract class Abstract_WhoDat implements WhoDat_Interface {
 			$message
 		);
 		do_action( 'tribe_log', 'error', __CLASS__, [ $log ] );
+	}
+
+	/**
+	 * Sends a GET request to WhoDat, with control over the HTTP arguments.
+	 *
+	 * Deliberately absent from WhoDat_Interface: adding a parameter to an interface method, optional or
+	 * not, is a fatal error for every implementer that does not declare it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $endpoint          The endpoint path.
+	 * @param array  $query_args        Query args appended to the URL.
+	 * @param array  $request_arguments Arguments passed on to wp_remote_get().
+	 *
+	 * @return mixed The decoded response body, or null when the request could not be made.
+	 */
+	protected function get_with_request_args( string $endpoint, array $query_args = [], array $request_arguments = [] ) {
+		$url = $this->get_api_url( $endpoint, $query_args );
+
+		$request = wp_remote_get( $url, $request_arguments ); // phpcs:ignore WordPress.WP.AlternativeFunctions.remote_get_remote_get, WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+
+		if ( is_wp_error( $request ) ) {
+			$this->log_error( 'WhoDat request error:', $request->get_error_message(), $url );
+
+			return null;
+		}
+
+		return json_decode( wp_remote_retrieve_body( $request ), true );
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Contracts/WhoDat_Interface.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/WhoDat_Interface.php
@@ -52,15 +52,17 @@ interface WhoDat_Interface {
 	/**
 	 * Send a GET request to WhoDat.
 	 *
+	 * @since TBD Added the $request_arguments parameter.
 	 * @since 5.3.0 moved to Abstract_WhoDat.
 	 * @since 5.1.9
 	 *
-	 * @param string $endpoint   The endpoint path.
-	 * @param array  $query_args Query args appended to the URL.
+	 * @param string $endpoint          The endpoint path.
+	 * @param array  $query_args        Query args appended to the URL.
+	 * @param array  $request_arguments Arguments passed on to wp_remote_get().
 	 *
 	 * @return mixed|null
 	 */
-	public function get( $endpoint, array $query_args );
+	public function get( $endpoint, array $query_args, array $request_arguments = [] );
 
 	/**
 	 * Log WhoDat errors.

--- a/src/Tickets/Commerce/Gateways/Contracts/WhoDat_Interface.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/WhoDat_Interface.php
@@ -52,17 +52,15 @@ interface WhoDat_Interface {
 	/**
 	 * Send a GET request to WhoDat.
 	 *
-	 * @since TBD Added the $request_arguments parameter.
 	 * @since 5.3.0 moved to Abstract_WhoDat.
 	 * @since 5.1.9
 	 *
-	 * @param string $endpoint          The endpoint path.
-	 * @param array  $query_args        Query args appended to the URL.
-	 * @param array  $request_arguments Arguments passed on to wp_remote_get().
+	 * @param string $endpoint   The endpoint path.
+	 * @param array  $query_args Query args appended to the URL.
 	 *
 	 * @return mixed|null
 	 */
-	public function get( $endpoint, array $query_args, array $request_arguments = [] );
+	public function get( $endpoint, array $query_args );
 
 	/**
 	 * Log WhoDat errors.

--- a/src/Tickets/Commerce/Gateways/Square/Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Controller.php
@@ -33,6 +33,7 @@ class Controller extends Controller_Contract {
 		$this->container->singleton( Gateway::class );
 		$this->container->singleton( Merchant::class );
 		$this->container->singleton( WhoDat::class );
+		$this->container->singleton( Token_Refresher::class );
 		$this->container->singleton( Order::class );
 		$this->container->singleton( Settings::class );
 

--- a/src/Tickets/Commerce/Gateways/Square/Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Controller.php
@@ -12,6 +12,10 @@ use TEC\Tickets\Commerce\Gateways\Square\REST\On_Boarding_Endpoint;
 use TEC\Tickets\Commerce\Gateways\Square\REST\Order_Endpoint;
 use TEC\Tickets\Commerce\Gateways\Square\REST\Webhook_Endpoint;
 use TEC\Tickets\Commerce\Gateways\Square\Syncs\Controller as Syncs_Controller;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Client;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Lock;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Policy;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 use TEC\Tickets\Commerce\Gateways\Square\Webhooks;
 
 /**
@@ -33,6 +37,10 @@ class Controller extends Controller_Contract {
 		$this->container->singleton( Gateway::class );
 		$this->container->singleton( Merchant::class );
 		$this->container->singleton( WhoDat::class );
+		$this->container->singleton( Refresh_Status::class );
+		$this->container->singleton( Refresh_Policy::class );
+		$this->container->singleton( Refresh_Lock::class );
+		$this->container->singleton( Refresh_Client::class );
 		$this->container->singleton( Token_Refresher::class );
 		$this->container->singleton( Order::class );
 		$this->container->singleton( Settings::class );

--- a/src/Tickets/Commerce/Gateways/Square/Hooks.php
+++ b/src/Tickets/Commerce/Gateways/Square/Hooks.php
@@ -57,6 +57,7 @@ class Hooks extends Controller_Contract {
 	 * @return void
 	 */
 	public function do_register(): void {
+		add_action( 'admin_init', [ $this, 'maybe_refresh_access_token' ] );
 		add_filter( 'tec_tickets_commerce_gateways', [ $this, 'filter_add_gateway' ] );
 		add_filter( 'tec_repository_schema_tc_orders', [ $this, 'filter_orders_repository_schema' ], 10, 2 );
 		add_filter( 'tec_tickets_commerce_order_square_get_value_refunded', [ $this, 'filter_order_get_value_refunded' ], 10, 2 );
@@ -72,11 +73,33 @@ class Hooks extends Controller_Contract {
 	 * @return void
 	 */
 	public function unregister(): void {
+		remove_action( 'admin_init', [ $this, 'maybe_refresh_access_token' ] );
 		remove_filter( 'tec_tickets_commerce_gateways', [ $this, 'filter_add_gateway' ] );
 		remove_filter( 'tec_repository_schema_tc_orders', [ $this, 'filter_orders_repository_schema' ] );
 		remove_filter( 'tec_tickets_commerce_order_square_get_value_refunded', [ $this, 'filter_order_get_value_refunded' ] );
 		remove_filter( 'tec_tickets_commerce_success_page_should_display_billing_fields', [ $this, 'filter_display_billing_fields' ], 20 );
 		remove_filter( 'tec_tickets_commerce_order_has_pending_non_completed_transition', [ $this, 'filter_order_has_pending_non_completed_transition' ] );
+	}
+
+	/**
+	 * Renews the Square access token from the admin when it is due.
+	 *
+	 * The request path alone is not enough. A site that takes no Square traffic for a month never calls
+	 * the API, so nothing would notice the token expiring; and once a connection is marked unavailable
+	 * the Square API stops being called at all, which would leave a mistaken verdict with no way back.
+	 * Both are covered here without a scheduled action, which sites with a stalled cron queue would not
+	 * run. Token_Refresher throttles this, so it is one non-autoloaded option read on a normal page load.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function maybe_refresh_access_token(): void {
+		if ( wp_doing_ajax() || wp_doing_cron() ) {
+			return;
+		}
+
+		$this->container->get( Token_Refresher::class )->refresh_if_needed();
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -247,7 +247,7 @@ class Merchant extends Abstract_Merchant {
 	public function save_signup_data( array $signup_data ): bool {
 		unset( $signup_data['state'] );
 
-		$this->delete_token_status();
+		$this->delete_refresh_status();
 
 		return update_option( $this->get_signup_data_key(), $signup_data );
 	}
@@ -261,7 +261,7 @@ class Merchant extends Abstract_Merchant {
 	 *
 	 * @return string
 	 */
-	public function get_token_status_option_key(): string {
+	public function get_refresh_status_option_key(): string {
 		$gateway_key = Gateway::get_key();
 		$mode        = $this->get_mode();
 
@@ -271,12 +271,15 @@ class Merchant extends Abstract_Merchant {
 	/**
 	 * Returns the outcome of the last access token refresh attempt.
 	 *
+	 * The timestamps are UTC, so that they compare correctly against strtotime(), which WordPress pins
+	 * to UTC whatever the site timezone is.
+	 *
 	 * @since TBD
 	 *
-	 * @return array{invalid_at: string, error: string, failures: int, last_attempt_at: string}
+	 * @return array{invalid_at: string, error: string, failures: int, last_attempt_at: string, first_failure_at: string}
 	 */
-	public function get_token_status(): array {
-		$status = get_option( $this->get_token_status_option_key(), [] );
+	public function get_refresh_status(): array {
+		$status = get_option( $this->get_refresh_status_option_key(), [] );
 
 		if ( ! is_array( $status ) ) {
 			$status = [];
@@ -284,13 +287,25 @@ class Merchant extends Abstract_Merchant {
 
 		return array_merge(
 			[
-				'invalid_at'      => '',
-				'error'           => '',
-				'failures'        => 0,
-				'last_attempt_at' => '',
+				'invalid_at'       => '',
+				'error'            => '',
+				'failures'         => 0,
+				'last_attempt_at'  => '',
+				'first_failure_at' => '',
 			],
 			$status
 		);
+	}
+
+	/**
+	 * How many consecutive refresh attempts have failed.
+	 *
+	 * @since TBD
+	 *
+	 * @return int
+	 */
+	public function get_refresh_failure_count(): int {
+		return (int) $this->get_refresh_status()['failures'];
 	}
 
 	/**
@@ -302,8 +317,8 @@ class Merchant extends Abstract_Merchant {
 	 *
 	 * @return bool
 	 */
-	public function update_token_status( array $data ): bool {
-		return update_option( $this->get_token_status_option_key(), array_merge( $this->get_token_status(), $data ), false );
+	public function update_refresh_status( array $data ): bool {
+		return update_option( $this->get_refresh_status_option_key(), array_merge( $this->get_refresh_status(), $data ), false );
 	}
 
 	/**
@@ -313,8 +328,8 @@ class Merchant extends Abstract_Merchant {
 	 *
 	 * @return bool
 	 */
-	public function delete_token_status(): bool {
-		return delete_option( $this->get_token_status_option_key() );
+	public function delete_refresh_status(): bool {
+		return delete_option( $this->get_refresh_status_option_key() );
 	}
 
 	/**
@@ -378,7 +393,7 @@ class Merchant extends Abstract_Merchant {
 	 * @return bool
 	 */
 	public function is_token_invalid(): bool {
-		return ! empty( $this->get_token_status()['invalid_at'] );
+		return ! empty( $this->get_refresh_status()['invalid_at'] );
 	}
 
 	/**
@@ -397,7 +412,7 @@ class Merchant extends Abstract_Merchant {
 
 		$update = [
 			'expires_at'   => '',
-			'refreshed_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ),
+			'refreshed_at' => Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ),
 		];
 
 		// Only overwrite what the response actually carried; omitted keys keep their current value.
@@ -426,7 +441,7 @@ class Merchant extends Abstract_Merchant {
 	 */
 	public function flush_option_cache(): void {
 		wp_cache_delete( $this->get_signup_data_key(), 'options' );
-		wp_cache_delete( $this->get_token_status_option_key(), 'options' );
+		wp_cache_delete( $this->get_refresh_status_option_key(), 'options' );
 		wp_cache_delete( 'alloptions', 'options' );
 	}
 
@@ -455,7 +470,8 @@ class Merchant extends Abstract_Merchant {
 			return $return;
 		}
 
-		$accepted = tribe( WhoDat::class )->is_token_accepted();
+		// Forced: this is the explicit recheck, and a token refreshed moments ago outdates the cache.
+		$accepted = tribe( WhoDat::class )->is_token_accepted( true );
 
 		if ( null === $accepted ) {
 			$return['errors'][] = __( 'Unable to connect to Square.', 'event-tickets' );
@@ -463,7 +479,7 @@ class Merchant extends Abstract_Merchant {
 		}
 
 		if ( ! $accepted ) {
-			$status = tribe( WhoDat::class )->get_token_status();
+			$status = tribe( WhoDat::class )->get_token_status( true );
 
 			$return['errors'][] = $status['message'] ?? $status['error_description'] ?? __( 'Square no longer accepts the stored credentials.', 'event-tickets' );
 			return $return;
@@ -484,7 +500,7 @@ class Merchant extends Abstract_Merchant {
 		// Also delete any stored merchant data.
 		$this->delete_merchant_data();
 
-		$this->delete_token_status();
+		$this->delete_refresh_status();
 
 		$result = delete_option( $this->get_signup_data_key() );
 

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -11,6 +11,8 @@ namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_Merchant;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
+use Tribe__Date_Utils as Dates;
+use DateTimeInterface;
 use Exception;
 
 /**
@@ -95,6 +97,11 @@ class Merchant extends Abstract_Merchant {
 			empty( $client_data['client_id'] )
 			|| empty( $client_data['access_token'] )
 		) {
+			return false;
+		}
+
+		// A token Square refused to renew cannot be recovered without a new OAuth handshake.
+		if ( $this->is_token_invalid() ) {
 			return false;
 		}
 
@@ -240,7 +247,187 @@ class Merchant extends Abstract_Merchant {
 	public function save_signup_data( array $signup_data ): bool {
 		unset( $signup_data['state'] );
 
+		$this->delete_token_status();
+
 		return update_option( $this->get_signup_data_key(), $signup_data );
+	}
+
+	/**
+	 * Returns the option key holding the outcome of the last access token refresh attempt.
+	 *
+	 * Scoped to the gateway mode so the sandbox and live connections never share state.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_token_status_option_key(): string {
+		$gateway_key = Gateway::get_key();
+		$mode        = $this->get_mode();
+
+		return "tec_tickets_commerce_{$gateway_key}_token_status_{$mode}";
+	}
+
+	/**
+	 * Returns the outcome of the last access token refresh attempt.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{invalid_at: string, error: string, failures: int, last_attempt_at: string}
+	 */
+	public function get_token_status(): array {
+		$status = get_option( $this->get_token_status_option_key(), [] );
+
+		if ( ! is_array( $status ) ) {
+			$status = [];
+		}
+
+		return array_merge(
+			[
+				'invalid_at'      => '',
+				'error'           => '',
+				'failures'        => 0,
+				'last_attempt_at' => '',
+			],
+			$status
+		);
+	}
+
+	/**
+	 * Merges data into the access token refresh status.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $data The status data to merge in.
+	 *
+	 * @return bool
+	 */
+	public function update_token_status( array $data ): bool {
+		return update_option( $this->get_token_status_option_key(), array_merge( $this->get_token_status(), $data ), false );
+	}
+
+	/**
+	 * Deletes the access token refresh status.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function delete_token_status(): bool {
+		return delete_option( $this->get_token_status_option_key() );
+	}
+
+	/**
+	 * Returns the moment the Square access token expires.
+	 *
+	 * @since TBD
+	 *
+	 * @return ?DateTimeInterface Null when no usable expiration is stored.
+	 */
+	public function get_token_expiration(): ?DateTimeInterface {
+		$data = get_option( $this->get_signup_data_key() );
+
+		if ( empty( $data['expires_at'] ) || ! is_string( $data['expires_at'] ) ) {
+			return null;
+		}
+
+		// Dates::build_date_object() falls back to "now" for anything it cannot parse.
+		if ( false === strtotime( $data['expires_at'] ) ) {
+			return null;
+		}
+
+		return Dates::build_date_object( $data['expires_at'] );
+	}
+
+	/**
+	 * Whether the Square access token has expired.
+	 *
+	 * Connections made before the expiration was tracked report false: an unknown expiration is not an
+	 * expired one, and treating it as expired would break every site that upgrades into this code.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_token_expired(): bool {
+		$expiration = $this->get_token_expiration();
+
+		return null !== $expiration && $expiration->getTimestamp() <= time();
+	}
+
+	/**
+	 * Whether the Square access token expires within the given number of seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $window Seconds ahead of now to look.
+	 *
+	 * @return bool
+	 */
+	public function is_token_expiring_within( int $window ): bool {
+		$expiration = $this->get_token_expiration();
+
+		return null !== $expiration && $expiration->getTimestamp() - $window <= time();
+	}
+
+	/**
+	 * Whether Square has refused to renew the stored credentials.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_token_invalid(): bool {
+		return ! empty( $this->get_token_status()['invalid_at'] );
+	}
+
+	/**
+	 * Stores the credentials returned by a successful token refresh.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $data The refresh response.
+	 *
+	 * @return bool Whether the credentials were stored.
+	 */
+	public function save_refreshed_tokens( array $data ): bool {
+		if ( empty( $data['access_token'] ) || ! is_string( $data['access_token'] ) ) {
+			return false;
+		}
+
+		$update = [
+			'expires_at'   => '',
+			'refreshed_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ),
+		];
+
+		// Only overwrite what the response actually carried; omitted keys keep their current value.
+		foreach ( [ 'access_token', 'refresh_token', 'expires_at', 'token_type', 'merchant_id', 'whodat_signature' ] as $key ) {
+			if ( ! empty( $data[ $key ] ) && is_string( $data[ $key ] ) ) {
+				$update[ $key ] = $data[ $key ];
+			}
+		}
+
+		// An expiration we cannot read is an unknown one, never the previous one.
+		if ( false === strtotime( $update['expires_at'] ) ) {
+			$update['expires_at'] = '';
+		}
+
+		return $this->update( $update );
+	}
+
+	/**
+	 * Drops the object cache entries backing the merchant options.
+	 *
+	 * Used to re-read the credentials from the database after another process may have refreshed them.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush_option_cache(): void {
+		wp_cache_delete( $this->get_signup_data_key(), 'options' );
+		wp_cache_delete( $this->get_token_status_option_key(), 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 
 	/**
@@ -294,6 +481,8 @@ class Merchant extends Abstract_Merchant {
 	public function delete_signup_data(): bool {
 		// Also delete any stored merchant data.
 		$this->delete_merchant_data();
+
+		$this->delete_token_status();
 
 		$result = delete_option( $this->get_signup_data_key() );
 

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -455,15 +455,17 @@ class Merchant extends Abstract_Merchant {
 			return $return;
 		}
 
-		$status = tribe( WhoDat::class )->get_token_status();
+		$accepted = tribe( WhoDat::class )->is_token_accepted();
 
-		if ( ! is_array( $status ) || empty( $status ) ) {
+		if ( null === $accepted ) {
 			$return['errors'][] = __( 'Unable to connect to Square.', 'event-tickets' );
 			return $return;
 		}
 
-		if ( ! empty( $status['error'] ) ) {
-			$return['errors'][] = $status['error_description'] ?? __( 'Unknown Square error.', 'event-tickets' );
+		if ( ! $accepted ) {
+			$status = tribe( WhoDat::class )->get_token_status();
+
+			$return['errors'][] = $status['message'] ?? $status['error_description'] ?? __( 'Square no longer accepts the stored credentials.', 'event-tickets' );
 			return $return;
 		}
 

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -470,8 +470,11 @@ class Merchant extends Abstract_Merchant {
 			return $return;
 		}
 
+		$who_dat = tribe( WhoDat::class );
+
 		// Forced: this is the explicit recheck, and a token refreshed moments ago outdates the cache.
-		$accepted = tribe( WhoDat::class )->is_token_accepted( true );
+		$status   = $who_dat->get_token_status( true );
+		$accepted = $who_dat->interpret_token_status( $status );
 
 		if ( null === $accepted ) {
 			$return['errors'][] = __( 'Unable to connect to Square.', 'event-tickets' );
@@ -479,8 +482,6 @@ class Merchant extends Abstract_Merchant {
 		}
 
 		if ( ! $accepted ) {
-			$status = tribe( WhoDat::class )->get_token_status( true );
-
 			$return['errors'][] = $status['message'] ?? $status['error_description'] ?? __( 'Square no longer accepts the stored credentials.', 'event-tickets' );
 			return $return;
 		}

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -9,6 +9,7 @@
 
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
+use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_Merchant;
 use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
@@ -86,6 +87,7 @@ class Merchant extends Abstract_Merchant {
 	 * Determines if the Merchant is connected.
 	 *
 	 * @since 5.24.0
+	 * @since TBD A recheck retries a rejected connection before reading its verdict back.
 	 *
 	 * @param bool $recheck Whether to force a recheck of the connection.
 	 *
@@ -99,6 +101,16 @@ class Merchant extends Abstract_Merchant {
 			|| empty( $client_data['access_token'] )
 		) {
 			return false;
+		}
+
+		/*
+		 * An explicit recheck is somebody asking us to go and look, so the rejected connection gets one
+		 * more attempt at renewal before its own verdict is read back. Reading the flag first would
+		 * answer from it and never look, leaving a connection that started working again to sit out the
+		 * re-check interval.
+		 */
+		if ( $recheck && $this->is_token_invalid() ) {
+			tribe( Token_Refresher::class )->refresh_now( 'connection_recheck', true );
 		}
 
 		// A token Square refused to renew cannot be recovered without a new OAuth handshake.
@@ -157,6 +169,35 @@ class Merchant extends Abstract_Merchant {
 		$data = get_option( $this->get_signup_data_key() );
 
 		if ( empty( $data['access_token'] ) ) {
+			return '';
+		}
+
+		return $data['access_token'];
+	}
+
+	/**
+	 * Returns the Square access token read straight from the database, bypassing the object cache.
+	 *
+	 * Callers that poll for another process's write cannot use the cached read: the signup data is
+	 * autoloaded, so seeing a fresh value means dropping the whole `alloptions` blob on every pass,
+	 * which a persistent object cache then rebuilds with a full scan of the options table.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The stored access token, or an empty string when there is none.
+	 */
+	public function get_access_token_uncached(): string {
+		$stored = DB::get_var(
+			DB::prepare(
+				'SELECT option_value FROM %i WHERE option_name = %s',
+				DB::prefix( 'options' ),
+				$this->get_signup_data_key()
+			)
+		);
+
+		$data = maybe_unserialize( $stored );
+
+		if ( ! is_array( $data ) || empty( $data['access_token'] ) ) {
 			return '';
 		}
 

--- a/src/Tickets/Commerce/Gateways/Square/Merchant.php
+++ b/src/Tickets/Commerce/Gateways/Square/Merchant.php
@@ -10,6 +10,7 @@
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_Merchant;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 use Tribe__Date_Utils as Dates;
 use DateTimeInterface;
@@ -247,89 +248,9 @@ class Merchant extends Abstract_Merchant {
 	public function save_signup_data( array $signup_data ): bool {
 		unset( $signup_data['state'] );
 
-		$this->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 
 		return update_option( $this->get_signup_data_key(), $signup_data );
-	}
-
-	/**
-	 * Returns the option key holding the outcome of the last access token refresh attempt.
-	 *
-	 * Scoped to the gateway mode so the sandbox and live connections never share state.
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public function get_refresh_status_option_key(): string {
-		$gateway_key = Gateway::get_key();
-		$mode        = $this->get_mode();
-
-		return "tec_tickets_commerce_{$gateway_key}_token_status_{$mode}";
-	}
-
-	/**
-	 * Returns the outcome of the last access token refresh attempt.
-	 *
-	 * The timestamps are UTC, so that they compare correctly against strtotime(), which WordPress pins
-	 * to UTC whatever the site timezone is.
-	 *
-	 * @since TBD
-	 *
-	 * @return array{invalid_at: string, error: string, failures: int, last_attempt_at: string, first_failure_at: string}
-	 */
-	public function get_refresh_status(): array {
-		$status = get_option( $this->get_refresh_status_option_key(), [] );
-
-		if ( ! is_array( $status ) ) {
-			$status = [];
-		}
-
-		return array_merge(
-			[
-				'invalid_at'       => '',
-				'error'            => '',
-				'failures'         => 0,
-				'last_attempt_at'  => '',
-				'first_failure_at' => '',
-			],
-			$status
-		);
-	}
-
-	/**
-	 * How many consecutive refresh attempts have failed.
-	 *
-	 * @since TBD
-	 *
-	 * @return int
-	 */
-	public function get_refresh_failure_count(): int {
-		return (int) $this->get_refresh_status()['failures'];
-	}
-
-	/**
-	 * Merges data into the access token refresh status.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $data The status data to merge in.
-	 *
-	 * @return bool
-	 */
-	public function update_refresh_status( array $data ): bool {
-		return update_option( $this->get_refresh_status_option_key(), array_merge( $this->get_refresh_status(), $data ), false );
-	}
-
-	/**
-	 * Deletes the access token refresh status.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool
-	 */
-	public function delete_refresh_status(): bool {
-		return delete_option( $this->get_refresh_status_option_key() );
 	}
 
 	/**
@@ -355,29 +276,13 @@ class Merchant extends Abstract_Merchant {
 	}
 
 	/**
-	 * Whether the Square access token has expired.
-	 *
-	 * Connections made before the expiration was tracked report false: an unknown expiration is not an
-	 * expired one, and treating it as expired would break every site that upgrades into this code.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool
-	 */
-	public function is_token_expired(): bool {
-		$expiration = $this->get_token_expiration();
-
-		return null !== $expiration && $expiration->getTimestamp() <= time();
-	}
-
-	/**
 	 * Whether the Square access token expires within the given number of seconds.
 	 *
 	 * @since TBD
 	 *
 	 * @param int $window Seconds ahead of now to look.
 	 *
-	 * @return bool
+	 * @return bool False when no expiration is stored, since an unknown one is not an imminent one.
 	 */
 	public function is_token_expiring_within( int $window ): bool {
 		$expiration = $this->get_token_expiration();
@@ -390,10 +295,10 @@ class Merchant extends Abstract_Merchant {
 	 *
 	 * @since TBD
 	 *
-	 * @return bool
+	 * @return bool True once Square has refused to renew the stored credentials.
 	 */
 	public function is_token_invalid(): bool {
-		return ! empty( $this->get_refresh_status()['invalid_at'] );
+		return tribe( Refresh_Status::class )->is_invalid();
 	}
 
 	/**
@@ -401,7 +306,7 @@ class Merchant extends Abstract_Merchant {
 	 *
 	 * @since TBD
 	 *
-	 * @param array $data The refresh response.
+	 * @param array{access_token?: string, refresh_token?: string, expires_at?: string, token_type?: string, merchant_id?: string, whodat_signature?: string} $data The refresh response.
 	 *
 	 * @return bool Whether the credentials were stored.
 	 */
@@ -441,7 +346,6 @@ class Merchant extends Abstract_Merchant {
 	 */
 	public function flush_option_cache(): void {
 		wp_cache_delete( $this->get_signup_data_key(), 'options' );
-		wp_cache_delete( $this->get_refresh_status_option_key(), 'options' );
 		wp_cache_delete( 'alloptions', 'options' );
 	}
 
@@ -472,8 +376,8 @@ class Merchant extends Abstract_Merchant {
 
 		$who_dat = tribe( WhoDat::class );
 
-		// Forced: this is the explicit recheck, and a token refreshed moments ago outdates the cache.
-		$status   = $who_dat->get_token_status( true );
+		// Uncached: this is the explicit recheck, and a token refreshed moments ago outdates the cache.
+		$status   = $who_dat->get_fresh_token_status();
 		$accepted = $who_dat->interpret_token_status( $status );
 
 		if ( null === $accepted ) {
@@ -501,7 +405,7 @@ class Merchant extends Abstract_Merchant {
 		// Also delete any stored merchant data.
 		$this->delete_merchant_data();
 
-		$this->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 
 		$result = delete_option( $this->get_signup_data_key() );
 

--- a/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
@@ -490,8 +490,10 @@ class Notices_Controller extends Controller_Contract {
 	/**
 	 * Determines if the token rejected notice should be displayed.
 	 *
-	 * Deliberately does not check is_active(): a rejected token is exactly the state that makes the
-	 * gateway inactive, so gating on it would hide the notice that explains why.
+	 * Deliberately checks neither is_active() nor is_enabled(): a rejected token is what makes the
+	 * gateway inactive, and saving the Payments tab in that state clears the enabled flag, because the
+	 * enable toggle renders disabled and so submits nothing. Gating on either would let the screen that
+	 * explains the problem erase the notice explaining it.
 	 *
 	 * @since TBD
 	 *
@@ -502,15 +504,15 @@ class Notices_Controller extends Controller_Contract {
 			return false;
 		}
 
-		if ( ! $this->gateway->is_enabled() ) {
-			return false;
-		}
-
 		return $this->merchant->is_token_invalid();
 	}
 
 	/**
 	 * Determines if the repeated refresh failure notice should be displayed.
+	 *
+	 * Failures only matter once the token is close enough to expiring for them to cost a sale. Warning
+	 * about them on day 5 of a 30 day token would leave an undismissable banner up for weeks over
+	 * something that has every chance of clearing up on its own.
 	 *
 	 * @since TBD
 	 *
@@ -530,7 +532,13 @@ class Notices_Controller extends Controller_Contract {
 			return false;
 		}
 
-		return (int) $this->merchant->get_token_status()['failures'] >= 3;
+		if ( $this->merchant->get_refresh_failure_count() < 3 ) {
+			return false;
+		}
+
+		// An expiration we never learned is treated as imminent, since it may already have passed.
+		return null === $this->merchant->get_token_expiration()
+			|| $this->merchant->is_token_expiring_within( 2 * DAY_IN_SECONDS );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
@@ -67,6 +67,24 @@ class Notices_Controller extends Controller_Contract {
 	public const REMOTELY_DISCONNECTED_NOTICE_SLUG = 'tec-tickets-commerce-square-remotely-disconnected-notice';
 
 	/**
+	 * Token rejected notice slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const TOKEN_INVALID_NOTICE_SLUG = 'tec-tickets-commerce-square-token-invalid-notice';
+
+	/**
+	 * Token refresh failing notice slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const TOKEN_REFRESH_FAILING_NOTICE_SLUG = 'tec-tickets-commerce-square-token-refresh-failing-notice';
+
+	/**
 	 * Webhooks instance.
 	 *
 	 * @since 5.24.0
@@ -172,6 +190,28 @@ class Notices_Controller extends Controller_Contract {
 			],
 			[ $this, 'should_display_remotely_disconnected_notice' ]
 		);
+
+		tribe_notice(
+			self::TOKEN_INVALID_NOTICE_SLUG,
+			[ $this, 'render_token_invalid_notice' ],
+			[
+				'type'     => 'error',
+				'dismiss'  => false,
+				'priority' => 10,
+			],
+			[ $this, 'should_display_token_invalid_notice' ]
+		);
+
+		tribe_notice(
+			self::TOKEN_REFRESH_FAILING_NOTICE_SLUG,
+			[ $this, 'render_token_refresh_failing_notice' ],
+			[
+				'type'     => 'warning',
+				'dismiss'  => false,
+				'priority' => 10,
+			],
+			[ $this, 'should_display_token_refresh_failing_notice' ]
+		);
 	}
 
 	/**
@@ -188,6 +228,8 @@ class Notices_Controller extends Controller_Contract {
 			self::CURRENCY_MISMATCH_NOTICE_SLUG,
 			self::JUST_ONBOARDED_NOTICE_SLUG,
 			self::REMOTELY_DISCONNECTED_NOTICE_SLUG,
+			self::TOKEN_INVALID_NOTICE_SLUG,
+			self::TOKEN_REFRESH_FAILING_NOTICE_SLUG,
 		] as $slug ) {
 			tec_remove_notice( $slug );
 		}
@@ -442,6 +484,84 @@ class Notices_Controller extends Controller_Contract {
 			),
 			esc_url( admin_url( 'admin.php?page=tec-tickets-settings&tab=payments' ) ),
 			esc_html__( 'Configure TicketsCommerce Currency', 'event-tickets' )
+		);
+	}
+
+	/**
+	 * Determines if the token rejected notice should be displayed.
+	 *
+	 * Deliberately does not check is_active(): a rejected token is exactly the state that makes the
+	 * gateway inactive, so gating on it would hide the notice that explains why.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_display_token_invalid_notice(): bool {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		if ( ! $this->gateway->is_enabled() ) {
+			return false;
+		}
+
+		return $this->merchant->is_token_invalid();
+	}
+
+	/**
+	 * Determines if the repeated refresh failure notice should be displayed.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_display_token_refresh_failing_notice(): bool {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		if ( ! $this->gateway->is_enabled() ) {
+			return false;
+		}
+
+		// The rejected notice covers this case with a clearer message.
+		if ( $this->merchant->is_token_invalid() ) {
+			return false;
+		}
+
+		return (int) $this->merchant->get_token_status()['failures'] >= 3;
+	}
+
+	/**
+	 * Render the token rejected notice.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function render_token_invalid_notice(): string {
+		return sprintf(
+			'<p><strong>%1$s</strong></p><p>%2$s</p><p><a href="%3$s" class="button button-primary">%4$s</a></p>',
+			esc_html__( 'Square connection expired', 'event-tickets' ),
+			esc_html__( 'Square would not renew the credentials for this site, so ticket sales through Square are paused. Reconnect your Square account to start selling again.', 'event-tickets' ),
+			esc_url( admin_url( 'admin.php?page=tec-tickets-settings&tab=square' ) ),
+			esc_html__( 'Reconnect Square', 'event-tickets' )
+		);
+	}
+
+	/**
+	 * Render the repeated refresh failure notice.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function render_token_refresh_failing_notice(): string {
+		return sprintf(
+			'<p><strong>%1$s</strong></p><p>%2$s</p>',
+			esc_html__( 'Square connection could not be renewed', 'event-tickets' ),
+			esc_html__( 'The last few attempts to renew your Square credentials did not go through. Ticket sales through Square still work for now, but they will stop once the current credentials expire.', 'event-tickets' )
 		);
 	}
 

--- a/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
@@ -85,6 +85,18 @@ class Notices_Controller extends Controller_Contract {
 	public const TOKEN_REFRESH_FAILING_NOTICE_SLUG = 'tec-tickets-commerce-square-token-refresh-failing-notice';
 
 	/**
+	 * How many consecutive refresh failures the notice waits for.
+	 *
+	 * Below the disconnect threshold in Token_Refresher, so the warning has room to appear while the
+	 * connection is still working, but high enough that a single bad response does not raise it.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	public const REFRESH_FAILURES_BEFORE_NOTICE = 3;
+
+	/**
 	 * Webhooks instance.
 	 *
 	 * @since 5.24.0
@@ -532,7 +544,7 @@ class Notices_Controller extends Controller_Contract {
 			return false;
 		}
 
-		if ( $this->merchant->get_refresh_failure_count() < 3 ) {
+		if ( $this->merchant->get_refresh_failure_count() < self::REFRESH_FAILURES_BEFORE_NOTICE ) {
 			return false;
 		}
 

--- a/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Notices_Controller.php
@@ -11,6 +11,7 @@ namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\Contracts\Container;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 
 /**
@@ -87,7 +88,7 @@ class Notices_Controller extends Controller_Contract {
 	/**
 	 * How many consecutive refresh failures the notice waits for.
 	 *
-	 * Below the disconnect threshold in Token_Refresher, so the warning has room to appear while the
+	 * Below the disconnect threshold in Refresh_Client, so the warning has room to appear while the
 	 * connection is still working, but high enough that a single bad response does not raise it.
 	 *
 	 * @since TBD
@@ -124,20 +125,32 @@ class Notices_Controller extends Controller_Contract {
 	private Merchant $merchant;
 
 	/**
+	 * Token refresh status instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Refresh_Status
+	 */
+	private Refresh_Status $refresh_status;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 5.24.0
+	 * @since TBD Added the $refresh_status parameter.
 	 *
-	 * @param Container $container Container instance.
-	 * @param Webhooks  $webhooks  Webhooks instance.
-	 * @param Gateway   $gateway   Gateway instance.
-	 * @param Merchant  $merchant  Merchant instance.
+	 * @param Container      $container      Container instance.
+	 * @param Webhooks       $webhooks       Webhooks instance.
+	 * @param Gateway        $gateway        Gateway instance.
+	 * @param Merchant       $merchant       Merchant instance.
+	 * @param Refresh_Status $refresh_status Token refresh status instance.
 	 */
-	public function __construct( Container $container, Webhooks $webhooks, Gateway $gateway, Merchant $merchant ) {
+	public function __construct( Container $container, Webhooks $webhooks, Gateway $gateway, Merchant $merchant, Refresh_Status $refresh_status ) {
 		parent::__construct( $container );
-		$this->webhooks = $webhooks;
-		$this->gateway  = $gateway;
-		$this->merchant = $merchant;
+		$this->webhooks       = $webhooks;
+		$this->gateway        = $gateway;
+		$this->merchant       = $merchant;
+		$this->refresh_status = $refresh_status;
 	}
 
 	/**
@@ -544,7 +557,7 @@ class Notices_Controller extends Controller_Contract {
 			return false;
 		}
 
-		if ( $this->merchant->get_refresh_failure_count() < self::REFRESH_FAILURES_BEFORE_NOTICE ) {
+		if ( $this->refresh_status->get_failure_count() < self::REFRESH_FAILURES_BEFORE_NOTICE ) {
 			return false;
 		}
 

--- a/src/Tickets/Commerce/Gateways/Square/Requests.php
+++ b/src/Tickets/Commerce/Gateways/Square/Requests.php
@@ -133,45 +133,6 @@ class Requests extends Abstract_Requests {
 	}
 
 	/**
-	 * Whether Square turned the request down because of the access token.
-	 *
-	 * Square reports these under a plural `errors` key, which Abstract_Requests::process_response() leaves
-	 * alone because it looks for the singular `error` shape, so the decoded body arrives here as-is.
-	 *
-	 * @since TBD
-	 *
-	 * @param mixed $response The response returned by the request.
-	 * @param bool  $raw      Whether the response is an unprocessed HTTP response.
-	 *
-	 * @return bool
-	 */
-	protected static function is_unauthorized_response( $response, bool $raw = false ): bool {
-		if ( $raw ) {
-			return 401 === (int) wp_remote_retrieve_response_code( $response );
-		}
-
-		if ( ! is_array( $response ) || empty( $response['errors'] ) || ! is_array( $response['errors'] ) ) {
-			return false;
-		}
-
-		foreach ( $response['errors'] as $error ) {
-			if ( ! is_array( $error ) ) {
-				continue;
-			}
-
-			if ( 'AUTHENTICATION_ERROR' === ( $error['category'] ?? '' ) ) {
-				return true;
-			}
-
-			if ( in_array( $error['code'] ?? '', [ 'UNAUTHORIZED', 'ACCESS_TOKEN_EXPIRED', 'ACCESS_TOKEN_REVOKED' ], true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Get REST API endpoint URL for requests.
 	 *
 	 * @since 5.24.0
@@ -247,5 +208,44 @@ class Requests extends Abstract_Requests {
 			'Content-Type'   => 'application/json',
 			'Accept'         => 'application/json',
 		];
+	}
+
+	/**
+	 * Whether Square turned the request down because of the access token.
+	 *
+	 * Square reports these under a plural `errors` key, which Abstract_Requests::process_response() leaves
+	 * alone because it looks for the singular `error` shape, so the decoded body arrives here as-is.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $response The response returned by the request.
+	 * @param bool  $raw      Whether the response is an unprocessed HTTP response.
+	 *
+	 * @return bool
+	 */
+	protected static function is_unauthorized_response( $response, bool $raw = false ): bool {
+		if ( $raw ) {
+			return 401 === (int) wp_remote_retrieve_response_code( $response );
+		}
+
+		if ( ! is_array( $response ) || empty( $response['errors'] ) || ! is_array( $response['errors'] ) ) {
+			return false;
+		}
+
+		foreach ( $response['errors'] as $error ) {
+			if ( ! is_array( $error ) ) {
+				continue;
+			}
+
+			if ( 'AUTHENTICATION_ERROR' === ( $error['category'] ?? '' ) ) {
+				return true;
+			}
+
+			if ( in_array( $error['code'] ?? '', [ 'UNAUTHORIZED', 'ACCESS_TOKEN_EXPIRED', 'ACCESS_TOKEN_REVOKED' ], true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Square/Requests.php
+++ b/src/Tickets/Commerce/Gateways/Square/Requests.php
@@ -75,7 +75,8 @@ class Requests extends Abstract_Requests {
 	 */
 	public static function get_with_cache( $endpoint, array $query_args = [], array $request_arguments = [], $raw = false ): ?array {
 		$merchant_id = self::get_merchant_id();
-		$cache_key   = md5( wp_json_encode( [ $merchant_id, $endpoint, $query_args, $request_arguments, $raw ] ) );
+		$token_hash  = substr( md5( tribe( static::$merchant )->get_access_token() ), 0, 8 );
+		$cache_key   = md5( wp_json_encode( [ $merchant_id, $token_hash, $endpoint, $query_args, $request_arguments, $raw ] ) );
 		$cache       = tribe_cache();
 
 		$cached_response = $cache[ $cache_key ] ?? $cache->get_transient( $cache_key );
@@ -89,6 +90,82 @@ class Requests extends Abstract_Requests {
 		$cache->set_transient( $cache_key, $response, MINUTE_IN_SECONDS * 10 );
 
 		return $response;
+	}
+
+	/**
+	 * Sends a request to Square, keeping the access token current.
+	 *
+	 * Square access tokens expire, and nothing else in the plugin renews them, so the renewal happens
+	 * here: this is the one place every Square API call passes through, and it is reached even on sites
+	 * where the cron queue is not running.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $method            The request method.
+	 * @param string $url               The endpoint path or full URL.
+	 * @param array  $query_args        Query args appended to the URL.
+	 * @param array  $request_arguments Request arguments.
+	 * @param bool   $raw               Whether to return the raw response.
+	 * @param int    $retries           How many times this request has already been re-sent.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public static function request( $method, $url, array $query_args = [], array $request_arguments = [], $raw = false, $retries = 0 ) {
+		if ( 0 === $retries ) {
+			tribe( Token_Refresher::class )->refresh_if_needed();
+		}
+
+		$response = parent::request( $method, $url, $query_args, $request_arguments, $raw, $retries );
+
+		// Square can reject a token before its recorded expiration, for instance after a password reset.
+		if ( 0 !== $retries || ! static::is_unauthorized_response( $response, (bool) $raw ) ) {
+			return $response;
+		}
+
+		if ( ! tribe( Token_Refresher::class )->refresh_now( 'square_unauthorized' ) ) {
+			return $response;
+		}
+
+		return static::request( $method, $url, $query_args, $request_arguments, $raw, $retries + 1 );
+	}
+
+	/**
+	 * Whether Square turned the request down because of the access token.
+	 *
+	 * Square reports these under a plural `errors` key, which Abstract_Requests::process_response() leaves
+	 * alone because it looks for the singular `error` shape, so the decoded body arrives here as-is.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $response The response returned by the request.
+	 * @param bool  $raw      Whether the response is an unprocessed HTTP response.
+	 *
+	 * @return bool
+	 */
+	protected static function is_unauthorized_response( $response, bool $raw = false ): bool {
+		if ( $raw ) {
+			return 401 === (int) wp_remote_retrieve_response_code( $response );
+		}
+
+		if ( ! is_array( $response ) || empty( $response['errors'] ) || ! is_array( $response['errors'] ) ) {
+			return false;
+		}
+
+		foreach ( $response['errors'] as $error ) {
+			if ( ! is_array( $error ) ) {
+				continue;
+			}
+
+			if ( 'AUTHENTICATION_ERROR' === ( $error['category'] ?? '' ) ) {
+				return true;
+			}
+
+			if ( in_array( $error['code'] ?? '', [ 'UNAUTHORIZED', 'ACCESS_TOKEN_EXPIRED', 'ACCESS_TOKEN_REVOKED' ], true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Requests.php
+++ b/src/Tickets/Commerce/Gateways/Square/Requests.php
@@ -74,6 +74,9 @@ class Requests extends Abstract_Requests {
 	 * @return array|null
 	 */
 	public static function get_with_cache( $endpoint, array $query_args = [], array $request_arguments = [], $raw = false ): ?array {
+		// Before the key is built, or a refresh mid-request would file the response under the old token.
+		tribe( Token_Refresher::class )->refresh_if_needed();
+
 		$merchant_id = self::get_merchant_id();
 		$token_hash  = substr( md5( tribe( static::$merchant )->get_access_token() ), 0, 8 );
 		$cache_key   = md5( wp_json_encode( [ $merchant_id, $token_hash, $endpoint, $query_args, $request_arguments, $raw ] ) );

--- a/src/Tickets/Commerce/Gateways/Square/Requests.php
+++ b/src/Tickets/Commerce/Gateways/Square/Requests.php
@@ -121,7 +121,7 @@ class Requests extends Abstract_Requests {
 		$response = parent::request( $method, $url, $query_args, $request_arguments, $raw, $retries );
 
 		// Square can reject a token before its recorded expiration, for instance after a password reset.
-		if ( 0 !== $retries || ! static::is_unauthorized_response( $response, (bool) $raw ) ) {
+		if ( 0 !== $retries || ! self::is_unauthorized_response( $response, tribe_is_truthy( $raw ) ) ) {
 			return $response;
 		}
 
@@ -223,9 +223,9 @@ class Requests extends Abstract_Requests {
 	 *
 	 * @return bool
 	 */
-	protected static function is_unauthorized_response( $response, bool $raw = false ): bool {
+	private static function is_unauthorized_response( $response, bool $raw = false ): bool {
 		if ( $raw ) {
-			return 401 === (int) wp_remote_retrieve_response_code( $response );
+			return 401 === absint( wp_remote_retrieve_response_code( $response ) );
 		}
 
 		if ( ! is_array( $response ) || empty( $response['errors'] ) || ! is_array( $response['errors'] ) ) {

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Client.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Client.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Sends the Square access token refresh and reads Square's answer.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+use TEC\Tickets\Commerce\Gateways\Square\WhoDat;
+use WP_Error;
+
+/**
+ * Class Refresh_Client
+ *
+ * The endpoint answers a rejected refresh token with an HTML 500 rather than a machine readable error,
+ * so the response alone often says nothing. Turning that into a verdict a caller can act on - and
+ * corroborating it against Square when it is ambiguous - is this class's whole job.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+final class Refresh_Client {
+	/**
+	 * How many failures must pile up before an uncorroborated rejection counts as final.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const PERSISTENT_FAILURES = 5;
+
+	/**
+	 * Merchant instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Merchant
+	 */
+	private Merchant $merchant;
+
+	/**
+	 * WhoDat instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var WhoDat
+	 */
+	private WhoDat $who_dat;
+
+	/**
+	 * Refresh status instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Refresh_Status
+	 */
+	private Refresh_Status $status;
+
+	/**
+	 * Refresh_Client constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Merchant       $merchant Merchant instance.
+	 * @param WhoDat         $who_dat  WhoDat instance.
+	 * @param Refresh_Status $status   Refresh status instance.
+	 */
+	public function __construct( Merchant $merchant, WhoDat $who_dat, Refresh_Status $status ) {
+		$this->merchant = $merchant;
+		$this->who_dat  = $who_dat;
+		$this->status   = $status;
+	}
+
+	/**
+	 * Asks Square to renew the credentials.
+	 *
+	 * @since TBD
+	 *
+	 * @return Refresh_Outcome The verdict Square's answer supports.
+	 */
+	public function refresh(): Refresh_Outcome {
+		return $this->classify( $this->who_dat->request_token_refresh() );
+	}
+
+	/**
+	 * Decides whether a refresh attempt failed for good or is worth trying again.
+	 *
+	 * Square's own view of the stored access token settles the ambiguous cases: if Square no longer
+	 * accepts the token and it cannot be renewed, the connection really is finished. Anything less
+	 * certain counts as transient, so that an outage never disconnects a working site.
+	 *
+	 * @since TBD
+	 *
+	 * @param array{code: int, body: mixed, error: ?WP_Error} $result The outcome of the refresh request.
+	 *
+	 * @return Refresh_Outcome Success carrying the new credentials, or the failure verdict and its code.
+	 */
+	private function classify( array $result ): Refresh_Outcome {
+		$code = $result['code'];
+		$body = $result['body'];
+
+		if ( 200 === $code && is_array( $body ) && ! empty( $body['access_token'] ) && is_string( $body['access_token'] ) ) {
+			return Refresh_Outcome::success( $body );
+		}
+
+		// The request never completed, so nothing has been established about the credentials.
+		if ( $result['error'] instanceof WP_Error || 0 === $code ) {
+			return Refresh_Outcome::transient( $code );
+		}
+
+		// An outright authorization refusal needs no corroboration.
+		if ( 401 === $code || 403 === $code ) {
+			return Refresh_Outcome::permanent( $code );
+		}
+
+		// Everything else, a rate limit or a gateway error included, has to be corroborated.
+		return $this->is_rejection_final()
+			? Refresh_Outcome::permanent( $code )
+			: Refresh_Outcome::transient( $code );
+	}
+
+	/**
+	 * Whether a refusal the response could not explain is worth acting on.
+	 *
+	 * Square's status endpoint reports on the *access* token, which has usually expired by the time a
+	 * refresh runs, so on its own it cannot tell a revoked grant from an outage: it says UNAUTHORIZED
+	 * either way. It only carries independent information while the access token is still inside its
+	 * own lifetime. When it does not, the connection is written off only after failures that keep
+	 * repeating over more than a day, which an outage does not do.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the connection should be written off rather than retried.
+	 */
+	private function is_rejection_final(): bool {
+		// Capped like the refresh itself: this runs on the same checkout request the refresh came from.
+		$status = $this->who_dat->get_fresh_token_status( [ 'timeout' => WhoDat::TOKEN_REQUEST_TIMEOUT ] );
+
+		if ( false !== $this->who_dat->interpret_token_status( $status ) ) {
+			return false;
+		}
+
+		$expiration = $this->merchant->get_token_expiration();
+
+		/*
+		 * Square refusing a token that is still inside its own lifetime means the grant itself is gone.
+		 * An expiration we never recorded proves nothing either way, so it does not count here.
+		 */
+		if ( null !== $expiration && $expiration->getTimestamp() > time() ) {
+			return true;
+		}
+
+		$first_failure = $this->status->get_first_failure_timestamp();
+
+		return $this->status->get_failure_count() >= self::PERSISTENT_FAILURES
+			&& null !== $first_failure
+			&& $first_failure <= time() - DAY_IN_SECONDS;
+	}
+}

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Lock.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Lock.php
@@ -51,7 +51,8 @@ final class Refresh_Lock {
 	/**
 	 * How often to re-read the credentials while waiting, in microseconds.
 	 *
-	 * Each poll drops the options cache, so this is coarse enough to keep the count down over the wait.
+	 * Each poll is one indexed row read, so this only has to be fine enough to hand the waiter its
+	 * token promptly once the holder writes it.
 	 *
 	 * @since TBD
 	 *
@@ -207,6 +208,10 @@ final class Refresh_Lock {
 			usleep( self::POLL );
 
 			$waited += self::POLL;
+
+			if ( $this->merchant->get_access_token_uncached() === $previous_token ) {
+				continue;
+			}
 
 			$this->merchant->flush_option_cache();
 

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Lock.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Lock.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Serializes the Square access token refresh across concurrent requests.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+use TEC\Common\StellarWP\DB\DB;
+use TEC\Tickets\Commerce\Gateways\Square\Gateway;
+use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+use TEC\Tickets\Commerce\Gateways\Square\WhoDat;
+use Throwable;
+
+/**
+ * Class Refresh_Lock
+ *
+ * Two concurrent refreshes would each spend the refresh token, so only one may run. The lock lives in
+ * the options table rather than in the object cache, because it has to hold across processes on a
+ * site with no persistent cache.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+final class Refresh_Lock {
+	/**
+	 * Seconds after which a held lock is considered abandoned.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const TIMEOUT = 60;
+
+	/**
+	 * How long to keep polling for the winner's result when the lock is contended, in microseconds.
+	 *
+	 * Has to outlast the holder's refresh call, or every waiter walks away before the new token lands
+	 * and takes the rejection it was waiting to avoid. A second of headroom covers the writes around it.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const WAIT = ( WhoDat::TOKEN_REQUEST_TIMEOUT + 1 ) * 1000000;
+
+	/**
+	 * How often to re-read the credentials while waiting, in microseconds.
+	 *
+	 * Each poll drops the options cache, so this is coarse enough to keep the count down over the wait.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const POLL = 250000;
+
+	/**
+	 * Merchant instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Merchant
+	 */
+	private Merchant $merchant;
+
+	/**
+	 * The value written into the lock row while this process holds it.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private string $value = '';
+
+	/**
+	 * Refresh_Lock constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Merchant $merchant Merchant instance.
+	 */
+	public function __construct( Merchant $merchant ) {
+		$this->merchant = $merchant;
+	}
+
+	/**
+	 * Takes the lock.
+	 *
+	 * INSERT IGNORE is atomic on the unique option_name index; add_option() reads before it writes and
+	 * can be raced.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the lock is now held by this process.
+	 */
+	public function acquire(): bool {
+		$key   = $this->get_option_key();
+		$now   = time();
+		$table = DB::prefix( 'options' );
+		$value = $now . ':' . wp_generate_password( 12, false );
+
+		try {
+			$acquired = DB::query(
+				DB::prepare(
+					'INSERT IGNORE INTO %i ( option_name, option_value, autoload ) VALUES ( %s, %s, %s )',
+					$table,
+					$key,
+					$value,
+					'no'
+				)
+			) > 0;
+
+			if ( ! $acquired ) {
+				// A crash must not hold refreshes off forever.
+				$acquired = DB::query(
+					DB::prepare(
+						'UPDATE %i SET option_value = %s WHERE option_name = %s AND CAST( SUBSTRING_INDEX( option_value, %s, 1 ) AS UNSIGNED ) < %d',
+						$table,
+						$value,
+						$key,
+						':',
+						$now - self::TIMEOUT
+					)
+				) > 0;
+			}
+		} catch ( Throwable $e ) {
+			// Left unlogged the refresh would simply stop happening, which is the failure being fixed.
+			do_action(
+				'tribe_log',
+				'error',
+				'Square access token refresh could not take its lock',
+				[
+					'source' => 'tickets-commerce-square',
+					'error'  => $e->getMessage(),
+				]
+			);
+
+			return false;
+		}
+
+		if ( ! $acquired ) {
+			return false;
+		}
+
+		$this->value = $value;
+
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( $key, 'options' );
+
+		return true;
+	}
+
+	/**
+	 * Releases the lock, but only while this process still holds it.
+	 *
+	 * A process that stalled past the timeout has had its lock taken over, and must not delete the row a
+	 * second process is now working under.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function release(): void {
+		if ( '' === $this->value ) {
+			return;
+		}
+
+		try {
+			DB::query(
+				DB::prepare(
+					'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
+					DB::prefix( 'options' ),
+					$this->get_option_key(),
+					$this->value
+				)
+			);
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// The stale takeover will clear it.
+		}
+
+		$this->value = '';
+
+		wp_cache_delete( $this->get_option_key(), 'options' );
+	}
+
+	/**
+	 * Waits out a refresh another process is already running.
+	 *
+	 * Without this every concurrent request that finds an expired token fails its Square call while the
+	 * winner is still mid-refresh, which at checkout means a failed payment per shopper.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $previous_token The access token this process started with.
+	 *
+	 * @return bool Whether the credentials were renewed by whoever held the lock.
+	 */
+	public function wait_for_holder( string $previous_token ): bool {
+		$waited = 0;
+
+		while ( $waited < self::WAIT ) {
+			usleep( self::POLL );
+
+			$waited += self::POLL;
+
+			$this->merchant->flush_option_cache();
+
+			if ( $this->merchant->get_access_token() !== $previous_token ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The option name backing the lock.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The option name the lock row is stored under.
+	 */
+	private function get_option_key(): string {
+		$gateway_key = Gateway::get_key();
+		$mode        = $this->merchant->get_mode();
+
+		return "tec_tickets_commerce_{$gateway_key}_token_refresh_lock_{$mode}";
+	}
+}

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Outcome.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Outcome.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * The result of a single Square access token refresh attempt.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+/**
+ * Class Refresh_Outcome
+ *
+ * A refresh either produced credentials, ended the connection, or did neither and is worth retrying.
+ * Modelled as an object rather than a string constant so that no caller can compare against the wrong
+ * one, and so the credentials travel with the verdict that says they exist.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+final class Refresh_Outcome {
+	/**
+	 * The refresh response carried a new access token.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SUCCESS = 'success';
+
+	/**
+	 * Square refused the refresh token; only a new OAuth handshake can recover.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const PERMANENT = 'permanent';
+
+	/**
+	 * The refresh did not go through, but the credentials may still be good.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TRANSIENT = 'transient';
+
+	/**
+	 * Which of the three verdicts this is.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private string $verdict;
+
+	/**
+	 * The response code the refresh came back with, 0 when the request never completed.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private int $code;
+
+	/**
+	 * The credentials the refresh returned, empty unless it succeeded.
+	 *
+	 * @since TBD
+	 *
+	 * @var array{access_token?: string, refresh_token?: string, expires_at?: string, token_type?: string, merchant_id?: string, whodat_signature?: string}
+	 */
+	private array $credentials;
+
+	/**
+	 * The refresh returned new credentials.
+	 *
+	 * @since TBD
+	 *
+	 * @param array{access_token?: string, refresh_token?: string, expires_at?: string, token_type?: string, merchant_id?: string, whodat_signature?: string} $credentials The credentials the refresh returned.
+	 *
+	 * @return self An outcome carrying the new credentials.
+	 */
+	public static function success( array $credentials ): self {
+		return new self( self::SUCCESS, 200, $credentials );
+	}
+
+	/**
+	 * Square will not renew this connection.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $code The response code the refresh came back with.
+	 *
+	 * @return self An outcome only a new OAuth handshake can clear.
+	 */
+	public static function permanent( int $code ): self {
+		return new self( self::PERMANENT, $code );
+	}
+
+	/**
+	 * The refresh did not go through, and is worth trying again.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $code The response code the refresh came back with, 0 when it never completed.
+	 *
+	 * @return self An outcome the caller may retry later.
+	 */
+	public static function transient( int $code ): self {
+		return new self( self::TRANSIENT, $code );
+	}
+
+	/**
+	 * Whether the refresh returned new credentials.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the refresh returned new credentials.
+	 */
+	public function is_success(): bool {
+		return self::SUCCESS === $this->verdict;
+	}
+
+	/**
+	 * Whether Square will not renew this connection.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when Square will not renew this connection.
+	 */
+	public function is_permanent(): bool {
+		return self::PERMANENT === $this->verdict;
+	}
+
+	/**
+	 * Whether the refresh is worth trying again.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the refresh is worth trying again.
+	 */
+	public function is_transient(): bool {
+		return self::TRANSIENT === $this->verdict;
+	}
+
+	/**
+	 * Returns the response code the refresh came back with.
+	 *
+	 * @since TBD
+	 *
+	 * @return int Zero when the request never completed.
+	 */
+	public function get_code(): int {
+		return $this->code;
+	}
+
+	/**
+	 * Returns the credentials the refresh returned.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{access_token?: string, refresh_token?: string, expires_at?: string, token_type?: string, merchant_id?: string, whodat_signature?: string} Empty unless the refresh succeeded.
+	 */
+	public function get_credentials(): array {
+		return $this->credentials;
+	}
+
+	/**
+	 * Refresh_Outcome constructor.
+	 *
+	 * Private: an outcome is built through one of the three named constructors, which is what keeps an
+	 * unreachable combination - success with no credentials, say - from being expressible.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $verdict     One of the class verdict constants.
+	 * @param int    $code        The response code the refresh came back with.
+	 * @param array  $credentials The credentials the refresh returned, in the shape get_credentials() documents.
+	 */
+	private function __construct( string $verdict, int $code, array $credentials = [] ) {
+		$this->verdict     = $verdict;
+		$this->code        = $code;
+		$this->credentials = $credentials;
+	}
+}

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Outcome.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Outcome.php
@@ -137,17 +137,6 @@ final class Refresh_Outcome {
 	}
 
 	/**
-	 * Whether the refresh is worth trying again.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool True when the refresh is worth trying again.
-	 */
-	public function is_transient(): bool {
-		return self::TRANSIENT === $this->verdict;
-	}
-
-	/**
 	 * Returns the response code the refresh came back with.
 	 *
 	 * @since TBD

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Policy.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Policy.php
@@ -15,14 +15,40 @@ use TEC\Tickets\Commerce\Gateways\Square\Merchant;
  * Class Refresh_Policy
  *
  * Answers "should this run now?" from the stored credentials and the refresh history alone: no
- * network, no writes, no locking. Every interval it works from is filterable, and every one of those
- * filters is the reason a method here exists.
+ * network, no writes, no locking.
  *
  * @since TBD
  *
  * @package TEC\Tickets\Commerce\Gateways\Square\Token
  */
 final class Refresh_Policy {
+	/**
+	 * How long before its expiration the access token is refreshed, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const REFRESH_WINDOW = DAY_IN_SECONDS;
+
+	/**
+	 * How often a connection with no recorded expiration retries, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const UNKNOWN_EXPIRATION_INTERVAL = 12 * HOUR_IN_SECONDS;
+
+	/**
+	 * How long a rejected connection waits before it asks Square again, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const INVALID_RECHECK_INTERVAL = 12 * HOUR_IN_SECONDS;
+
 	/**
 	 * Merchant instance.
 	 *
@@ -81,10 +107,10 @@ final class Refresh_Policy {
 			// Connected before the expiration was tracked: try occasionally until we learn a real one.
 			$last_attempt = $this->status->get_last_attempt_timestamp();
 
-			return null === $last_attempt || $last_attempt < time() - $this->get_unknown_expiration_interval();
+			return null === $last_attempt || $last_attempt < time() - self::UNKNOWN_EXPIRATION_INTERVAL;
 		}
 
-		return $expiration->getTimestamp() - $this->get_refresh_window() <= time();
+		return $expiration->getTimestamp() - self::REFRESH_WINDOW <= time();
 	}
 
 	/**
@@ -111,63 +137,9 @@ final class Refresh_Policy {
 		}
 
 		$backoff = $invalid
-			? $this->get_invalid_recheck_interval()
+			? self::INVALID_RECHECK_INTERVAL
 			: min( 12 * HOUR_IN_SECONDS, HOUR_IN_SECONDS * ( 2 ** min( 4, $failures - 1 ) ) );
 
 		return $last_attempt + $backoff > time();
-	}
-
-	/**
-	 * How long before the expiration a refresh is attempted, in seconds.
-	 *
-	 * @since TBD
-	 *
-	 * @return int The window, in seconds.
-	 */
-	private function get_refresh_window(): int {
-		/**
-		 * Filters how long before its expiration the Square access token is refreshed.
-		 *
-		 * @since TBD
-		 *
-		 * @param int $window The window, in seconds.
-		 */
-		return absint( apply_filters( 'tec_tickets_commerce_square_token_refresh_window', DAY_IN_SECONDS ) );
-	}
-
-	/**
-	 * How often a connection with no recorded expiration retries, in seconds.
-	 *
-	 * @since TBD
-	 *
-	 * @return int The interval, in seconds.
-	 */
-	private function get_unknown_expiration_interval(): int {
-		/**
-		 * Filters how often a Square connection with no recorded expiration attempts a refresh.
-		 *
-		 * @since TBD
-		 *
-		 * @param int $interval The interval, in seconds.
-		 */
-		return absint( apply_filters( 'tec_tickets_commerce_square_token_refresh_unknown_expiration_interval', 12 * HOUR_IN_SECONDS ) );
-	}
-
-	/**
-	 * How long a rejected connection waits before it asks Square again.
-	 *
-	 * @since TBD
-	 *
-	 * @return int The interval, in seconds.
-	 */
-	private function get_invalid_recheck_interval(): int {
-		/**
-		 * Filters how often a rejected Square connection re-checks whether it can be renewed after all.
-		 *
-		 * @since TBD
-		 *
-		 * @param int $interval The interval, in seconds.
-		 */
-		return absint( apply_filters( 'tec_tickets_commerce_square_token_invalid_recheck_interval', 12 * HOUR_IN_SECONDS ) );
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Policy.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Policy.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Decides when the Square access token should be refreshed.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+
+/**
+ * Class Refresh_Policy
+ *
+ * Answers "should this run now?" from the stored credentials and the refresh history alone: no
+ * network, no writes, no locking. Every interval it works from is filterable, and every one of those
+ * filters is the reason a method here exists.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+final class Refresh_Policy {
+	/**
+	 * Merchant instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Merchant
+	 */
+	private Merchant $merchant;
+
+	/**
+	 * Refresh status instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Refresh_Status
+	 */
+	private Refresh_Status $status;
+
+	/**
+	 * Refresh_Policy constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Merchant       $merchant Merchant instance.
+	 * @param Refresh_Status $status   Refresh status instance.
+	 */
+	public function __construct( Merchant $merchant, Refresh_Status $status ) {
+		$this->merchant = $merchant;
+		$this->status   = $status;
+	}
+
+	/**
+	 * Whether a refresh is due.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the token is close to expiring, or a rejected connection is due a re-check.
+	 */
+	public function should_refresh(): bool {
+		if ( ! $this->merchant->get_access_token() || ! $this->merchant->get_refresh_token() ) {
+			return false;
+		}
+
+		if ( $this->is_backing_off() ) {
+			return false;
+		}
+
+		// A rejected connection is retried rarely rather than never, so a wrong verdict heals itself.
+		if ( $this->status->is_invalid() ) {
+			return true;
+		}
+
+		$expiration = $this->merchant->get_token_expiration();
+
+		if ( null === $expiration ) {
+			// Connected before the expiration was tracked: try occasionally until we learn a real one.
+			$last_attempt = $this->status->get_last_attempt_timestamp();
+
+			return null === $last_attempt || $last_attempt < time() - $this->get_unknown_expiration_interval();
+		}
+
+		return $expiration->getTimestamp() - $this->get_refresh_window() <= time();
+	}
+
+	/**
+	 * Whether repeated transient failures are currently holding refreshes off.
+	 *
+	 * Keeps a WhoDat outage from turning into an outbound request on every page load.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True while the back-off window opened by the last failure is still running.
+	 */
+	public function is_backing_off(): bool {
+		$failures = $this->status->get_failure_count();
+		$invalid  = $this->status->is_invalid();
+
+		if ( $failures < 1 && ! $invalid ) {
+			return false;
+		}
+
+		$last_attempt = $this->status->get_last_attempt_timestamp();
+
+		if ( null === $last_attempt ) {
+			return false;
+		}
+
+		$backoff = $invalid
+			? $this->get_invalid_recheck_interval()
+			: min( 12 * HOUR_IN_SECONDS, HOUR_IN_SECONDS * ( 2 ** min( 4, $failures - 1 ) ) );
+
+		return $last_attempt + $backoff > time();
+	}
+
+	/**
+	 * How long before the expiration a refresh is attempted, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @return int The window, in seconds.
+	 */
+	private function get_refresh_window(): int {
+		/**
+		 * Filters how long before its expiration the Square access token is refreshed.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $window The window, in seconds.
+		 */
+		return absint( apply_filters( 'tec_tickets_commerce_square_token_refresh_window', DAY_IN_SECONDS ) );
+	}
+
+	/**
+	 * How often a connection with no recorded expiration retries, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @return int The interval, in seconds.
+	 */
+	private function get_unknown_expiration_interval(): int {
+		/**
+		 * Filters how often a Square connection with no recorded expiration attempts a refresh.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $interval The interval, in seconds.
+		 */
+		return absint( apply_filters( 'tec_tickets_commerce_square_token_refresh_unknown_expiration_interval', 12 * HOUR_IN_SECONDS ) );
+	}
+
+	/**
+	 * How long a rejected connection waits before it asks Square again.
+	 *
+	 * @since TBD
+	 *
+	 * @return int The interval, in seconds.
+	 */
+	private function get_invalid_recheck_interval(): int {
+		/**
+		 * Filters how often a rejected Square connection re-checks whether it can be renewed after all.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $interval The interval, in seconds.
+		 */
+		return absint( apply_filters( 'tec_tickets_commerce_square_token_invalid_recheck_interval', 12 * HOUR_IN_SECONDS ) );
+	}
+}

--- a/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Status.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token/Refresh_Status.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Stores the outcome of the Square access token refresh attempts.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+use TEC\Tickets\Commerce\Gateways\Square\Gateway;
+use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+use Tribe__Date_Utils as Dates;
+
+/**
+ * Class Refresh_Status
+ *
+ * The record of how the access token refresh has been going: when it last ran, how many attempts in a
+ * row have failed, and whether Square has refused to renew the credentials outright. Storage only -
+ * what to do about any of it belongs to Refresh_Policy, and announcing it to Token_Refresher.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square\Token
+ */
+final class Refresh_Status {
+	/**
+	 * Merchant instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Merchant
+	 */
+	private Merchant $merchant;
+
+	/**
+	 * Refresh_Status constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Merchant $merchant Merchant instance.
+	 */
+	public function __construct( Merchant $merchant ) {
+		$this->merchant = $merchant;
+	}
+
+	/**
+	 * Returns the outcome of the last access token refresh attempt.
+	 *
+	 * The timestamps are UTC, so that they compare correctly against strtotime(), which WordPress pins
+	 * to UTC whatever the site timezone is.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{invalid_at: string, error: int, failures: int, last_attempt_at: string, first_failure_at: string}
+	 */
+	public function get(): array {
+		$status = get_option( $this->get_option_key(), [] );
+
+		if ( ! is_array( $status ) ) {
+			$status = [];
+		}
+
+		return array_merge(
+			[
+				'invalid_at'       => '',
+				'error'            => 0,
+				'failures'         => 0,
+				'last_attempt_at'  => '',
+				'first_failure_at' => '',
+			],
+			$status
+		);
+	}
+
+	/**
+	 * Returns how many consecutive refresh attempts have failed.
+	 *
+	 * @since TBD
+	 *
+	 * @return int Zero when no failure has been recorded.
+	 */
+	public function get_failure_count(): int {
+		return absint( $this->get()['failures'] );
+	}
+
+	/**
+	 * Returns when the last refresh was attempted.
+	 *
+	 * @since TBD
+	 *
+	 * @return ?int A UTC timestamp, or null when no attempt has been recorded.
+	 */
+	public function get_last_attempt_timestamp(): ?int {
+		return $this->read_timestamp( 'last_attempt_at' );
+	}
+
+	/**
+	 * Returns when the current run of failures started.
+	 *
+	 * @since TBD
+	 *
+	 * @return ?int A UTC timestamp, or null when no failure has been recorded.
+	 */
+	public function get_first_failure_timestamp(): ?int {
+		return $this->read_timestamp( 'first_failure_at' );
+	}
+
+	/**
+	 * Whether Square has refused to renew the stored credentials.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True once a permanent failure has been recorded.
+	 */
+	public function is_invalid(): bool {
+		return ! empty( $this->get()['invalid_at'] );
+	}
+
+	/**
+	 * Records that a refresh was attempted, whatever came of it.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function record_attempt(): void {
+		$this->update( [ 'last_attempt_at' => $this->now() ] );
+	}
+
+	/**
+	 * Clears the failure bookkeeping after the credentials were renewed.
+	 *
+	 * The last attempt survives: it is the only throttle a connection with no known expiration has.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function record_success(): void {
+		$this->update(
+			[
+				'invalid_at'       => '',
+				'error'            => 0,
+				'failures'         => 0,
+				'first_failure_at' => '',
+			]
+		);
+	}
+
+	/**
+	 * Marks the connection as one Square will not renew.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $code The response code the refresh came back with.
+	 *
+	 * @return void
+	 */
+	public function record_permanent_failure( int $code ): void {
+		$this->update(
+			[
+				'invalid_at' => $this->now(),
+				'error'      => $code,
+			]
+		);
+	}
+
+	/**
+	 * Counts a failure that may well clear up on its own.
+	 *
+	 * @since TBD
+	 *
+	 * @return int The number of consecutive failures after this one.
+	 */
+	public function record_transient_failure(): int {
+		$status   = $this->get();
+		$failures = absint( $status['failures'] ) + 1;
+
+		$this->update(
+			[
+				'failures'         => $failures,
+				'first_failure_at' => $status['first_failure_at'] ?: $this->now(),
+			]
+		);
+
+		return $failures;
+	}
+
+	/**
+	 * Deletes the stored status.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the option was deleted.
+	 */
+	public function delete(): bool {
+		return delete_option( $this->get_option_key() );
+	}
+
+	/**
+	 * Drops the object cache entry backing the status.
+	 *
+	 * Used to re-read the status from the database after another process may have written it.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush_cache(): void {
+		wp_cache_delete( $this->get_option_key(), 'options' );
+	}
+
+	/**
+	 * Merges data into the stored status.
+	 *
+	 * The single write path: the record_* methods above are the transitions this class knows how to
+	 * name, and this is the general form they specialize, matching Merchant::update() next door.
+	 *
+	 * @since TBD
+	 *
+	 * @param array{invalid_at?: string, error?: int, failures?: int, last_attempt_at?: string, first_failure_at?: string} $data The status data to merge in.
+	 *
+	 * @return bool Whether the option was written.
+	 */
+	public function update( array $data ): bool {
+		return update_option( $this->get_option_key(), array_merge( $this->get(), $data ), false );
+	}
+
+	/**
+	 * The option key holding the status.
+	 *
+	 * Scoped to the gateway mode so the sandbox and live connections never share state.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The option key, scoped to the gateway mode.
+	 */
+	private function get_option_key(): string {
+		$gateway_key = Gateway::get_key();
+		$mode        = $this->merchant->get_mode();
+
+		return "tec_tickets_commerce_{$gateway_key}_token_status_{$mode}";
+	}
+
+	/**
+	 * Reads one of the stored dates as a timestamp.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The status key to read.
+	 *
+	 * @return ?int A UTC timestamp, or null when nothing usable is stored under that key.
+	 */
+	private function read_timestamp( string $key ): ?int {
+		$stored = $this->get()[ $key ];
+
+		if ( ! is_string( $stored ) || '' === $stored ) {
+			return null;
+		}
+
+		$timestamp = strtotime( $stored );
+
+		return false === $timestamp ? null : $timestamp;
+	}
+
+	/**
+	 * The current moment, in the format the stored timestamps use.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	private function now(): string {
+		return Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT );
+	}
+}

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * Keeps the Square OAuth access token alive.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Square;
+
+use TEC\Common\StellarWP\DB\DB;
+use Tribe__Date_Utils as Dates;
+use Throwable;
+
+/**
+ * Class Token_Refresher
+ *
+ * Square access tokens expire roughly 30 days after they are minted. The refresh runs from the request
+ * path rather than from a scheduled action so that a site with a stalled cron queue still recovers.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Square
+ */
+class Token_Refresher {
+	/**
+	 * The refresh response carried a new access token.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const RESULT_SUCCESS = 'success';
+
+	/**
+	 * Square refused the refresh token; only a new OAuth handshake can recover.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const RESULT_PERMANENT = 'permanent';
+
+	/**
+	 * The refresh did not go through, but the credentials may still be good.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const RESULT_TRANSIENT = 'transient';
+
+	/**
+	 * Seconds after which a held refresh lock is considered abandoned.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected const LOCK_TIMEOUT = 60;
+
+	/**
+	 * Merchant instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Merchant
+	 */
+	private Merchant $merchant;
+
+	/**
+	 * WhoDat instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var WhoDat
+	 */
+	private WhoDat $who_dat;
+
+	/**
+	 * Guards against a refresh re-entering itself within the same process.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	private bool $refreshing = false;
+
+	/**
+	 * Token_Refresher constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Merchant $merchant Merchant instance.
+	 * @param WhoDat   $who_dat  WhoDat instance.
+	 */
+	public function __construct( Merchant $merchant, WhoDat $who_dat ) {
+		$this->merchant = $merchant;
+		$this->who_dat  = $who_dat;
+	}
+
+	/**
+	 * Refreshes the access token when it is close enough to expiring.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the stored credentials are known to be current.
+	 */
+	public function refresh_if_needed(): bool {
+		if ( ! $this->should_refresh() ) {
+			return false;
+		}
+
+		return $this->do_refresh( 'expiring' );
+	}
+
+	/**
+	 * Refreshes the access token regardless of its recorded expiration.
+	 *
+	 * Used when Square itself rejects the token, which can happen before the recorded expiration.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $reason Why the refresh was forced, for logging.
+	 *
+	 * @return bool Whether the stored access token is now different from the rejected one.
+	 */
+	public function refresh_now( string $reason = 'forced' ): bool {
+		if ( ! $this->merchant->get_refresh_token() || $this->merchant->is_token_invalid() ) {
+			return false;
+		}
+
+		return $this->do_refresh( $reason, true );
+	}
+
+	/**
+	 * Whether a refresh is due.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_refresh(): bool {
+		if ( ! $this->merchant->get_access_token() || ! $this->merchant->get_refresh_token() ) {
+			return false;
+		}
+
+		if ( $this->merchant->is_token_invalid() ) {
+			return false;
+		}
+
+		if ( $this->is_backing_off() ) {
+			return false;
+		}
+
+		$expiration = $this->merchant->get_token_expiration();
+
+		if ( null === $expiration ) {
+			// Connected before the expiration was tracked: try occasionally until we learn a real one.
+			$last_attempt = strtotime( (string) $this->merchant->get_token_status()['last_attempt_at'] );
+
+			return false === $last_attempt || $last_attempt < time() - $this->get_unknown_expiration_interval();
+		}
+
+		return $expiration->getTimestamp() - $this->get_refresh_window() <= time();
+	}
+
+	/**
+	 * How long before the expiration a refresh is attempted, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @return int
+	 */
+	public function get_refresh_window(): int {
+		/**
+		 * Filters how long before its expiration the Square access token is refreshed.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $window The window, in seconds.
+		 */
+		return (int) apply_filters( 'tec_tickets_commerce_square_token_refresh_window', DAY_IN_SECONDS );
+	}
+
+	/**
+	 * How often a connection with no recorded expiration retries, in seconds.
+	 *
+	 * @since TBD
+	 *
+	 * @return int
+	 */
+	protected function get_unknown_expiration_interval(): int {
+		/**
+		 * Filters how often a Square connection with no recorded expiration attempts a refresh.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $interval The interval, in seconds.
+		 */
+		return (int) apply_filters( 'tec_tickets_commerce_square_token_refresh_unknown_expiration_interval', 12 * HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Whether repeated transient failures are currently holding refreshes off.
+	 *
+	 * Keeps a WhoDat outage from turning into an outbound request on every page load.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	protected function is_backing_off(): bool {
+		$status   = $this->merchant->get_token_status();
+		$failures = (int) $status['failures'];
+
+		if ( $failures < 1 ) {
+			return false;
+		}
+
+		$last_attempt = strtotime( (string) $status['last_attempt_at'] );
+
+		if ( false === $last_attempt ) {
+			return false;
+		}
+
+		$backoff = min( 12 * HOUR_IN_SECONDS, HOUR_IN_SECONDS * ( 2 ** min( 4, $failures - 1 ) ) );
+
+		return $last_attempt + $backoff > time();
+	}
+
+	/**
+	 * Performs the refresh under a cross-process lock.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $reason Why the refresh was attempted, for logging.
+	 * @param bool   $forced Whether the recorded expiration was ignored.
+	 *
+	 * @return bool
+	 */
+	protected function do_refresh( string $reason, bool $forced = false ): bool {
+		if ( $this->refreshing ) {
+			return false;
+		}
+
+		$previous_token = $this->merchant->get_access_token();
+
+		if ( ! $this->create_lock() ) {
+			return false;
+		}
+
+		$this->refreshing = true;
+
+		try {
+			// Whoever held the lock may have already done the work.
+			$this->merchant->flush_option_cache();
+
+			if ( $forced ) {
+				if ( $this->merchant->get_access_token() !== $previous_token ) {
+					return true;
+				}
+			} elseif ( ! $this->should_refresh() ) {
+				return true;
+			}
+
+			$response = $this->who_dat->refresh_token();
+			$result   = $this->classify_response( $response );
+
+			$this->merchant->update_token_status(
+				[ 'last_attempt_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ) ]
+			);
+
+			if ( self::RESULT_SUCCESS === $result ) {
+				return $this->record_success( $response, $reason );
+			}
+
+			if ( self::RESULT_PERMANENT === $result ) {
+				$this->record_permanent_failure( $this->get_error_code( $response ), $reason );
+
+				return false;
+			}
+
+			$this->record_transient_failure( $reason );
+
+			return false;
+		} finally {
+			$this->refreshing = false;
+			$this->release_lock();
+		}
+	}
+
+	/**
+	 * Stores the refreshed credentials and clears the failure bookkeeping.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $response The refresh response.
+	 * @param string $reason   Why the refresh was attempted.
+	 *
+	 * @return bool
+	 */
+	protected function record_success( array $response, string $reason ): bool {
+		if ( ! $this->merchant->save_refreshed_tokens( $response ) ) {
+			$this->record_transient_failure( $reason );
+
+			return false;
+		}
+
+		$this->merchant->delete_token_status();
+
+		/**
+		 * Fires after the Square access token has been refreshed.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $reason Why the refresh was attempted.
+		 */
+		do_action( 'tec_tickets_commerce_square_access_token_refreshed', $reason );
+
+		return true;
+	}
+
+	/**
+	 * Marks the connection as unrecoverable.
+	 *
+	 * The credentials are deliberately kept so support can still see what is stored.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $error  The error code Square returned.
+	 * @param string $reason Why the refresh was attempted.
+	 *
+	 * @return void
+	 */
+	protected function record_permanent_failure( string $error, string $reason ): void {
+		$this->merchant->update_token_status(
+			[
+				'invalid_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ),
+				'error'      => $error,
+			]
+		);
+
+		do_action(
+			'tribe_log',
+			'error',
+			'Square rejected the access token refresh',
+			[
+				'source' => 'tickets-commerce-square',
+				'error'  => $error,
+				'reason' => $reason,
+			]
+		);
+
+		/**
+		 * Fires when Square refuses to renew the stored credentials.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $error  The error code Square returned.
+		 * @param string $reason Why the refresh was attempted.
+		 */
+		do_action( 'tec_tickets_commerce_square_access_token_refresh_failed', $error, $reason );
+	}
+
+	/**
+	 * Counts a failure that may well clear up on its own.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $reason Why the refresh was attempted.
+	 *
+	 * @return void
+	 */
+	protected function record_transient_failure( string $reason ): void {
+		$failures = (int) $this->merchant->get_token_status()['failures'];
+
+		$this->merchant->update_token_status( [ 'failures' => $failures + 1 ] );
+
+		do_action(
+			'tribe_log',
+			'warning',
+			'Square access token refresh did not go through',
+			[
+				'source'   => 'tickets-commerce-square',
+				'reason'   => $reason,
+				'failures' => $failures + 1,
+			]
+		);
+	}
+
+	/**
+	 * Decides whether a refresh response is a success, an unrecoverable rejection, or a blip.
+	 *
+	 * Abstract_WhoDat::get() returns null both for transport errors and for bodies it cannot decode, and
+	 * returns the decoded body whatever the status code, so the body is all there is to go on.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $response The refresh response.
+	 *
+	 * @return string One of the RESULT_* constants.
+	 */
+	protected function classify_response( $response ): string {
+		if ( ! is_array( $response ) ) {
+			return self::RESULT_TRANSIENT;
+		}
+
+		if ( ! empty( $response['access_token'] ) && is_string( $response['access_token'] ) ) {
+			return self::RESULT_SUCCESS;
+		}
+
+		$error = $this->get_error_code( $response );
+
+		if ( '' === $error ) {
+			return self::RESULT_TRANSIENT;
+		}
+
+		return in_array( $error, $this->get_permanent_error_codes(), true ) ? self::RESULT_PERMANENT : self::RESULT_TRANSIENT;
+	}
+
+	/**
+	 * Pulls an error code out of either the OAuth or the Square error shape.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $response The refresh response.
+	 *
+	 * @return string Lowercased error code, empty when there is none.
+	 */
+	protected function get_error_code( $response ): string {
+		if ( ! is_array( $response ) ) {
+			return '';
+		}
+
+		if ( ! empty( $response['error'] ) && is_string( $response['error'] ) ) {
+			return strtolower( $response['error'] );
+		}
+
+		$error = $response['errors'][0] ?? null;
+
+		if ( ! is_array( $error ) ) {
+			return '';
+		}
+
+		foreach ( [ 'code', 'category' ] as $key ) {
+			if ( ! empty( $error[ $key ] ) && is_string( $error[ $key ] ) ) {
+				return strtolower( $error[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * The error codes that mean the refresh token will never work again.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	protected function get_permanent_error_codes(): array {
+		$codes = [
+			'access_denied',
+			'authentication_error',
+			'forbidden',
+			'invalid_client',
+			'invalid_grant',
+			'refresh_token_expired',
+			'refresh_token_revoked',
+			'unauthorized',
+			'unauthorized_client',
+			'unsupported_grant_type',
+		];
+
+		/**
+		 * Filters the Square token refresh errors treated as unrecoverable.
+		 *
+		 * Anything not listed here is treated as transient and leaves the connection alone.
+		 *
+		 * @since TBD
+		 *
+		 * @param string[] $codes Lowercased error codes.
+		 */
+		return (array) apply_filters( 'tec_tickets_commerce_square_permanent_token_errors', $codes );
+	}
+
+	/**
+	 * The option name backing the refresh lock.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	protected function get_lock_option_key(): string {
+		$gateway_key = Gateway::get_key();
+		$mode        = $this->merchant->get_mode();
+
+		return "tec_tickets_commerce_{$gateway_key}_token_refresh_lock_{$mode}";
+	}
+
+	/**
+	 * Takes the refresh lock.
+	 *
+	 * Two concurrent refreshes would each spend the refresh token, so only one may run. INSERT IGNORE is
+	 * atomic on the unique option_name index; add_option() reads before it writes and can be raced.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the lock is now held by this process.
+	 */
+	protected function create_lock(): bool {
+		$key   = $this->get_lock_option_key();
+		$now   = time();
+		$table = DB::prefix( 'options' );
+
+		try {
+			$acquired = (bool) DB::query(
+				DB::prepare(
+					'INSERT IGNORE INTO %i ( option_name, option_value, autoload ) VALUES ( %s, %s, %s )',
+					$table,
+					$key,
+					(string) $now,
+					'no'
+				)
+			);
+
+			if ( ! $acquired ) {
+				// A crash must not hold refreshes off forever.
+				$acquired = (bool) DB::query(
+					DB::prepare(
+						'UPDATE %i SET option_value = %s WHERE option_name = %s AND CAST( option_value AS UNSIGNED ) < %d',
+						$table,
+						(string) $now,
+						$key,
+						$now - self::LOCK_TIMEOUT
+					)
+				);
+			}
+		} catch ( Throwable $e ) {
+			return false;
+		}
+
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( $key, 'options' );
+
+		return $acquired;
+	}
+
+	/**
+	 * Releases the refresh lock.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function release_lock(): void {
+		delete_option( $this->get_lock_option_key() );
+	}
+}

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -538,7 +538,7 @@ class Token_Refresher {
 				'source'        => 'tickets-commerce-square',
 				'response_code' => $code,
 				'reason'        => $reason,
-				'failures'      => $failures + 1,
+				'failures'      => $failures,
 			]
 		);
 	}

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -12,6 +12,7 @@ namespace TEC\Tickets\Commerce\Gateways\Square;
 use TEC\Common\StellarWP\DB\DB;
 use Tribe__Date_Utils as Dates;
 use Throwable;
+use WP_Error;
 
 /**
  * Class Token_Refresher
@@ -265,30 +266,65 @@ class Token_Refresher {
 				return true;
 			}
 
-			$response = $this->who_dat->refresh_token();
-			$result   = $this->classify_response( $response );
+			$result = $this->who_dat->request_token_refresh();
+			$status = $this->classify_result( $result );
 
 			$this->merchant->update_token_status(
 				[ 'last_attempt_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ) ]
 			);
 
-			if ( self::RESULT_SUCCESS === $result ) {
-				return $this->record_success( $response, $reason );
+			if ( self::RESULT_SUCCESS === $status ) {
+				return $this->record_success( (array) $result['body'], $reason );
 			}
 
-			if ( self::RESULT_PERMANENT === $result ) {
-				$this->record_permanent_failure( $this->get_error_code( $response ), $reason );
+			if ( self::RESULT_PERMANENT === $status ) {
+				$this->record_permanent_failure( (int) $result['code'], $reason );
 
 				return false;
 			}
 
-			$this->record_transient_failure( $reason );
+			$this->record_transient_failure( (int) $result['code'], $reason );
 
 			return false;
 		} finally {
 			$this->refreshing = false;
 			$this->release_lock();
 		}
+	}
+
+	/**
+	 * Decides whether a refresh attempt failed for good or is worth trying again.
+	 *
+	 * The endpoint answers a rejected refresh token with an HTML 500 rather than a machine readable
+	 * error, so a 500 on its own says nothing. Square's own view of the stored access token settles it:
+	 * if Square no longer accepts the token and it cannot be renewed, the connection really is finished.
+	 * Anything less certain counts as transient, so that an outage never disconnects a working site.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $result The outcome of the refresh request.
+	 *
+	 * @return string One of the RESULT_* constants.
+	 */
+	protected function classify_result( array $result ): string {
+		$code = (int) $result['code'];
+		$body = $result['body'];
+
+		if ( 200 === $code && ! empty( $body['access_token'] ) && is_string( $body['access_token'] ) ) {
+			return self::RESULT_SUCCESS;
+		}
+
+		// The request never completed, so nothing has been established about the credentials.
+		if ( $result['error'] instanceof WP_Error || 0 === $code ) {
+			return self::RESULT_TRANSIENT;
+		}
+
+		// The request was understood and turned down.
+		if ( $code >= 400 && $code < 500 ) {
+			return self::RESULT_PERMANENT;
+		}
+
+		return false === $this->who_dat->is_token_accepted( true ) ? self::RESULT_PERMANENT : self::RESULT_TRANSIENT;
 	}
 
 	/**
@@ -303,7 +339,7 @@ class Token_Refresher {
 	 */
 	protected function record_success( array $response, string $reason ): bool {
 		if ( ! $this->merchant->save_refreshed_tokens( $response ) ) {
-			$this->record_transient_failure( $reason );
+			$this->record_transient_failure( 200, $reason );
 
 			return false;
 		}
@@ -329,16 +365,16 @@ class Token_Refresher {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $error  The error code Square returned.
+	 * @param int    $code   The response code the refresh came back with.
 	 * @param string $reason Why the refresh was attempted.
 	 *
 	 * @return void
 	 */
-	protected function record_permanent_failure( string $error, string $reason ): void {
+	protected function record_permanent_failure( int $code, string $reason ): void {
 		$this->merchant->update_token_status(
 			[
 				'invalid_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ),
-				'error'      => $error,
+				'error'      => (string) $code,
 			]
 		);
 
@@ -347,9 +383,9 @@ class Token_Refresher {
 			'error',
 			'Square rejected the access token refresh',
 			[
-				'source' => 'tickets-commerce-square',
-				'error'  => $error,
-				'reason' => $reason,
+				'source'        => 'tickets-commerce-square',
+				'response_code' => $code,
+				'reason'        => $reason,
 			]
 		);
 
@@ -358,10 +394,10 @@ class Token_Refresher {
 		 *
 		 * @since TBD
 		 *
-		 * @param string $error  The error code Square returned.
+		 * @param int    $code   The response code the refresh came back with.
 		 * @param string $reason Why the refresh was attempted.
 		 */
-		do_action( 'tec_tickets_commerce_square_access_token_refresh_failed', $error, $reason );
+		do_action( 'tec_tickets_commerce_square_access_token_refresh_failed', $code, $reason );
 	}
 
 	/**
@@ -369,11 +405,12 @@ class Token_Refresher {
 	 *
 	 * @since TBD
 	 *
+	 * @param int    $code   The response code the refresh came back with, 0 when it never completed.
 	 * @param string $reason Why the refresh was attempted.
 	 *
 	 * @return void
 	 */
-	protected function record_transient_failure( string $reason ): void {
+	protected function record_transient_failure( int $code, string $reason ): void {
 		$failures = (int) $this->merchant->get_token_status()['failures'];
 
 		$this->merchant->update_token_status( [ 'failures' => $failures + 1 ] );
@@ -383,107 +420,12 @@ class Token_Refresher {
 			'warning',
 			'Square access token refresh did not go through',
 			[
-				'source'   => 'tickets-commerce-square',
-				'reason'   => $reason,
-				'failures' => $failures + 1,
+				'source'        => 'tickets-commerce-square',
+				'response_code' => $code,
+				'reason'        => $reason,
+				'failures'      => $failures + 1,
 			]
 		);
-	}
-
-	/**
-	 * Decides whether a refresh response is a success, an unrecoverable rejection, or a blip.
-	 *
-	 * Abstract_WhoDat::get() returns null both for transport errors and for bodies it cannot decode, and
-	 * returns the decoded body whatever the status code, so the body is all there is to go on.
-	 *
-	 * @since TBD
-	 *
-	 * @param mixed $response The refresh response.
-	 *
-	 * @return string One of the RESULT_* constants.
-	 */
-	protected function classify_response( $response ): string {
-		if ( ! is_array( $response ) ) {
-			return self::RESULT_TRANSIENT;
-		}
-
-		if ( ! empty( $response['access_token'] ) && is_string( $response['access_token'] ) ) {
-			return self::RESULT_SUCCESS;
-		}
-
-		$error = $this->get_error_code( $response );
-
-		if ( '' === $error ) {
-			return self::RESULT_TRANSIENT;
-		}
-
-		return in_array( $error, $this->get_permanent_error_codes(), true ) ? self::RESULT_PERMANENT : self::RESULT_TRANSIENT;
-	}
-
-	/**
-	 * Pulls an error code out of either the OAuth or the Square error shape.
-	 *
-	 * @since TBD
-	 *
-	 * @param mixed $response The refresh response.
-	 *
-	 * @return string Lowercased error code, empty when there is none.
-	 */
-	protected function get_error_code( $response ): string {
-		if ( ! is_array( $response ) ) {
-			return '';
-		}
-
-		if ( ! empty( $response['error'] ) && is_string( $response['error'] ) ) {
-			return strtolower( $response['error'] );
-		}
-
-		$error = $response['errors'][0] ?? null;
-
-		if ( ! is_array( $error ) ) {
-			return '';
-		}
-
-		foreach ( [ 'code', 'category' ] as $key ) {
-			if ( ! empty( $error[ $key ] ) && is_string( $error[ $key ] ) ) {
-				return strtolower( $error[ $key ] );
-			}
-		}
-
-		return '';
-	}
-
-	/**
-	 * The error codes that mean the refresh token will never work again.
-	 *
-	 * @since TBD
-	 *
-	 * @return string[]
-	 */
-	protected function get_permanent_error_codes(): array {
-		$codes = [
-			'access_denied',
-			'authentication_error',
-			'forbidden',
-			'invalid_client',
-			'invalid_grant',
-			'refresh_token_expired',
-			'refresh_token_revoked',
-			'unauthorized',
-			'unauthorized_client',
-			'unsupported_grant_type',
-		];
-
-		/**
-		 * Filters the Square token refresh errors treated as unrecoverable.
-		 *
-		 * Anything not listed here is treated as transient and leaves the connection alone.
-		 *
-		 * @since TBD
-		 *
-		 * @param string[] $codes Lowercased error codes.
-		 */
-		return (array) apply_filters( 'tec_tickets_commerce_square_permanent_token_errors', $codes );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -64,20 +64,25 @@ class Token_Refresher {
 	/**
 	 * How long to keep polling for the winner's result when the lock is contended, in microseconds.
 	 *
+	 * Has to outlast the holder's refresh call, or every waiter walks away before the new token lands
+	 * and takes the rejection it was waiting to avoid. A second of headroom covers the writes around it.
+	 *
 	 * @since TBD
 	 *
 	 * @var int
 	 */
-	protected const LOCK_WAIT = 1000000;
+	protected const LOCK_WAIT = ( WhoDat::TOKEN_REQUEST_TIMEOUT + 1 ) * 1000000;
 
 	/**
 	 * How often to re-read the credentials while waiting on a contended lock, in microseconds.
 	 *
+	 * Each poll drops the options cache, so this is coarse enough to keep the count down over the wait.
+	 *
 	 * @since TBD
 	 *
 	 * @var int
 	 */
-	protected const LOCK_POLL = 100000;
+	protected const LOCK_POLL = 250000;
 
 	/**
 	 * How many failures must pile up before an uncorroborated rejection counts as final.
@@ -312,8 +317,10 @@ class Token_Refresher {
 		$previous_token = $this->merchant->get_access_token();
 
 		if ( ! $this->create_lock() ) {
-			// Only a caller whose request already failed waits; a proactive refresh has nothing to gain
-			// from holding a page load open while somebody else does the work.
+			/**
+			 * Only a caller whose request already failed waits; a proactive refresh has nothing to gain
+			 * from holding a page load open while somebody else does the work.
+			 */
 			return $forced && $this->wait_for_lock_holder( $previous_token );
 		}
 
@@ -407,14 +414,19 @@ class Token_Refresher {
 	 * @return bool
 	 */
 	protected function is_rejection_final(): bool {
-		if ( false !== $this->who_dat->is_token_accepted( true ) ) {
+		// Capped like the refresh itself: this runs on the same checkout request the refresh came from.
+		$status = $this->who_dat->get_token_status( true, [ 'timeout' => WhoDat::TOKEN_REQUEST_TIMEOUT ] );
+
+		if ( false !== $this->who_dat->interpret_token_status( $status ) ) {
 			return false;
 		}
 
 		$expiration = $this->merchant->get_token_expiration();
 
-		// Square refusing a token that is still inside its own lifetime means the grant itself is gone.
-		// An expiration we never recorded proves nothing either way, so it does not count here.
+		/**
+		 * Square refusing a token that is still inside its own lifetime means the grant itself is gone.
+		 * An expiration we never recorded proves nothing either way, so it does not count here.
+		 */
 		if ( null !== $expiration && $expiration->getTimestamp() > time() ) {
 			return true;
 		}

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -62,6 +62,33 @@ class Token_Refresher {
 	protected const LOCK_TIMEOUT = 60;
 
 	/**
+	 * How long to keep polling for the winner's result when the lock is contended, in microseconds.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected const LOCK_WAIT = 1000000;
+
+	/**
+	 * How often to re-read the credentials while waiting on a contended lock, in microseconds.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected const LOCK_POLL = 100000;
+
+	/**
+	 * How many failures must pile up before an uncorroborated rejection counts as final.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected const PERSISTENT_FAILURES = 5;
+
+	/**
 	 * Merchant instance.
 	 *
 	 * @since TBD
@@ -87,6 +114,15 @@ class Token_Refresher {
 	 * @var bool
 	 */
 	private bool $refreshing = false;
+
+	/**
+	 * The value written into the lock row while this process holds it.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private string $lock_value = '';
 
 	/**
 	 * Token_Refresher constructor.
@@ -128,7 +164,12 @@ class Token_Refresher {
 	 * @return bool Whether the stored access token is now different from the rejected one.
 	 */
 	public function refresh_now( string $reason = 'forced' ): bool {
-		if ( ! $this->merchant->get_refresh_token() || $this->merchant->is_token_invalid() ) {
+		if ( ! $this->merchant->get_refresh_token() ) {
+			return false;
+		}
+
+		// Without this a connection Square keeps rejecting would refresh once per Square API call.
+		if ( $this->is_backing_off() ) {
 			return false;
 		}
 
@@ -147,19 +188,20 @@ class Token_Refresher {
 			return false;
 		}
 
-		if ( $this->merchant->is_token_invalid() ) {
+		if ( $this->is_backing_off() ) {
 			return false;
 		}
 
-		if ( $this->is_backing_off() ) {
-			return false;
+		// A rejected connection is retried rarely rather than never, so a wrong verdict heals itself.
+		if ( $this->merchant->is_token_invalid() ) {
+			return true;
 		}
 
 		$expiration = $this->merchant->get_token_expiration();
 
 		if ( null === $expiration ) {
 			// Connected before the expiration was tracked: try occasionally until we learn a real one.
-			$last_attempt = strtotime( (string) $this->merchant->get_token_status()['last_attempt_at'] );
+			$last_attempt = strtotime( (string) $this->merchant->get_refresh_status()['last_attempt_at'] );
 
 			return false === $last_attempt || $last_attempt < time() - $this->get_unknown_expiration_interval();
 		}
@@ -213,10 +255,11 @@ class Token_Refresher {
 	 * @return bool
 	 */
 	protected function is_backing_off(): bool {
-		$status   = $this->merchant->get_token_status();
+		$status   = $this->merchant->get_refresh_status();
 		$failures = (int) $status['failures'];
+		$invalid  = ! empty( $status['invalid_at'] );
 
-		if ( $failures < 1 ) {
+		if ( $failures < 1 && ! $invalid ) {
 			return false;
 		}
 
@@ -226,9 +269,29 @@ class Token_Refresher {
 			return false;
 		}
 
-		$backoff = min( 12 * HOUR_IN_SECONDS, HOUR_IN_SECONDS * ( 2 ** min( 4, $failures - 1 ) ) );
+		$backoff = $invalid
+			? $this->get_invalid_recheck_interval()
+			: min( 12 * HOUR_IN_SECONDS, HOUR_IN_SECONDS * ( 2 ** min( 4, $failures - 1 ) ) );
 
 		return $last_attempt + $backoff > time();
+	}
+
+	/**
+	 * How long a rejected connection waits before it asks Square again.
+	 *
+	 * @since TBD
+	 *
+	 * @return int
+	 */
+	protected function get_invalid_recheck_interval(): int {
+		/**
+		 * Filters how often a rejected Square connection re-checks whether it can be renewed after all.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $interval The interval, in seconds.
+		 */
+		return (int) apply_filters( 'tec_tickets_commerce_square_token_invalid_recheck_interval', 12 * HOUR_IN_SECONDS );
 	}
 
 	/**
@@ -249,7 +312,9 @@ class Token_Refresher {
 		$previous_token = $this->merchant->get_access_token();
 
 		if ( ! $this->create_lock() ) {
-			return false;
+			// Only a caller whose request already failed waits; a proactive refresh has nothing to gain
+			// from holding a page load open while somebody else does the work.
+			return $forced && $this->wait_for_lock_holder( $previous_token );
 		}
 
 		$this->refreshing = true;
@@ -269,8 +334,8 @@ class Token_Refresher {
 			$result = $this->who_dat->request_token_refresh();
 			$status = $this->classify_result( $result );
 
-			$this->merchant->update_token_status(
-				[ 'last_attempt_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ) ]
+			$this->merchant->update_refresh_status(
+				[ 'last_attempt_at' => Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ) ]
 			);
 
 			if ( self::RESULT_SUCCESS === $status ) {
@@ -319,12 +384,47 @@ class Token_Refresher {
 			return self::RESULT_TRANSIENT;
 		}
 
-		// The request was understood and turned down.
-		if ( $code >= 400 && $code < 500 ) {
+		// An outright authorization refusal needs no corroboration.
+		if ( 401 === $code || 403 === $code ) {
 			return self::RESULT_PERMANENT;
 		}
 
-		return false === $this->who_dat->is_token_accepted( true ) ? self::RESULT_PERMANENT : self::RESULT_TRANSIENT;
+		// Everything else, a rate limit or a gateway error included, has to be corroborated.
+		return $this->is_rejection_final() ? self::RESULT_PERMANENT : self::RESULT_TRANSIENT;
+	}
+
+	/**
+	 * Whether a refusal the response could not explain is worth acting on.
+	 *
+	 * Square's status endpoint reports on the *access* token, which has usually expired by the time a
+	 * refresh runs, so on its own it cannot tell a revoked grant from an outage: it says UNAUTHORIZED
+	 * either way. It only carries independent information while the access token is still inside its
+	 * own lifetime. When it does not, the connection is written off only after failures that keep
+	 * repeating over more than a day, which an outage does not do.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	protected function is_rejection_final(): bool {
+		if ( false !== $this->who_dat->is_token_accepted( true ) ) {
+			return false;
+		}
+
+		$expiration = $this->merchant->get_token_expiration();
+
+		// Square refusing a token that is still inside its own lifetime means the grant itself is gone.
+		// An expiration we never recorded proves nothing either way, so it does not count here.
+		if ( null !== $expiration && $expiration->getTimestamp() > time() ) {
+			return true;
+		}
+
+		$status        = $this->merchant->get_refresh_status();
+		$first_failure = strtotime( (string) $status['first_failure_at'] );
+
+		return (int) $status['failures'] >= self::PERSISTENT_FAILURES
+			&& false !== $first_failure
+			&& $first_failure <= time() - DAY_IN_SECONDS;
 	}
 
 	/**
@@ -344,7 +444,15 @@ class Token_Refresher {
 			return false;
 		}
 
-		$this->merchant->delete_token_status();
+		// last_attempt_at survives: it is the only throttle a connection with no known expiration has.
+		$this->merchant->update_refresh_status(
+			[
+				'invalid_at'       => '',
+				'error'            => '',
+				'failures'         => 0,
+				'first_failure_at' => '',
+			]
+		);
 
 		/**
 		 * Fires after the Square access token has been refreshed.
@@ -359,9 +467,10 @@ class Token_Refresher {
 	}
 
 	/**
-	 * Marks the connection as unrecoverable.
+	 * Marks the connection as unavailable.
 	 *
-	 * The credentials are deliberately kept so support can still see what is stored.
+	 * The credentials are deliberately kept, both so support can still see what is stored and so the
+	 * occasional re-check can lift the flag if Square starts renewing them again.
 	 *
 	 * @since TBD
 	 *
@@ -371,9 +480,9 @@ class Token_Refresher {
 	 * @return void
 	 */
 	protected function record_permanent_failure( int $code, string $reason ): void {
-		$this->merchant->update_token_status(
+		$this->merchant->update_refresh_status(
 			[
-				'invalid_at' => Dates::build_date_object()->format( Dates::DBDATETIMEFORMAT ),
+				'invalid_at' => Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ),
 				'error'      => (string) $code,
 			]
 		);
@@ -411,9 +520,15 @@ class Token_Refresher {
 	 * @return void
 	 */
 	protected function record_transient_failure( int $code, string $reason ): void {
-		$failures = (int) $this->merchant->get_token_status()['failures'];
+		$status   = $this->merchant->get_refresh_status();
+		$failures = (int) $status['failures'] + 1;
 
-		$this->merchant->update_token_status( [ 'failures' => $failures + 1 ] );
+		$this->merchant->update_refresh_status(
+			[
+				'failures'         => $failures,
+				'first_failure_at' => $status['first_failure_at'] ?: Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ),
+			]
+		);
 
 		do_action(
 			'tribe_log',
@@ -456,6 +571,7 @@ class Token_Refresher {
 		$key   = $this->get_lock_option_key();
 		$now   = time();
 		$table = DB::prefix( 'options' );
+		$value = $now . ':' . wp_generate_password( 12, false );
 
 		try {
 			$acquired = (bool) DB::query(
@@ -463,7 +579,7 @@ class Token_Refresher {
 					'INSERT IGNORE INTO %i ( option_name, option_value, autoload ) VALUES ( %s, %s, %s )',
 					$table,
 					$key,
-					(string) $now,
+					$value,
 					'no'
 				)
 			);
@@ -472,32 +588,102 @@ class Token_Refresher {
 				// A crash must not hold refreshes off forever.
 				$acquired = (bool) DB::query(
 					DB::prepare(
-						'UPDATE %i SET option_value = %s WHERE option_name = %s AND CAST( option_value AS UNSIGNED ) < %d',
+						'UPDATE %i SET option_value = %s WHERE option_name = %s AND CAST( SUBSTRING_INDEX( option_value, %s, 1 ) AS UNSIGNED ) < %d',
 						$table,
-						(string) $now,
+						$value,
 						$key,
+						':',
 						$now - self::LOCK_TIMEOUT
 					)
 				);
 			}
 		} catch ( Throwable $e ) {
+			// Left unlogged the refresh would simply stop happening, which is the failure being fixed.
+			do_action(
+				'tribe_log',
+				'error',
+				'Square access token refresh could not take its lock',
+				[
+					'source' => 'tickets-commerce-square',
+					'error'  => $e->getMessage(),
+				]
+			);
+
 			return false;
 		}
+
+		if ( ! $acquired ) {
+			return false;
+		}
+
+		$this->lock_value = $value;
 
 		wp_cache_delete( 'notoptions', 'options' );
 		wp_cache_delete( $key, 'options' );
 
-		return $acquired;
+		return true;
 	}
 
 	/**
-	 * Releases the refresh lock.
+	 * Releases the refresh lock, but only while this process still holds it.
+	 *
+	 * A process that stalled past the lock timeout has had its lock taken over, and must not delete the
+	 * row a second process is now working under.
 	 *
 	 * @since TBD
 	 *
 	 * @return void
 	 */
 	protected function release_lock(): void {
-		delete_option( $this->get_lock_option_key() );
+		if ( '' === $this->lock_value ) {
+			return;
+		}
+
+		try {
+			DB::query(
+				DB::prepare(
+					'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
+					DB::prefix( 'options' ),
+					$this->get_lock_option_key(),
+					$this->lock_value
+				)
+			);
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// The stale takeover will clear it.
+		}
+
+		$this->lock_value = '';
+
+		wp_cache_delete( $this->get_lock_option_key(), 'options' );
+	}
+
+	/**
+	 * Waits out a refresh another process is already running.
+	 *
+	 * Without this every concurrent request that finds an expired token fails its Square call while the
+	 * winner is still mid-refresh, which at checkout means a failed payment per shopper.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $previous_token The access token this process started with.
+	 *
+	 * @return bool Whether the credentials were renewed by whoever held the lock.
+	 */
+	protected function wait_for_lock_holder( string $previous_token ): bool {
+		$waited = 0;
+
+		while ( $waited < self::LOCK_WAIT ) {
+			usleep( self::LOCK_POLL );
+
+			$waited += self::LOCK_POLL;
+
+			$this->merchant->flush_option_cache();
+
+			if ( $this->merchant->get_access_token() !== $previous_token ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -131,17 +131,18 @@ final class Token_Refresher {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $reason Why the refresh was forced, for logging.
+	 * @param string $reason         Why the refresh was forced, for logging.
+	 * @param bool   $ignore_backoff Whether to attempt the refresh even inside the back-off window.
 	 *
 	 * @return bool Whether the stored access token is now different from the rejected one.
 	 */
-	public function refresh_now( string $reason = 'forced' ): bool {
+	public function refresh_now( string $reason = 'forced', bool $ignore_backoff = false ): bool {
 		if ( ! $this->merchant->get_refresh_token() ) {
 			return false;
 		}
 
 		// Without this a connection Square keeps rejecting would refresh once per Square API call.
-		if ( $this->policy->is_backing_off() ) {
+		if ( ! $ignore_backoff && $this->policy->is_backing_off() ) {
 			return false;
 		}
 
@@ -230,15 +231,6 @@ final class Token_Refresher {
 
 		$this->status->record_success();
 
-		/**
-		 * Fires after the Square access token has been refreshed.
-		 *
-		 * @since TBD
-		 *
-		 * @param string $reason Why the refresh was attempted.
-		 */
-		do_action( 'tec_tickets_commerce_square_access_token_refreshed', $reason );
-
 		return true;
 	}
 
@@ -268,16 +260,6 @@ final class Token_Refresher {
 				'reason'        => $reason,
 			]
 		);
-
-		/**
-		 * Fires when Square refuses to renew the stored credentials.
-		 *
-		 * @since TBD
-		 *
-		 * @param int    $code   The response code the refresh came back with.
-		 * @param string $reason Why the refresh was attempted.
-		 */
-		do_action( 'tec_tickets_commerce_square_access_token_refresh_failed', $code, $reason );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
+++ b/src/Tickets/Commerce/Gateways/Square/Token_Refresher.php
@@ -9,10 +9,11 @@
 
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
-use TEC\Common\StellarWP\DB\DB;
-use Tribe__Date_Utils as Dates;
-use Throwable;
-use WP_Error;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Client;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Lock;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Outcome;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Policy;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 
 /**
  * Class Token_Refresher
@@ -20,79 +21,15 @@ use WP_Error;
  * Square access tokens expire roughly 30 days after they are minted. The refresh runs from the request
  * path rather than from a scheduled action so that a site with a stalled cron queue still recovers.
  *
+ * This class orders the work and announces what came of it; when to run is Refresh_Policy's, running
+ * exactly once across processes is Refresh_Lock's, talking to Square is Refresh_Client's, and what is
+ * remembered afterwards is Refresh_Status's.
+ *
  * @since TBD
  *
  * @package TEC\Tickets\Commerce\Gateways\Square
  */
-class Token_Refresher {
-	/**
-	 * The refresh response carried a new access token.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	public const RESULT_SUCCESS = 'success';
-
-	/**
-	 * Square refused the refresh token; only a new OAuth handshake can recover.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	public const RESULT_PERMANENT = 'permanent';
-
-	/**
-	 * The refresh did not go through, but the credentials may still be good.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	public const RESULT_TRANSIENT = 'transient';
-
-	/**
-	 * Seconds after which a held refresh lock is considered abandoned.
-	 *
-	 * @since TBD
-	 *
-	 * @var int
-	 */
-	protected const LOCK_TIMEOUT = 60;
-
-	/**
-	 * How long to keep polling for the winner's result when the lock is contended, in microseconds.
-	 *
-	 * Has to outlast the holder's refresh call, or every waiter walks away before the new token lands
-	 * and takes the rejection it was waiting to avoid. A second of headroom covers the writes around it.
-	 *
-	 * @since TBD
-	 *
-	 * @var int
-	 */
-	protected const LOCK_WAIT = ( WhoDat::TOKEN_REQUEST_TIMEOUT + 1 ) * 1000000;
-
-	/**
-	 * How often to re-read the credentials while waiting on a contended lock, in microseconds.
-	 *
-	 * Each poll drops the options cache, so this is coarse enough to keep the count down over the wait.
-	 *
-	 * @since TBD
-	 *
-	 * @var int
-	 */
-	protected const LOCK_POLL = 250000;
-
-	/**
-	 * How many failures must pile up before an uncorroborated rejection counts as final.
-	 *
-	 * @since TBD
-	 *
-	 * @var int
-	 */
-	protected const PERSISTENT_FAILURES = 5;
-
+final class Token_Refresher {
 	/**
 	 * Merchant instance.
 	 *
@@ -103,13 +40,40 @@ class Token_Refresher {
 	private Merchant $merchant;
 
 	/**
-	 * WhoDat instance.
+	 * Refresh policy instance.
 	 *
 	 * @since TBD
 	 *
-	 * @var WhoDat
+	 * @var Refresh_Policy
 	 */
-	private WhoDat $who_dat;
+	private Refresh_Policy $policy;
+
+	/**
+	 * Refresh lock instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Refresh_Lock
+	 */
+	private Refresh_Lock $lock;
+
+	/**
+	 * Refresh client instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Refresh_Client
+	 */
+	private Refresh_Client $client;
+
+	/**
+	 * Refresh status instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Refresh_Status
+	 */
+	private Refresh_Status $status;
 
 	/**
 	 * Guards against a refresh re-entering itself within the same process.
@@ -121,25 +85,28 @@ class Token_Refresher {
 	private bool $refreshing = false;
 
 	/**
-	 * The value written into the lock row while this process holds it.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private string $lock_value = '';
-
-	/**
 	 * Token_Refresher constructor.
 	 *
 	 * @since TBD
 	 *
-	 * @param Merchant $merchant Merchant instance.
-	 * @param WhoDat   $who_dat  WhoDat instance.
+	 * @param Merchant       $merchant Merchant instance.
+	 * @param Refresh_Policy $policy   Refresh policy instance.
+	 * @param Refresh_Lock   $lock     Refresh lock instance.
+	 * @param Refresh_Client $client   Refresh client instance.
+	 * @param Refresh_Status $status   Refresh status instance.
 	 */
-	public function __construct( Merchant $merchant, WhoDat $who_dat ) {
+	public function __construct(
+		Merchant $merchant,
+		Refresh_Policy $policy,
+		Refresh_Lock $lock,
+		Refresh_Client $client,
+		Refresh_Status $status
+	) {
 		$this->merchant = $merchant;
-		$this->who_dat  = $who_dat;
+		$this->policy   = $policy;
+		$this->lock     = $lock;
+		$this->client   = $client;
+		$this->status   = $status;
 	}
 
 	/**
@@ -150,7 +117,7 @@ class Token_Refresher {
 	 * @return bool Whether the stored credentials are known to be current.
 	 */
 	public function refresh_if_needed(): bool {
-		if ( ! $this->should_refresh() ) {
+		if ( ! $this->policy->should_refresh() ) {
 			return false;
 		}
 
@@ -174,7 +141,7 @@ class Token_Refresher {
 		}
 
 		// Without this a connection Square keeps rejecting would refresh once per Square API call.
-		if ( $this->is_backing_off() ) {
+		if ( $this->policy->is_backing_off() ) {
 			return false;
 		}
 
@@ -182,146 +149,28 @@ class Token_Refresher {
 	}
 
 	/**
-	 * Whether a refresh is due.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool
-	 */
-	public function should_refresh(): bool {
-		if ( ! $this->merchant->get_access_token() || ! $this->merchant->get_refresh_token() ) {
-			return false;
-		}
-
-		if ( $this->is_backing_off() ) {
-			return false;
-		}
-
-		// A rejected connection is retried rarely rather than never, so a wrong verdict heals itself.
-		if ( $this->merchant->is_token_invalid() ) {
-			return true;
-		}
-
-		$expiration = $this->merchant->get_token_expiration();
-
-		if ( null === $expiration ) {
-			// Connected before the expiration was tracked: try occasionally until we learn a real one.
-			$last_attempt = strtotime( (string) $this->merchant->get_refresh_status()['last_attempt_at'] );
-
-			return false === $last_attempt || $last_attempt < time() - $this->get_unknown_expiration_interval();
-		}
-
-		return $expiration->getTimestamp() - $this->get_refresh_window() <= time();
-	}
-
-	/**
-	 * How long before the expiration a refresh is attempted, in seconds.
-	 *
-	 * @since TBD
-	 *
-	 * @return int
-	 */
-	public function get_refresh_window(): int {
-		/**
-		 * Filters how long before its expiration the Square access token is refreshed.
-		 *
-		 * @since TBD
-		 *
-		 * @param int $window The window, in seconds.
-		 */
-		return (int) apply_filters( 'tec_tickets_commerce_square_token_refresh_window', DAY_IN_SECONDS );
-	}
-
-	/**
-	 * How often a connection with no recorded expiration retries, in seconds.
-	 *
-	 * @since TBD
-	 *
-	 * @return int
-	 */
-	protected function get_unknown_expiration_interval(): int {
-		/**
-		 * Filters how often a Square connection with no recorded expiration attempts a refresh.
-		 *
-		 * @since TBD
-		 *
-		 * @param int $interval The interval, in seconds.
-		 */
-		return (int) apply_filters( 'tec_tickets_commerce_square_token_refresh_unknown_expiration_interval', 12 * HOUR_IN_SECONDS );
-	}
-
-	/**
-	 * Whether repeated transient failures are currently holding refreshes off.
-	 *
-	 * Keeps a WhoDat outage from turning into an outbound request on every page load.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool
-	 */
-	protected function is_backing_off(): bool {
-		$status   = $this->merchant->get_refresh_status();
-		$failures = (int) $status['failures'];
-		$invalid  = ! empty( $status['invalid_at'] );
-
-		if ( $failures < 1 && ! $invalid ) {
-			return false;
-		}
-
-		$last_attempt = strtotime( (string) $status['last_attempt_at'] );
-
-		if ( false === $last_attempt ) {
-			return false;
-		}
-
-		$backoff = $invalid
-			? $this->get_invalid_recheck_interval()
-			: min( 12 * HOUR_IN_SECONDS, HOUR_IN_SECONDS * ( 2 ** min( 4, $failures - 1 ) ) );
-
-		return $last_attempt + $backoff > time();
-	}
-
-	/**
-	 * How long a rejected connection waits before it asks Square again.
-	 *
-	 * @since TBD
-	 *
-	 * @return int
-	 */
-	protected function get_invalid_recheck_interval(): int {
-		/**
-		 * Filters how often a rejected Square connection re-checks whether it can be renewed after all.
-		 *
-		 * @since TBD
-		 *
-		 * @param int $interval The interval, in seconds.
-		 */
-		return (int) apply_filters( 'tec_tickets_commerce_square_token_invalid_recheck_interval', 12 * HOUR_IN_SECONDS );
-	}
-
-	/**
-	 * Performs the refresh under a cross-process lock.
+	 * Performs the refresh under the cross-process lock.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $reason Why the refresh was attempted, for logging.
 	 * @param bool   $forced Whether the recorded expiration was ignored.
 	 *
-	 * @return bool
+	 * @return bool Whether the stored credentials are known to be current after this attempt.
 	 */
-	protected function do_refresh( string $reason, bool $forced = false ): bool {
+	private function do_refresh( string $reason, bool $forced = false ): bool {
 		if ( $this->refreshing ) {
 			return false;
 		}
 
 		$previous_token = $this->merchant->get_access_token();
 
-		if ( ! $this->create_lock() ) {
-			/**
+		if ( ! $this->lock->acquire() ) {
+			/*
 			 * Only a caller whose request already failed waits; a proactive refresh has nothing to gain
 			 * from holding a page load open while somebody else does the work.
 			 */
-			return $forced && $this->wait_for_lock_holder( $previous_token );
+			return $forced && $this->lock->wait_for_holder( $previous_token );
 		}
 
 		$this->refreshing = true;
@@ -329,114 +178,37 @@ class Token_Refresher {
 		try {
 			// Whoever held the lock may have already done the work.
 			$this->merchant->flush_option_cache();
+			$this->status->flush_cache();
 
 			if ( $forced ) {
 				if ( $this->merchant->get_access_token() !== $previous_token ) {
 					return true;
 				}
-			} elseif ( ! $this->should_refresh() ) {
+			} elseif ( ! $this->policy->should_refresh() ) {
 				return true;
 			}
 
-			$result = $this->who_dat->request_token_refresh();
-			$status = $this->classify_result( $result );
+			$outcome = $this->client->refresh();
 
-			$this->merchant->update_refresh_status(
-				[ 'last_attempt_at' => Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ) ]
-			);
+			$this->status->record_attempt();
 
-			if ( self::RESULT_SUCCESS === $status ) {
-				return $this->record_success( (array) $result['body'], $reason );
+			if ( $outcome->is_success() ) {
+				return $this->record_success( $outcome, $reason );
 			}
 
-			if ( self::RESULT_PERMANENT === $status ) {
-				$this->record_permanent_failure( (int) $result['code'], $reason );
+			if ( $outcome->is_permanent() ) {
+				$this->record_permanent_failure( $outcome->get_code(), $reason );
 
 				return false;
 			}
 
-			$this->record_transient_failure( (int) $result['code'], $reason );
+			$this->record_transient_failure( $outcome->get_code(), $reason );
 
 			return false;
 		} finally {
 			$this->refreshing = false;
-			$this->release_lock();
+			$this->lock->release();
 		}
-	}
-
-	/**
-	 * Decides whether a refresh attempt failed for good or is worth trying again.
-	 *
-	 * The endpoint answers a rejected refresh token with an HTML 500 rather than a machine readable
-	 * error, so a 500 on its own says nothing. Square's own view of the stored access token settles it:
-	 * if Square no longer accepts the token and it cannot be renewed, the connection really is finished.
-	 * Anything less certain counts as transient, so that an outage never disconnects a working site.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $result The outcome of the refresh request.
-	 *
-	 * @return string One of the RESULT_* constants.
-	 */
-	protected function classify_result( array $result ): string {
-		$code = (int) $result['code'];
-		$body = $result['body'];
-
-		if ( 200 === $code && ! empty( $body['access_token'] ) && is_string( $body['access_token'] ) ) {
-			return self::RESULT_SUCCESS;
-		}
-
-		// The request never completed, so nothing has been established about the credentials.
-		if ( $result['error'] instanceof WP_Error || 0 === $code ) {
-			return self::RESULT_TRANSIENT;
-		}
-
-		// An outright authorization refusal needs no corroboration.
-		if ( 401 === $code || 403 === $code ) {
-			return self::RESULT_PERMANENT;
-		}
-
-		// Everything else, a rate limit or a gateway error included, has to be corroborated.
-		return $this->is_rejection_final() ? self::RESULT_PERMANENT : self::RESULT_TRANSIENT;
-	}
-
-	/**
-	 * Whether a refusal the response could not explain is worth acting on.
-	 *
-	 * Square's status endpoint reports on the *access* token, which has usually expired by the time a
-	 * refresh runs, so on its own it cannot tell a revoked grant from an outage: it says UNAUTHORIZED
-	 * either way. It only carries independent information while the access token is still inside its
-	 * own lifetime. When it does not, the connection is written off only after failures that keep
-	 * repeating over more than a day, which an outage does not do.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool
-	 */
-	protected function is_rejection_final(): bool {
-		// Capped like the refresh itself: this runs on the same checkout request the refresh came from.
-		$status = $this->who_dat->get_token_status( true, [ 'timeout' => WhoDat::TOKEN_REQUEST_TIMEOUT ] );
-
-		if ( false !== $this->who_dat->interpret_token_status( $status ) ) {
-			return false;
-		}
-
-		$expiration = $this->merchant->get_token_expiration();
-
-		/**
-		 * Square refusing a token that is still inside its own lifetime means the grant itself is gone.
-		 * An expiration we never recorded proves nothing either way, so it does not count here.
-		 */
-		if ( null !== $expiration && $expiration->getTimestamp() > time() ) {
-			return true;
-		}
-
-		$status        = $this->merchant->get_refresh_status();
-		$first_failure = strtotime( (string) $status['first_failure_at'] );
-
-		return (int) $status['failures'] >= self::PERSISTENT_FAILURES
-			&& false !== $first_failure
-			&& $first_failure <= time() - DAY_IN_SECONDS;
 	}
 
 	/**
@@ -444,27 +216,19 @@ class Token_Refresher {
 	 *
 	 * @since TBD
 	 *
-	 * @param array  $response The refresh response.
-	 * @param string $reason   Why the refresh was attempted.
+	 * @param Refresh_Outcome $outcome The successful outcome.
+	 * @param string          $reason  Why the refresh was attempted.
 	 *
-	 * @return bool
+	 * @return bool Whether the refreshed credentials were stored.
 	 */
-	protected function record_success( array $response, string $reason ): bool {
-		if ( ! $this->merchant->save_refreshed_tokens( $response ) ) {
-			$this->record_transient_failure( 200, $reason );
+	private function record_success( Refresh_Outcome $outcome, string $reason ): bool {
+		if ( ! $this->merchant->save_refreshed_tokens( $outcome->get_credentials() ) ) {
+			$this->record_transient_failure( $outcome->get_code(), $reason );
 
 			return false;
 		}
 
-		// last_attempt_at survives: it is the only throttle a connection with no known expiration has.
-		$this->merchant->update_refresh_status(
-			[
-				'invalid_at'       => '',
-				'error'            => '',
-				'failures'         => 0,
-				'first_failure_at' => '',
-			]
-		);
+		$this->status->record_success();
 
 		/**
 		 * Fires after the Square access token has been refreshed.
@@ -491,13 +255,8 @@ class Token_Refresher {
 	 *
 	 * @return void
 	 */
-	protected function record_permanent_failure( int $code, string $reason ): void {
-		$this->merchant->update_refresh_status(
-			[
-				'invalid_at' => Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ),
-				'error'      => (string) $code,
-			]
-		);
+	private function record_permanent_failure( int $code, string $reason ): void {
+		$this->status->record_permanent_failure( $code );
 
 		do_action(
 			'tribe_log',
@@ -531,16 +290,8 @@ class Token_Refresher {
 	 *
 	 * @return void
 	 */
-	protected function record_transient_failure( int $code, string $reason ): void {
-		$status   = $this->merchant->get_refresh_status();
-		$failures = (int) $status['failures'] + 1;
-
-		$this->merchant->update_refresh_status(
-			[
-				'failures'         => $failures,
-				'first_failure_at' => $status['first_failure_at'] ?: Dates::build_date_object( 'now', 'UTC' )->format( Dates::DBDATETIMEFORMAT ),
-			]
-		);
+	private function record_transient_failure( int $code, string $reason ): void {
+		$failures = $this->status->record_transient_failure();
 
 		do_action(
 			'tribe_log',
@@ -553,149 +304,5 @@ class Token_Refresher {
 				'failures'      => $failures,
 			]
 		);
-	}
-
-	/**
-	 * The option name backing the refresh lock.
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	protected function get_lock_option_key(): string {
-		$gateway_key = Gateway::get_key();
-		$mode        = $this->merchant->get_mode();
-
-		return "tec_tickets_commerce_{$gateway_key}_token_refresh_lock_{$mode}";
-	}
-
-	/**
-	 * Takes the refresh lock.
-	 *
-	 * Two concurrent refreshes would each spend the refresh token, so only one may run. INSERT IGNORE is
-	 * atomic on the unique option_name index; add_option() reads before it writes and can be raced.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the lock is now held by this process.
-	 */
-	protected function create_lock(): bool {
-		$key   = $this->get_lock_option_key();
-		$now   = time();
-		$table = DB::prefix( 'options' );
-		$value = $now . ':' . wp_generate_password( 12, false );
-
-		try {
-			$acquired = (bool) DB::query(
-				DB::prepare(
-					'INSERT IGNORE INTO %i ( option_name, option_value, autoload ) VALUES ( %s, %s, %s )',
-					$table,
-					$key,
-					$value,
-					'no'
-				)
-			);
-
-			if ( ! $acquired ) {
-				// A crash must not hold refreshes off forever.
-				$acquired = (bool) DB::query(
-					DB::prepare(
-						'UPDATE %i SET option_value = %s WHERE option_name = %s AND CAST( SUBSTRING_INDEX( option_value, %s, 1 ) AS UNSIGNED ) < %d',
-						$table,
-						$value,
-						$key,
-						':',
-						$now - self::LOCK_TIMEOUT
-					)
-				);
-			}
-		} catch ( Throwable $e ) {
-			// Left unlogged the refresh would simply stop happening, which is the failure being fixed.
-			do_action(
-				'tribe_log',
-				'error',
-				'Square access token refresh could not take its lock',
-				[
-					'source' => 'tickets-commerce-square',
-					'error'  => $e->getMessage(),
-				]
-			);
-
-			return false;
-		}
-
-		if ( ! $acquired ) {
-			return false;
-		}
-
-		$this->lock_value = $value;
-
-		wp_cache_delete( 'notoptions', 'options' );
-		wp_cache_delete( $key, 'options' );
-
-		return true;
-	}
-
-	/**
-	 * Releases the refresh lock, but only while this process still holds it.
-	 *
-	 * A process that stalled past the lock timeout has had its lock taken over, and must not delete the
-	 * row a second process is now working under.
-	 *
-	 * @since TBD
-	 *
-	 * @return void
-	 */
-	protected function release_lock(): void {
-		if ( '' === $this->lock_value ) {
-			return;
-		}
-
-		try {
-			DB::query(
-				DB::prepare(
-					'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
-					DB::prefix( 'options' ),
-					$this->get_lock_option_key(),
-					$this->lock_value
-				)
-			);
-		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// The stale takeover will clear it.
-		}
-
-		$this->lock_value = '';
-
-		wp_cache_delete( $this->get_lock_option_key(), 'options' );
-	}
-
-	/**
-	 * Waits out a refresh another process is already running.
-	 *
-	 * Without this every concurrent request that finds an expired token fails its Square call while the
-	 * winner is still mid-refresh, which at checkout means a failed payment per shopper.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $previous_token The access token this process started with.
-	 *
-	 * @return bool Whether the credentials were renewed by whoever held the lock.
-	 */
-	protected function wait_for_lock_holder( string $previous_token ): bool {
-		$waited = 0;
-
-		while ( $waited < self::LOCK_WAIT ) {
-			usleep( self::LOCK_POLL );
-
-			$waited += self::LOCK_POLL;
-
-			$this->merchant->flush_option_cache();
-
-			if ( $this->merchant->get_access_token() !== $previous_token ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -172,7 +172,9 @@ class WhoDat extends Abstract_WhoDat {
 		$response = wp_remote_post(
 			$url,
 			[
-				'body' => [
+				// This runs inside a checkout request, so it may not hold it open for WordPress's default.
+				'timeout' => 3,
+				'body'    => [
 					'grant_type'    => 'refresh_token',
 					'refresh_token' => $refresh_token,
 					'merchant_id'   => $merchant->get_merchant_id(),
@@ -244,7 +246,8 @@ class WhoDat extends Abstract_WhoDat {
 			return true;
 		}
 
-		if ( ! empty( $status['type'] ) || ! empty( $status['error'] ) ) {
+		// Only this one type means the token was refused; the rest describe Square being unwell.
+		if ( isset( $status['type'] ) && 'UNAUTHORIZED' === strtoupper( (string) $status['type'] ) ) {
 			return false;
 		}
 

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -169,11 +169,13 @@ class WhoDat extends Abstract_WhoDat {
 
 		$url = $this->get_api_url( 'oauth/token/refresh' );
 
+		// Admin refreshes can afford to wait, but checkout requests must not hold the customer's request open.
+		$timeout = is_admin() ? 10 : 3;
+
 		$response = wp_remote_post(
 			$url,
 			[
-				// This runs inside a checkout request, so it may not hold it open for WordPress's default.
-				'timeout' => 3,
+				'timeout' => $timeout,
 				'body'    => [
 					'grant_type'    => 'refresh_token',
 					'refresh_token' => $refresh_token,

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -134,11 +134,18 @@ class WhoDat extends Abstract_WhoDat {
 	 * @return ?array
 	 */
 	public function refresh_token(): ?array {
-		$refresh_token = tribe( Merchant::class )->get_refresh_token();
+		$merchant      = tribe( Merchant::class );
+		$refresh_token = $merchant->get_refresh_token();
+
+		if ( ! $refresh_token ) {
+			return null;
+		}
 
 		$query_args = [
 			'grant_type'    => 'refresh_token',
 			'refresh_token' => $refresh_token,
+			'merchant_id'   => $merchant->get_merchant_id(),
+			'mode'          => $merchant->get_mode(),
 		];
 
 		return $this->get( 'oauth/token/refresh', $query_args );

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -169,13 +169,11 @@ class WhoDat extends Abstract_WhoDat {
 
 		$url = $this->get_api_url( 'oauth/token/refresh' );
 
-		// Admin refreshes can afford to wait, but checkout requests must not hold the customer's request open.
-		$timeout = is_admin() ? 10 : 3;
-
 		$response = wp_remote_post(
 			$url,
 			[
-				'timeout' => $timeout,
+				// This runs inside a checkout request, so it may not hold it open for WordPress's default.
+				'timeout' => 3,
 				'body'    => [
 					'grant_type'    => 'refresh_token',
 					'refresh_token' => $refresh_token,
@@ -217,11 +215,12 @@ class WhoDat extends Abstract_WhoDat {
 			'mode'         => $merchant->get_mode(),
 		];
 
-		if ( $force ) {
-			return $this->get( 'oauth/token/status', $query_args );
-		}
+		$status = $force ?
+			$this->get( 'oauth/token/status', $query_args ) :
+			$this->get_with_cache( 'oauth/token/status', $query_args );
 
-		return $this->get_with_cache( 'oauth/token/status', $query_args );
+		// A scalar body decodes to a scalar, and every caller here reads the status as an array.
+		return is_array( $status ) ? $status : null;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -42,6 +42,17 @@ class WhoDat extends Abstract_WhoDat {
 	protected const STATE_NONCE_ACTION = 'tec-tc-square-connect';
 
 	/**
+	 * How long the token calls made from a front end request may take, in seconds.
+	 *
+	 * These run inside checkout, so they may not hold the page open for WordPress's default.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	public const TOKEN_REQUEST_TIMEOUT = 3;
+
+	/**
 	 * Creates a new account link for the client and redirects the user to setup the account details.
 	 *
 	 * @since 5.24.0
@@ -172,8 +183,7 @@ class WhoDat extends Abstract_WhoDat {
 		$response = wp_remote_post(
 			$url,
 			[
-				// This runs inside a checkout request, so it may not hold it open for WordPress's default.
-				'timeout' => 3,
+				'timeout' => self::TOKEN_REQUEST_TIMEOUT,
 				'body'    => [
 					'grant_type'    => 'refresh_token',
 					'refresh_token' => $refresh_token,
@@ -201,13 +211,14 @@ class WhoDat extends Abstract_WhoDat {
 	 * Get the token status from Square.
 	 *
 	 * @since 5.24.0
-	 * @since TBD Added the $force parameter.
+	 * @since TBD Added the $force and $request_arguments parameters.
 	 *
-	 * @param bool $force Whether to bypass the cached status.
+	 * @param bool  $force             Whether to bypass the cached status.
+	 * @param array $request_arguments Arguments passed on to wp_remote_get(), forced requests only.
 	 *
 	 * @return array|null
 	 */
-	public function get_token_status( bool $force = false ): ?array {
+	public function get_token_status( bool $force = false, array $request_arguments = [] ): ?array {
 		$merchant = tribe( Merchant::class );
 
 		$query_args = [
@@ -216,7 +227,7 @@ class WhoDat extends Abstract_WhoDat {
 		];
 
 		$status = $force ?
-			$this->get( 'oauth/token/status', $query_args ) :
+			$this->get( 'oauth/token/status', $query_args, $request_arguments ) :
 			$this->get_with_cache( 'oauth/token/status', $query_args );
 
 		// A scalar body decodes to a scalar, and every caller here reads the status as an array.
@@ -237,8 +248,22 @@ class WhoDat extends Abstract_WhoDat {
 	 * @return ?bool True when accepted, false when rejected, null when it could not be established.
 	 */
 	public function is_token_accepted( bool $force = false ): ?bool {
-		$status = $this->get_token_status( $force );
+		return $this->interpret_token_status( $this->get_token_status( $force ) );
+	}
 
+	/**
+	 * Reads the verdict out of a status response that has already been fetched.
+	 *
+	 * Split from is_token_accepted() so that a caller which also needs the message the endpoint sent
+	 * does not have to ask for the same status twice.
+	 *
+	 * @since TBD
+	 *
+	 * @param ?array $status The decoded status response.
+	 *
+	 * @return ?bool True when accepted, false when rejected, null when it could not be established.
+	 */
+	public function interpret_token_status( ?array $status ): ?bool {
 		if ( ! is_array( $status ) ) {
 			return null;
 		}

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -13,6 +13,7 @@ namespace TEC\Tickets\Commerce\Gateways\Square;
 use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_WhoDat;
 use TEC\Tickets\Commerce\Gateways\Square\REST\On_Boarding_Endpoint;
 use RuntimeException;
+use WP_Error;
 /**
  * Class WhoDat. Handles connection to Square when the platform keys are needed.
  *
@@ -130,35 +131,81 @@ class WhoDat extends Abstract_WhoDat {
 	 * Requests WhoDat to refresh the oAuth tokens.
 	 *
 	 * @since 5.24.0
+	 * @since TBD Sends a POST; the endpoint answers 405 to the GET this used to send.
 	 *
-	 * @return ?array
+	 * @return ?array The refreshed credentials, or null when they could not be refreshed.
 	 */
 	public function refresh_token(): ?array {
+		$result = $this->request_token_refresh();
+
+		return empty( $result['body']['access_token'] ) ? null : $result['body'];
+	}
+
+	/**
+	 * Requests WhoDat to refresh the oAuth tokens, reporting how the request went.
+	 *
+	 * The endpoint answers a rejected refresh token with an HTML error page rather than a machine
+	 * readable body, so the status code is the only thing a caller can reason about.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{code: int, body: mixed, error: ?WP_Error} The response code (0 when the request never
+	 *                                                         completed), the decoded body, and the
+	 *                                                         transport error if there was one.
+	 */
+	public function request_token_refresh(): array {
 		$merchant      = tribe( Merchant::class );
 		$refresh_token = $merchant->get_refresh_token();
 
-		if ( ! $refresh_token ) {
-			return null;
-		}
-
-		$query_args = [
-			'grant_type'    => 'refresh_token',
-			'refresh_token' => $refresh_token,
-			'merchant_id'   => $merchant->get_merchant_id(),
-			'mode'          => $merchant->get_mode(),
+		$result = [
+			'code'  => 0,
+			'body'  => null,
+			'error' => null,
 		];
 
-		return $this->get( 'oauth/token/refresh', $query_args );
+		if ( ! $refresh_token ) {
+			return $result;
+		}
+
+		$url = $this->get_api_url( 'oauth/token/refresh' );
+
+		$response = wp_remote_post(
+			$url,
+			[
+				'body' => [
+					'grant_type'    => 'refresh_token',
+					'refresh_token' => $refresh_token,
+					'merchant_id'   => $merchant->get_merchant_id(),
+					'mode'          => $merchant->get_mode(),
+				],
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log_error( 'WhoDat request error:', $response->get_error_message(), $url );
+
+			$result['error'] = $response;
+
+			return $result;
+		}
+
+		$result['code'] = (int) wp_remote_retrieve_response_code( $response );
+		$result['body'] = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		return $result;
 	}
 
 	/**
 	 * Get the token status from Square.
 	 *
 	 * @since 5.24.0
+	 * @since TBD Added the $force parameter.
+	 *
+	 * @param bool $force Whether to bypass the cached status.
 	 *
 	 * @return array|null
 	 */
-	public function get_token_status(): ?array {
+	public function get_token_status( bool $force = false ): ?array {
 		$merchant = tribe( Merchant::class );
 
 		$query_args = [
@@ -166,7 +213,42 @@ class WhoDat extends Abstract_WhoDat {
 			'mode'         => $merchant->get_mode(),
 		];
 
+		if ( $force ) {
+			return $this->get( 'oauth/token/status', $query_args );
+		}
+
 		return $this->get_with_cache( 'oauth/token/status', $query_args );
+	}
+
+	/**
+	 * Whether Square still accepts the stored access token.
+	 *
+	 * The status endpoint answers a rejected token with `{ type: UNAUTHORIZED }` and a valid one with the
+	 * granted scopes. Anything else - an outage, a malformed body - is reported as unknown rather than as
+	 * a rejection, so a blip is never mistaken for a revoked connection.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $force Whether to bypass the cached status.
+	 *
+	 * @return ?bool True when accepted, false when rejected, null when it could not be established.
+	 */
+	public function is_token_accepted( bool $force = false ): ?bool {
+		$status = $this->get_token_status( $force );
+
+		if ( ! is_array( $status ) ) {
+			return null;
+		}
+
+		if ( ! empty( $status['scopes'] ) ) {
+			return true;
+		}
+
+		if ( ! empty( $status['type'] ) || ! empty( $status['error'] ) ) {
+			return false;
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -141,6 +141,10 @@ class WhoDat extends Abstract_WhoDat {
 	/**
 	 * Requests WhoDat to refresh the oAuth tokens.
 	 *
+	 * Nothing calls this. The refresh runs through request_token_refresh(), which reports the response
+	 * code that telling a revoked grant from an outage depends on; this only survives because it is
+	 * public and released.
+	 *
 	 * @since 5.24.0
 	 * @since TBD Sends a POST; the endpoint answers 405 to the GET this used to send.
 	 *

--- a/src/Tickets/Commerce/Gateways/Square/WhoDat.php
+++ b/src/Tickets/Commerce/Gateways/Square/WhoDat.php
@@ -201,7 +201,7 @@ class WhoDat extends Abstract_WhoDat {
 			return $result;
 		}
 
-		$result['code'] = (int) wp_remote_retrieve_response_code( $response );
+		$result['code'] = absint( wp_remote_retrieve_response_code( $response ) );
 		$result['body'] = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		return $result;
@@ -211,51 +211,44 @@ class WhoDat extends Abstract_WhoDat {
 	 * Get the token status from Square.
 	 *
 	 * @since 5.24.0
-	 * @since TBD Added the $force and $request_arguments parameters.
-	 *
-	 * @param bool  $force             Whether to bypass the cached status.
-	 * @param array $request_arguments Arguments passed on to wp_remote_get(), forced requests only.
+	 * @since TBD Returns null for a body that did not decode to an array.
 	 *
 	 * @return array|null
 	 */
-	public function get_token_status( bool $force = false, array $request_arguments = [] ): ?array {
-		$merchant = tribe( Merchant::class );
+	public function get_token_status(): ?array {
+		$status = $this->get_with_cache( 'oauth/token/status', $this->get_token_status_query_args() );
 
-		$query_args = [
-			'access_token' => $merchant->get_access_token(),
-			'mode'         => $merchant->get_mode(),
-		];
-
-		$status = $force ?
-			$this->get( 'oauth/token/status', $query_args, $request_arguments ) :
-			$this->get_with_cache( 'oauth/token/status', $query_args );
-
-		// A scalar body decodes to a scalar, and every caller here reads the status as an array.
+		// A scalar body decodes to a scalar, and every caller reads the status as an array.
 		return is_array( $status ) ? $status : null;
 	}
 
 	/**
-	 * Whether Square still accepts the stored access token.
+	 * Get the token status from Square, bypassing the cache.
+	 *
+	 * A separate method rather than a flag on get_token_status(): that one is released, so widening it
+	 * would break any override, and `get_token_status( true )` says nothing at the call site.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $request_arguments Arguments passed on to wp_remote_get().
+	 *
+	 * @return array|null The decoded status response, or null when the body was not an array.
+	 */
+	public function get_fresh_token_status( array $request_arguments = [] ): ?array {
+		$status = $this->get_with_request_args( 'oauth/token/status', $this->get_token_status_query_args(), $request_arguments );
+
+		return is_array( $status ) ? $status : null;
+	}
+
+	/**
+	 * Reads the verdict out of a status response.
 	 *
 	 * The status endpoint answers a rejected token with `{ type: UNAUTHORIZED }` and a valid one with the
 	 * granted scopes. Anything else - an outage, a malformed body - is reported as unknown rather than as
 	 * a rejection, so a blip is never mistaken for a revoked connection.
 	 *
-	 * @since TBD
-	 *
-	 * @param bool $force Whether to bypass the cached status.
-	 *
-	 * @return ?bool True when accepted, false when rejected, null when it could not be established.
-	 */
-	public function is_token_accepted( bool $force = false ): ?bool {
-		return $this->interpret_token_status( $this->get_token_status( $force ) );
-	}
-
-	/**
-	 * Reads the verdict out of a status response that has already been fetched.
-	 *
-	 * Split from is_token_accepted() so that a caller which also needs the message the endpoint sent
-	 * does not have to ask for the same status twice.
+	 * Takes the response rather than fetching it, so a caller that also needs the message the endpoint
+	 * sent does not have to ask for the same status twice.
 	 *
 	 * @since TBD
 	 *
@@ -264,7 +257,7 @@ class WhoDat extends Abstract_WhoDat {
 	 * @return ?bool True when accepted, false when rejected, null when it could not be established.
 	 */
 	public function interpret_token_status( ?array $status ): ?bool {
-		if ( ! is_array( $status ) ) {
+		if ( null === $status ) {
 			return null;
 		}
 
@@ -273,7 +266,7 @@ class WhoDat extends Abstract_WhoDat {
 		}
 
 		// Only this one type means the token was refused; the rest describe Square being unwell.
-		if ( isset( $status['type'] ) && 'UNAUTHORIZED' === strtoupper( (string) $status['type'] ) ) {
+		if ( isset( $status['type'] ) && is_string( $status['type'] ) && 'UNAUTHORIZED' === strtoupper( $status['type'] ) ) {
 			return false;
 		}
 
@@ -456,5 +449,21 @@ class WhoDat extends Abstract_WhoDat {
 		$connection_response = $this->get_with_cache( 'oauth/authorize', $query_args );
 
 		return $connection_response['auth_url'] ?? '';
+	}
+
+	/**
+	 * The query args identifying the connection whose token status is being asked about.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{access_token: string, mode: string}
+	 */
+	private function get_token_status_query_args(): array {
+		$merchant = tribe( Merchant::class );
+
+		return [
+			'access_token' => $merchant->get_access_token(),
+			'mode'         => $merchant->get_mode(),
+		];
 	}
 }

--- a/tests/square_integration/Hooks_Test.php
+++ b/tests/square_integration/Hooks_Test.php
@@ -33,6 +33,66 @@ class Hooks_Test extends Controller_Test_Case {
 	}
 
 	/**
+	 * The Square request path cannot be the only trigger: a site that takes no Square traffic would
+	 * never notice its token expiring, and one already marked unavailable stops making Square calls
+	 * altogether, which would leave a mistaken verdict with no way back.
+	 *
+	 * @test
+	 */
+	public function it_should_renew_the_access_token_from_the_admin(): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$this->assertNotFalse( has_action( 'admin_init', [ $controller, 'maybe_refresh_access_token' ] ) );
+
+		$merchant = tribe( Merchant::class );
+		$merchant->delete_refresh_status();
+		$merchant->save_signup_data(
+			array_merge(
+				tec_tickets_tests_get_fake_merchant_data(),
+				[ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + HOUR_IN_SECONDS ) ]
+			)
+		);
+
+		$refreshed = false;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $pre, $args, $url ) use ( &$refreshed ) {
+				if ( false === strpos( $url, 'oauth/token/refresh' ) ) {
+					return $pre;
+				}
+
+				$refreshed = true;
+
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode(
+						[
+							'access_token'  => 'renewed-from-the-admin',
+							'refresh_token' => 'rt-8PoFNX4o9XOz9vMYOrZ6vA',
+							'expires_at'    => gmdate( 'Y-m-d\TH:i:s\Z', time() + 30 * DAY_IN_SECONDS ),
+						]
+					),
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			},
+			10,
+			3
+		);
+
+		$controller->maybe_refresh_access_token();
+
+		$this->assertTrue( $refreshed );
+		$this->assertSame( 'renewed-from-the-admin', $merchant->get_access_token() );
+
+		$merchant->delete_refresh_status();
+		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_filter_the_orders_repository_schema(): void {

--- a/tests/square_integration/Hooks_Test.php
+++ b/tests/square_integration/Hooks_Test.php
@@ -13,6 +13,7 @@ use TEC\Tickets\Commerce\Status\Completed;
 use TEC\Tickets\Commerce\Status\Status_Handler;
 use TEC\Tickets\Commerce\Order as Commerce_Order;
 use Tribe\Tests\Traits\With_Uopz;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 
 class Hooks_Test extends Controller_Test_Case {
 	use With_Uopz;
@@ -46,7 +47,7 @@ class Hooks_Test extends Controller_Test_Case {
 		$this->assertNotFalse( has_action( 'admin_init', [ $controller, 'maybe_refresh_access_token' ] ) );
 
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		$merchant->save_signup_data(
 			array_merge(
 				tec_tickets_tests_get_fake_merchant_data(),
@@ -88,7 +89,7 @@ class Hooks_Test extends Controller_Test_Case {
 		$this->assertTrue( $refreshed );
 		$this->assertSame( 'renewed-from-the-admin', $merchant->get_access_token() );
 
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 	}
 

--- a/tests/square_integration/Merchant_Test.php
+++ b/tests/square_integration/Merchant_Test.php
@@ -11,7 +11,7 @@ class Merchant_Test extends WPTestCase {
 	 */
 	public function restore_merchant_data(): void {
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_token_status();
+		$merchant->delete_refresh_status();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 	}
 
@@ -116,13 +116,13 @@ class Merchant_Test extends WPTestCase {
 
 		$this->assertTrue( $merchant->is_connected() );
 
-		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
 		$this->assertTrue( $merchant->is_token_invalid() );
 		$this->assertFalse( $merchant->is_connected() );
 		$this->assertFalse( $merchant->is_active() );
 
-		$merchant->delete_token_status();
+		$merchant->delete_refresh_status();
 
 		$this->assertTrue( $merchant->is_connected() );
 	}
@@ -135,10 +135,10 @@ class Merchant_Test extends WPTestCase {
 	public function it_should_not_share_state_with_stripe(): void {
 		$merchant = tribe( Merchant::class );
 
-		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
-		$this->assertNotSame( Stripe_Merchant::$merchant_unauthorized_option_key, $merchant->get_token_status_option_key() );
-		$this->assertNotSame( Stripe_Merchant::$merchant_deauthorized_option_key, $merchant->get_token_status_option_key() );
+		$this->assertNotSame( Stripe_Merchant::$merchant_unauthorized_option_key, $merchant->get_refresh_status_option_key() );
+		$this->assertNotSame( Stripe_Merchant::$merchant_deauthorized_option_key, $merchant->get_refresh_status_option_key() );
 		$this->assertEmpty( get_option( Stripe_Merchant::$merchant_unauthorized_option_key ) );
 		$this->assertEmpty( get_option( Stripe_Merchant::$merchant_deauthorized_option_key ) );
 	}
@@ -152,10 +152,10 @@ class Merchant_Test extends WPTestCase {
 
 		try {
 			$merchant->set_mode( 'live' );
-			$live = $merchant->get_token_status_option_key();
+			$live = $merchant->get_refresh_status_option_key();
 
 			$merchant->set_mode( 'sandbox' );
-			$sandbox = $merchant->get_token_status_option_key();
+			$sandbox = $merchant->get_refresh_status_option_key();
 
 			$this->assertNotSame( $live, $sandbox );
 		} finally {
@@ -237,12 +237,12 @@ class Merchant_Test extends WPTestCase {
 	public function it_should_clear_the_token_status_on_reconnect_and_disconnect(): void {
 		$merchant = tribe( Merchant::class );
 
-		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 
 		$this->assertFalse( $merchant->is_token_invalid() );
 
-		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 		$merchant->delete_signup_data();
 
 		$this->assertFalse( $merchant->is_token_invalid() );

--- a/tests/square_integration/Merchant_Test.php
+++ b/tests/square_integration/Merchant_Test.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Gateways\Square;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Gateways\Stripe\Merchant as Stripe_Merchant;
+
+class Merchant_Test extends WPTestCase {
+	/**
+	 * @after
+	 */
+	public function restore_merchant_data(): void {
+		$merchant = tribe( Merchant::class );
+		$merchant->delete_token_status();
+		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
+	}
+
+	/**
+	 * Replaces the stored signup data, keeping the rest of the fixture intact.
+	 *
+	 * @param array    $overrides Values to override.
+	 * @param string[] $remove    Keys to drop entirely.
+	 */
+	protected function set_signup_data( array $overrides = [], array $remove = [] ): Merchant {
+		$merchant = tribe( Merchant::class );
+		$data     = array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides );
+
+		foreach ( $remove as $key ) {
+			unset( $data[ $key ] );
+		}
+
+		$merchant->save_signup_data( $data );
+
+		return $merchant;
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_read_a_utc_expiration(): void {
+		$merchant = $this->set_signup_data( [ 'expires_at' => '2030-06-01T10:00:00Z' ] );
+
+		$this->assertSame( 1906538400, $merchant->get_token_expiration()->getTimestamp() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_honour_an_explicit_offset_in_the_expiration(): void {
+		$merchant = $this->set_signup_data( [ 'expires_at' => '2030-06-01T10:00:00+02:00' ] );
+
+		$this->assertSame( 1906531200, $merchant->get_token_expiration()->getTimestamp() );
+	}
+
+	/**
+	 * The site timezone must not decide whether the token is still good.
+	 *
+	 * @test
+	 */
+	public function it_should_compare_expirations_independently_of_the_site_timezone(): void {
+		$original = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'Pacific/Kiritimati' );
+
+		try {
+			$merchant = $this->set_signup_data( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS ) ] );
+
+			$this->assertTrue( $merchant->is_token_expired() );
+		} finally {
+			update_option( 'timezone_string', $original );
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_report_no_expiration_for_unusable_values(): void {
+		foreach ( [ '', 'not-a-date', [ 'nested' ] ] as $value ) {
+			$merchant = $this->set_signup_data( [ 'expires_at' => $value ] );
+
+			$this->assertNull( $merchant->get_token_expiration() );
+		}
+
+		$merchant = $this->set_signup_data( [], [ 'expires_at' ] );
+
+		$this->assertNull( $merchant->get_token_expiration() );
+	}
+
+	/**
+	 * A connection made before the expiration was tracked must keep working.
+	 *
+	 * @test
+	 */
+	public function it_should_not_treat_an_unknown_expiration_as_expired(): void {
+		$merchant = $this->set_signup_data( [], [ 'expires_at' ] );
+
+		$this->assertFalse( $merchant->is_token_expired() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_report_an_expiring_token(): void {
+		$merchant = $this->set_signup_data( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 2 * DAY_IN_SECONDS ) ] );
+
+		$this->assertFalse( $merchant->is_token_expired() );
+		$this->assertTrue( $merchant->is_token_expiring_within( 3 * DAY_IN_SECONDS ) );
+		$this->assertFalse( $merchant->is_token_expiring_within( DAY_IN_SECONDS ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_be_connected_while_the_token_is_invalid(): void {
+		$merchant = tribe( Merchant::class );
+
+		$this->assertTrue( $merchant->is_connected() );
+
+		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+
+		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertFalse( $merchant->is_connected() );
+		$this->assertFalse( $merchant->is_active() );
+
+		$merchant->delete_token_status();
+
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * The Square token status must never touch the options Stripe stores its own state in.
+	 *
+	 * @test
+	 */
+	public function it_should_not_share_state_with_stripe(): void {
+		$merchant = tribe( Merchant::class );
+
+		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+
+		$this->assertNotSame( Stripe_Merchant::$merchant_unauthorized_option_key, $merchant->get_token_status_option_key() );
+		$this->assertNotSame( Stripe_Merchant::$merchant_deauthorized_option_key, $merchant->get_token_status_option_key() );
+		$this->assertEmpty( get_option( Stripe_Merchant::$merchant_unauthorized_option_key ) );
+		$this->assertEmpty( get_option( Stripe_Merchant::$merchant_deauthorized_option_key ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_scope_the_token_status_to_the_mode(): void {
+		$merchant = tribe( Merchant::class );
+		$original = $merchant->get_mode();
+
+		try {
+			$merchant->set_mode( 'live' );
+			$live = $merchant->get_token_status_option_key();
+
+			$merchant->set_mode( 'sandbox' );
+			$sandbox = $merchant->get_token_status_option_key();
+
+			$this->assertNotSame( $live, $sandbox );
+		} finally {
+			$merchant->set_mode( $original );
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_store_refreshed_tokens(): void {
+		$merchant = tribe( Merchant::class );
+		$expires  = gmdate( 'Y-m-d\TH:i:s\Z', time() + 30 * DAY_IN_SECONDS );
+
+		$this->assertTrue(
+			$merchant->save_refreshed_tokens(
+				[
+					'access_token'  => 'refreshed-access-token',
+					'refresh_token' => 'refreshed-refresh-token',
+					'expires_at'    => $expires,
+				]
+			)
+		);
+
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+		$this->assertSame( 'refreshed-refresh-token', $merchant->get_refresh_token() );
+		$this->assertSame( $expires, get_option( $merchant->get_signup_data_key() )['expires_at'] );
+		$this->assertNotEmpty( get_option( $merchant->get_signup_data_key() )['refreshed_at'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_keep_values_the_refresh_response_omitted(): void {
+		$merchant = tribe( Merchant::class );
+		$fixture  = tec_tickets_tests_get_fake_merchant_data();
+
+		$merchant->save_refreshed_tokens(
+			[
+				'access_token' => 'refreshed-access-token',
+				'expires_at'   => gmdate( 'Y-m-d\TH:i:s\Z', time() + 30 * DAY_IN_SECONDS ),
+			]
+		);
+
+		$this->assertSame( $fixture['refresh_token'], $merchant->get_refresh_token() );
+		$this->assertSame( $fixture['whodat_signature'], $merchant->get_whodat_signature() );
+		$this->assertSame( $fixture['merchant_id'], $merchant->get_merchant_id() );
+	}
+
+	/**
+	 * A refresh that does not report an expiration leaves it unknown, never the previous one.
+	 *
+	 * @test
+	 */
+	public function it_should_blank_an_unusable_expiration_on_refresh(): void {
+		$merchant = $this->set_signup_data( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS ) ] );
+
+		$merchant->save_refreshed_tokens( [ 'access_token' => 'refreshed-access-token' ] );
+
+		$this->assertSame( '', get_option( $merchant->get_signup_data_key() )['expires_at'] );
+		$this->assertNull( $merchant->get_token_expiration() );
+		$this->assertFalse( $merchant->is_token_expired() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_reject_a_refresh_response_without_an_access_token(): void {
+		$merchant = tribe( Merchant::class );
+
+		$this->assertFalse( $merchant->save_refreshed_tokens( [] ) );
+		$this->assertFalse( $merchant->save_refreshed_tokens( [ 'access_token' => '' ] ) );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_clear_the_token_status_on_reconnect_and_disconnect(): void {
+		$merchant = tribe( Merchant::class );
+
+		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+
+		$merchant->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$merchant->delete_signup_data();
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+	}
+}

--- a/tests/square_integration/Merchant_Test.php
+++ b/tests/square_integration/Merchant_Test.php
@@ -3,6 +3,7 @@
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 use TEC\Tickets\Commerce\Gateways\Stripe\Merchant as Stripe_Merchant;
 
 class Merchant_Test extends WPTestCase {
@@ -11,27 +12,8 @@ class Merchant_Test extends WPTestCase {
 	 */
 	public function restore_merchant_data(): void {
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
-	}
-
-	/**
-	 * Replaces the stored signup data, keeping the rest of the fixture intact.
-	 *
-	 * @param array    $overrides Values to override.
-	 * @param string[] $remove    Keys to drop entirely.
-	 */
-	protected function set_signup_data( array $overrides = [], array $remove = [] ): Merchant {
-		$merchant = tribe( Merchant::class );
-		$data     = array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides );
-
-		foreach ( $remove as $key ) {
-			unset( $data[ $key ] );
-		}
-
-		$merchant->save_signup_data( $data );
-
-		return $merchant;
 	}
 
 	/**
@@ -62,9 +44,10 @@ class Merchant_Test extends WPTestCase {
 		update_option( 'timezone_string', 'Pacific/Kiritimati' );
 
 		try {
-			$merchant = $this->set_signup_data( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS ) ] );
+			$expires_at = gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS );
+			$merchant   = $this->set_signup_data( [ 'expires_at' => $expires_at ] );
 
-			$this->assertTrue( $merchant->is_token_expired() );
+			$this->assertSame( strtotime( $expires_at ), $merchant->get_token_expiration()->getTimestamp() );
 		} finally {
 			update_option( 'timezone_string', $original );
 		}
@@ -93,7 +76,7 @@ class Merchant_Test extends WPTestCase {
 	public function it_should_not_treat_an_unknown_expiration_as_expired(): void {
 		$merchant = $this->set_signup_data( [], [ 'expires_at' ] );
 
-		$this->assertFalse( $merchant->is_token_expired() );
+		$this->assertNull( $merchant->get_token_expiration() );
 		$this->assertTrue( $merchant->is_connected() );
 	}
 
@@ -103,7 +86,6 @@ class Merchant_Test extends WPTestCase {
 	public function it_should_report_an_expiring_token(): void {
 		$merchant = $this->set_signup_data( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 2 * DAY_IN_SECONDS ) ] );
 
-		$this->assertFalse( $merchant->is_token_expired() );
 		$this->assertTrue( $merchant->is_token_expiring_within( 3 * DAY_IN_SECONDS ) );
 		$this->assertFalse( $merchant->is_token_expiring_within( DAY_IN_SECONDS ) );
 	}
@@ -116,13 +98,13 @@ class Merchant_Test extends WPTestCase {
 
 		$this->assertTrue( $merchant->is_connected() );
 
-		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
 		$this->assertTrue( $merchant->is_token_invalid() );
 		$this->assertFalse( $merchant->is_connected() );
 		$this->assertFalse( $merchant->is_active() );
 
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 
 		$this->assertTrue( $merchant->is_connected() );
 	}
@@ -135,32 +117,10 @@ class Merchant_Test extends WPTestCase {
 	public function it_should_not_share_state_with_stripe(): void {
 		$merchant = tribe( Merchant::class );
 
-		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
-		$this->assertNotSame( Stripe_Merchant::$merchant_unauthorized_option_key, $merchant->get_refresh_status_option_key() );
-		$this->assertNotSame( Stripe_Merchant::$merchant_deauthorized_option_key, $merchant->get_refresh_status_option_key() );
 		$this->assertEmpty( get_option( Stripe_Merchant::$merchant_unauthorized_option_key ) );
 		$this->assertEmpty( get_option( Stripe_Merchant::$merchant_deauthorized_option_key ) );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_scope_the_token_status_to_the_mode(): void {
-		$merchant = tribe( Merchant::class );
-		$original = $merchant->get_mode();
-
-		try {
-			$merchant->set_mode( 'live' );
-			$live = $merchant->get_refresh_status_option_key();
-
-			$merchant->set_mode( 'sandbox' );
-			$sandbox = $merchant->get_refresh_status_option_key();
-
-			$this->assertNotSame( $live, $sandbox );
-		} finally {
-			$merchant->set_mode( $original );
-		}
 	}
 
 	/**
@@ -217,7 +177,6 @@ class Merchant_Test extends WPTestCase {
 
 		$this->assertSame( '', get_option( $merchant->get_signup_data_key() )['expires_at'] );
 		$this->assertNull( $merchant->get_token_expiration() );
-		$this->assertFalse( $merchant->is_token_expired() );
 	}
 
 	/**
@@ -237,14 +196,34 @@ class Merchant_Test extends WPTestCase {
 	public function it_should_clear_the_token_status_on_reconnect_and_disconnect(): void {
 		$merchant = tribe( Merchant::class );
 
-		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 
 		$this->assertFalse( $merchant->is_token_invalid() );
 
-		$merchant->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 		$merchant->delete_signup_data();
 
 		$this->assertFalse( $merchant->is_token_invalid() );
 	}
+
+	/**
+	 * Replaces the stored signup data, keeping the rest of the fixture intact.
+	 *
+	 * @param array    $overrides Values to override.
+	 * @param string[] $remove    Keys to drop entirely.
+	 */
+	protected function set_signup_data( array $overrides = [], array $remove = [] ): Merchant {
+		$merchant = tribe( Merchant::class );
+		$data     = array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides );
+
+		foreach ( $remove as $key ) {
+			unset( $data[ $key ] );
+		}
+
+		$merchant->save_signup_data( $data );
+
+		return $merchant;
+	}
+
 }

--- a/tests/square_integration/Notices_Controller_Test.php
+++ b/tests/square_integration/Notices_Controller_Test.php
@@ -307,7 +307,10 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @test
 	 */
 	public function it_should_not_show_token_refresh_failing_notice_far_from_the_expiration(): void {
-		tribe( Merchant::class )->update_refresh_status( [ 'failures' => 5 ] );
+		$merchant = tribe( Merchant::class );
+
+		$merchant->update( [ 'expires_at' => gmdate( 'c', time() + 30 * DAY_IN_SECONDS ) ] );
+		$merchant->update_refresh_status( [ 'failures' => 5 ] );
 
 		$this->assertFalse( $this->make_controller()->should_display_token_refresh_failing_notice() );
 	}

--- a/tests/square_integration/Notices_Controller_Test.php
+++ b/tests/square_integration/Notices_Controller_Test.php
@@ -25,6 +25,13 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	}
 
 	/**
+	 * @after
+	 */
+	public function reset_token_status(): void {
+		tribe( Merchant::class )->delete_token_status();
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_not_show_webhook_notice_when_gateway_not_enabled(): void {
@@ -225,5 +232,93 @@ class Notices_Controller_Test extends Controller_Test_Case {
 		$notice = $this->make_controller()->render_remotely_disconnected_notice();
 
 		$this->assertMatchesHtmlSnapshot($notice);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_show_token_invalid_notice_while_the_token_works(): void {
+		$this->assertFalse( $this->make_controller()->should_display_token_invalid_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_show_token_invalid_notice_when_square_refused_the_refresh(): void {
+		tribe( Merchant::class )->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+
+		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
+	}
+
+	/**
+	 * The notice explains why the gateway went inactive, so it cannot depend on the gateway being active.
+	 *
+	 * @test
+	 */
+	public function it_should_show_token_invalid_notice_even_though_the_gateway_is_inactive(): void {
+		tribe( Merchant::class )->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+
+		$this->assertFalse( tribe( Gateway::class )->is_active() );
+		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_show_token_invalid_notice_when_gateway_not_enabled(): void {
+		tribe( Merchant::class )->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		$this->set_class_fn_return( Abstract_Gateway::class, 'is_enabled', false );
+
+		$this->assertFalse( $this->make_controller()->should_display_token_invalid_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_token_invalid_notice(): void {
+		$this->assertMatchesHtmlSnapshot( $this->make_controller()->render_token_invalid_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_only_show_token_refresh_failing_notice_after_repeated_failures(): void {
+		$merchant   = tribe( Merchant::class );
+		$controller = $this->make_controller();
+
+		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
+
+		$merchant->update_token_status( [ 'failures' => 2 ] );
+		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
+
+		$merchant->update_token_status( [ 'failures' => 3 ] );
+		$this->assertTrue( $controller->should_display_token_refresh_failing_notice() );
+	}
+
+	/**
+	 * The two notices describe the same connection, so they must never appear together.
+	 *
+	 * @test
+	 */
+	public function it_should_not_stack_the_two_token_notices(): void {
+		$merchant   = tribe( Merchant::class );
+		$controller = $this->make_controller();
+
+		$merchant->update_token_status(
+			[
+				'failures'   => 5,
+				'invalid_at' => '2026-01-01 00:00:00',
+			]
+		);
+
+		$this->assertTrue( $controller->should_display_token_invalid_notice() );
+		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_token_refresh_failing_notice(): void {
+		$this->assertMatchesHtmlSnapshot( $this->make_controller()->render_token_refresh_failing_notice() );
 	}
 }

--- a/tests/square_integration/Notices_Controller_Test.php
+++ b/tests/square_integration/Notices_Controller_Test.php
@@ -28,7 +28,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @after
 	 */
 	public function reset_token_status(): void {
-		tribe( Merchant::class )->delete_token_status();
+		tribe( Merchant::class )->delete_refresh_status();
 	}
 
 	/**
@@ -245,7 +245,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @test
 	 */
 	public function it_should_show_token_invalid_notice_when_square_refused_the_refresh(): void {
-		tribe( Merchant::class )->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Merchant::class )->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
 		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
 	}
@@ -256,20 +256,23 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @test
 	 */
 	public function it_should_show_token_invalid_notice_even_though_the_gateway_is_inactive(): void {
-		tribe( Merchant::class )->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Merchant::class )->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
 		$this->assertFalse( tribe( Gateway::class )->is_active() );
 		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
 	}
 
 	/**
+	 * Saving the Payments tab in this state clears the enabled flag, because the enable toggle renders
+	 * disabled and so submits nothing. The notice has to outlive that or it erases its own instructions.
+	 *
 	 * @test
 	 */
-	public function it_should_not_show_token_invalid_notice_when_gateway_not_enabled(): void {
-		tribe( Merchant::class )->update_token_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+	public function it_should_show_token_invalid_notice_even_though_the_gateway_is_not_enabled(): void {
+		tribe( Merchant::class )->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 		$this->set_class_fn_return( Abstract_Gateway::class, 'is_enabled', false );
 
-		$this->assertFalse( $this->make_controller()->should_display_token_invalid_notice() );
+		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
 	}
 
 	/**
@@ -286,13 +289,27 @@ class Notices_Controller_Test extends Controller_Test_Case {
 		$merchant   = tribe( Merchant::class );
 		$controller = $this->make_controller();
 
+		$merchant->update( [ 'expires_at' => gmdate( 'c', time() + HOUR_IN_SECONDS ) ] );
+
 		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
 
-		$merchant->update_token_status( [ 'failures' => 2 ] );
+		$merchant->update_refresh_status( [ 'failures' => 2 ] );
 		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
 
-		$merchant->update_token_status( [ 'failures' => 3 ] );
+		$merchant->update_refresh_status( [ 'failures' => 3 ] );
 		$this->assertTrue( $controller->should_display_token_refresh_failing_notice() );
+	}
+
+	/**
+	 * Failures far from the expiration have every chance of clearing up on their own, and the notice
+	 * cannot be dismissed, so warning about them would leave a banner up for weeks over nothing.
+	 *
+	 * @test
+	 */
+	public function it_should_not_show_token_refresh_failing_notice_far_from_the_expiration(): void {
+		tribe( Merchant::class )->update_refresh_status( [ 'failures' => 5 ] );
+
+		$this->assertFalse( $this->make_controller()->should_display_token_refresh_failing_notice() );
 	}
 
 	/**
@@ -304,7 +321,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 		$merchant   = tribe( Merchant::class );
 		$controller = $this->make_controller();
 
-		$merchant->update_token_status(
+		$merchant->update_refresh_status(
 			[
 				'failures'   => 5,
 				'invalid_at' => '2026-01-01 00:00:00',

--- a/tests/square_integration/Notices_Controller_Test.php
+++ b/tests/square_integration/Notices_Controller_Test.php
@@ -7,6 +7,7 @@ use TEC\Common\Tests\Provider\Controller_Test_Case;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 use Tribe\Tests\Traits\With_Uopz;
 use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_Gateway;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 
 /**
  * Test class for the Square Notices Controller
@@ -28,7 +29,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @after
 	 */
 	public function reset_token_status(): void {
-		tribe( Merchant::class )->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 	}
 
 	/**
@@ -245,7 +246,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @test
 	 */
 	public function it_should_show_token_invalid_notice_when_square_refused_the_refresh(): void {
-		tribe( Merchant::class )->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
 		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
 	}
@@ -256,7 +257,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @test
 	 */
 	public function it_should_show_token_invalid_notice_even_though_the_gateway_is_inactive(): void {
-		tribe( Merchant::class )->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 
 		$this->assertFalse( tribe( Gateway::class )->is_active() );
 		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
@@ -269,7 +270,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 	 * @test
 	 */
 	public function it_should_show_token_invalid_notice_even_though_the_gateway_is_not_enabled(): void {
-		tribe( Merchant::class )->update_refresh_status( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
+		tribe( Refresh_Status::class )->update( [ 'invalid_at' => '2026-01-01 00:00:00' ] );
 		$this->set_class_fn_return( Abstract_Gateway::class, 'is_enabled', false );
 
 		$this->assertTrue( $this->make_controller()->should_display_token_invalid_notice() );
@@ -293,10 +294,10 @@ class Notices_Controller_Test extends Controller_Test_Case {
 
 		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
 
-		$merchant->update_refresh_status( [ 'failures' => 2 ] );
+		tribe( Refresh_Status::class )->update( [ 'failures' => 2 ] );
 		$this->assertFalse( $controller->should_display_token_refresh_failing_notice() );
 
-		$merchant->update_refresh_status( [ 'failures' => 3 ] );
+		tribe( Refresh_Status::class )->update( [ 'failures' => 3 ] );
 		$this->assertTrue( $controller->should_display_token_refresh_failing_notice() );
 	}
 
@@ -310,7 +311,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 		$merchant = tribe( Merchant::class );
 
 		$merchant->update( [ 'expires_at' => gmdate( 'c', time() + 30 * DAY_IN_SECONDS ) ] );
-		$merchant->update_refresh_status( [ 'failures' => 5 ] );
+		tribe( Refresh_Status::class )->update( [ 'failures' => 5 ] );
 
 		$this->assertFalse( $this->make_controller()->should_display_token_refresh_failing_notice() );
 	}
@@ -324,7 +325,7 @@ class Notices_Controller_Test extends Controller_Test_Case {
 		$merchant   = tribe( Merchant::class );
 		$controller = $this->make_controller();
 
-		$merchant->update_refresh_status(
+		tribe( Refresh_Status::class )->update(
 			[
 				'failures'   => 5,
 				'invalid_at' => '2026-01-01 00:00:00',

--- a/tests/square_integration/Requests_Test.php
+++ b/tests/square_integration/Requests_Test.php
@@ -3,7 +3,6 @@
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use Codeception\TestCase\WPTestCase;
-use WP_Hook;
 
 class Requests_Test extends WPTestCase {
 	/**
@@ -56,13 +55,6 @@ class Requests_Test extends WPTestCase {
 	protected ?array $square_response_override = null;
 
 	/**
-	 * The tribe_log hook as it was before the test replaced it.
-	 *
-	 * @var mixed
-	 */
-	protected $previous_log_hook;
-
-	/**
 	 * The instance the shared filter callback should route to.
 	 *
 	 * WordPress restores $wp_filter after the @fter methods run, which puts an instance callback back
@@ -92,9 +84,9 @@ class Requests_Test extends WPTestCase {
 		self::$current = $this;
 		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
 
-		global $wp_filter;
-		$this->previous_log_hook = $wp_filter['tribe_log'] ?? null;
-		$wp_filter['tribe_log']  = new WP_Hook(); // phpcs:ignore
+		// The suite bootstrap turns any error or warning log into an exception; these tests assert on
+		// failure paths, which log on purpose. Lifted by name so the rest of $wp_filter stays untouched.
+		remove_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10 );
 	}
 
 	/**
@@ -104,15 +96,10 @@ class Requests_Test extends WPTestCase {
 		remove_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10 );
 		self::$current = null;
 
-		global $wp_filter;
-		if ( null === $this->previous_log_hook ) {
-			unset( $wp_filter['tribe_log'] );
-		} else {
-			$wp_filter['tribe_log'] = $this->previous_log_hook; // phpcs:ignore
-		}
+		add_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10, 3 );
 
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_token_status();
+		$merchant->delete_refresh_status();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 		delete_option( 'tec_tickets_commerce_square_token_refresh_lock_' . $merchant->get_mode() );
 		tribe_cache()->reset();
@@ -200,7 +187,7 @@ class Requests_Test extends WPTestCase {
 	 */
 	protected function connect( array $overrides = [] ): Merchant {
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_token_status();
+		$merchant->delete_refresh_status();
 		delete_option( 'tec_tickets_commerce_square_token_refresh_lock_' . $merchant->get_mode() );
 		$merchant->save_signup_data( array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides ) );
 		tribe_cache()->reset();
@@ -268,7 +255,7 @@ class Requests_Test extends WPTestCase {
 	 */
 	public function it_should_not_retry_when_the_refresh_is_refused(): void {
 		$merchant              = $this->connect( $this->not_due() );
-		$this->whodat_code     = 422;
+		$this->whodat_code     = 401;
 		$this->whodat_response = '<!DOCTYPE html><html><head><title>Error</title></head><body></body></html>';
 
 		$response = Requests::get( 'locations' );
@@ -291,6 +278,23 @@ class Requests_Test extends WPTestCase {
 		$this->assertCount( 1, $this->square_calls );
 		$this->assertSame( 0, $this->whodat_calls );
 		$this->assertSame( 'INVALID_REQUEST_ERROR', $response['errors'][0]['category'] );
+	}
+
+	/**
+	 * Square does not always file an expired token under AUTHENTICATION_ERROR, so the code has to be
+	 * enough on its own.
+	 *
+	 * @test
+	 */
+	public function it_should_retry_on_an_expired_token_code_whatever_the_category(): void {
+		$this->connect( $this->not_due() );
+
+		$this->square_response_override = [ 'errors' => [ [ 'category' => 'INVALID_REQUEST_ERROR', 'code' => 'ACCESS_TOKEN_EXPIRED' ] ] ];
+
+		Requests::get( 'locations' );
+
+		$this->assertCount( 2, $this->square_calls );
+		$this->assertSame( 1, $this->whodat_calls );
 	}
 
 	/**

--- a/tests/square_integration/Requests_Test.php
+++ b/tests/square_integration/Requests_Test.php
@@ -28,11 +28,25 @@ class Requests_Test extends WPTestCase {
 	protected string $accepted_token = 'refreshed-access-token';
 
 	/**
+	 * The response code WhoDat answers a refresh with.
+	 *
+	 * @var int
+	 */
+	protected int $whodat_code = 200;
+
+	/**
 	 * The body WhoDat answers a refresh with.
 	 *
 	 * @var mixed
 	 */
 	protected $whodat_response;
+
+	/**
+	 * What the token status endpoint reports about the stored access token.
+	 *
+	 * @var array
+	 */
+	protected array $token_status = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 
 	/**
 	 * The response Square should answer with instead of the default, when set.
@@ -65,6 +79,8 @@ class Requests_Test extends WPTestCase {
 		$this->square_calls    = [];
 		$this->whodat_calls    = 0;
 		$this->accepted_token  = 'refreshed-access-token';
+		$this->whodat_code     = 200;
+		$this->token_status    = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 		$this->whodat_response = [
 			'access_token'  => 'refreshed-access-token',
 			'refresh_token' => 'refreshed-refresh-token',
@@ -125,10 +141,14 @@ class Requests_Test extends WPTestCase {
 	 * @return mixed
 	 */
 	public function answer_request( $pre, $args, $url ) {
+		if ( false !== strpos( $url, 'oauth/token/status' ) ) {
+			return $this->build_response( $this->token_status );
+		}
+
 		if ( false !== strpos( $url, 'whodat' ) ) {
 			++$this->whodat_calls;
 
-			return $this->build_response( $this->whodat_response );
+			return $this->build_response( $this->whodat_response, $this->whodat_code );
 		}
 
 		if ( false === strpos( $url, 'squareup' ) ) {
@@ -163,7 +183,7 @@ class Requests_Test extends WPTestCase {
 	protected function build_response( $body, int $code = 200 ): array {
 		return [
 			'headers'  => [],
-			'body'     => wp_json_encode( $body ),
+			'body'     => is_string( $body ) ? $body : wp_json_encode( $body ),
 			'response' => [
 				'code'    => $code,
 				'message' => 200 === $code ? 'OK' : 'Unauthorized',
@@ -248,7 +268,8 @@ class Requests_Test extends WPTestCase {
 	 */
 	public function it_should_not_retry_when_the_refresh_is_refused(): void {
 		$merchant              = $this->connect( $this->not_due() );
-		$this->whodat_response = [ 'error' => 'invalid_grant' ];
+		$this->whodat_code     = 422;
+		$this->whodat_response = '<!DOCTYPE html><html><head><title>Error</title></head><body></body></html>';
 
 		$response = Requests::get( 'locations' );
 

--- a/tests/square_integration/Requests_Test.php
+++ b/tests/square_integration/Requests_Test.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Gateways\Square;
+
+use Codeception\TestCase\WPTestCase;
+use WP_Hook;
+
+class Requests_Test extends WPTestCase {
+	/**
+	 * The Authorization header of every Square API call made during the test.
+	 *
+	 * @var string[]
+	 */
+	protected array $square_calls = [];
+
+	/**
+	 * How many times WhoDat was asked for a new token.
+	 *
+	 * @var int
+	 */
+	protected int $whodat_calls = 0;
+
+	/**
+	 * The access token Square will accept.
+	 *
+	 * @var string
+	 */
+	protected string $accepted_token = 'refreshed-access-token';
+
+	/**
+	 * The body WhoDat answers a refresh with.
+	 *
+	 * @var mixed
+	 */
+	protected $whodat_response;
+
+	/**
+	 * The response Square should answer with instead of the default, when set.
+	 *
+	 * @var ?array
+	 */
+	protected ?array $square_response_override = null;
+
+	/**
+	 * The tribe_log hook as it was before the test replaced it.
+	 *
+	 * @var mixed
+	 */
+	protected $previous_log_hook;
+
+	/**
+	 * The instance the shared filter callback should route to.
+	 *
+	 * WordPress restores $wp_filter after the @fter methods run, which puts an instance callback back
+	 * once the instance is gone. A static callback keeps a single, stable registration instead.
+	 *
+	 * @var ?self
+	 */
+	protected static $current;
+
+	/**
+	 * @before
+	 */
+	public function intercept_requests(): void {
+		$this->square_calls    = [];
+		$this->whodat_calls    = 0;
+		$this->accepted_token  = 'refreshed-access-token';
+		$this->whodat_response = [
+			'access_token'  => 'refreshed-access-token',
+			'refresh_token' => 'refreshed-refresh-token',
+			'expires_at'    => gmdate( 'Y-m-d\TH:i:s\Z', time() + 30 * DAY_IN_SECONDS ),
+		];
+
+		$this->square_response_override = null;
+
+		self::$current = $this;
+		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
+
+		global $wp_filter;
+		$this->previous_log_hook = $wp_filter['tribe_log'] ?? null;
+		$wp_filter['tribe_log']  = new WP_Hook(); // phpcs:ignore
+	}
+
+	/**
+	 * @after
+	 */
+	public function restore_state(): void {
+		remove_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10 );
+		self::$current = null;
+
+		global $wp_filter;
+		if ( null === $this->previous_log_hook ) {
+			unset( $wp_filter['tribe_log'] );
+		} else {
+			$wp_filter['tribe_log'] = $this->previous_log_hook; // phpcs:ignore
+		}
+
+		$merchant = tribe( Merchant::class );
+		$merchant->delete_token_status();
+		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
+		delete_option( 'tec_tickets_commerce_square_token_refresh_lock_' . $merchant->get_mode() );
+		tribe_cache()->reset();
+	}
+
+	/**
+	 * Stands in for both WhoDat and the Square API.
+	 *
+	 * @param mixed  $pre  The short-circuit value.
+	 * @param array  $args The request arguments.
+	 * @param string $url  The request URL.
+	 *
+	 * @return mixed
+	 */
+	public static function route_request( $pre, $args, $url ) {
+		return self::$current ? self::$current->answer_request( $pre, $args, $url ) : $pre;
+	}
+
+	/**
+	 * Stands in for both WhoDat and the Square API.
+	 *
+	 * @param mixed  $pre  The short-circuit value.
+	 * @param array  $args The request arguments.
+	 * @param string $url  The request URL.
+	 *
+	 * @return mixed
+	 */
+	public function answer_request( $pre, $args, $url ) {
+		if ( false !== strpos( $url, 'whodat' ) ) {
+			++$this->whodat_calls;
+
+			return $this->build_response( $this->whodat_response );
+		}
+
+		if ( false === strpos( $url, 'squareup' ) ) {
+			return $pre;
+		}
+
+		$authorization        = (string) ( $args['headers']['Authorization'] ?? '' );
+		$this->square_calls[] = $authorization;
+
+		if ( null !== $this->square_response_override ) {
+			return $this->build_response( $this->square_response_override, 400 );
+		}
+
+		if ( 'Bearer ' . $this->accepted_token !== $authorization ) {
+			return $this->build_response(
+				[
+					'errors' => [
+						[
+							'category' => 'AUTHENTICATION_ERROR',
+							'code'     => 'UNAUTHORIZED',
+							'detail'   => 'This request could not be authorized.',
+						],
+					],
+				],
+				401
+			);
+		}
+
+		return $this->build_response( [ 'locations' => [ [ 'id' => 'L1', 'name' => 'HQ' ] ] ] );
+	}
+
+	protected function build_response( $body, int $code = 200 ): array {
+		return [
+			'headers'  => [],
+			'body'     => wp_json_encode( $body ),
+			'response' => [
+				'code'    => $code,
+				'message' => 200 === $code ? 'OK' : 'Unauthorized',
+			],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	}
+
+	/**
+	 * Puts the connection into a known state.
+	 *
+	 * @param array $overrides Signup data overrides.
+	 */
+	protected function connect( array $overrides = [] ): Merchant {
+		$merchant = tribe( Merchant::class );
+		$merchant->delete_token_status();
+		delete_option( 'tec_tickets_commerce_square_token_refresh_lock_' . $merchant->get_mode() );
+		$merchant->save_signup_data( array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides ) );
+		tribe_cache()->reset();
+
+		return $merchant;
+	}
+
+	protected function not_due(): array {
+		return [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ];
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_an_expired_token_before_signing_the_request(): void {
+		$merchant = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS ) ] );
+
+		$response = Requests::get( 'locations' );
+
+		$this->assertSame( 1, $this->whodat_calls );
+		$this->assertSame( [ 'Bearer refreshed-access-token' ], $this->square_calls );
+		$this->assertArrayHasKey( 'locations', $response );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+	}
+
+	/**
+	 * Square can reject a token before its recorded expiration, so the 401 has to be handled too.
+	 *
+	 * @test
+	 */
+	public function it_should_retry_once_after_square_rejects_the_token(): void {
+		$merchant = $this->connect( $this->not_due() );
+
+		$response = Requests::get( 'locations' );
+
+		$this->assertSame(
+			[
+				'Bearer ' . tec_tickets_tests_get_fake_merchant_data()['access_token'],
+				'Bearer refreshed-access-token',
+			],
+			$this->square_calls
+		);
+		$this->assertArrayHasKey( 'locations', $response );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+		$this->assertFalse( $merchant->is_token_invalid() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_never_retry_more_than_once(): void {
+		$this->connect( $this->not_due() );
+		// Nothing satisfies Square, so the retry gets rejected too.
+		$this->accepted_token = 'a-token-square-will-never-see';
+
+		$response = Requests::get( 'locations' );
+
+		$this->assertCount( 2, $this->square_calls );
+		$this->assertSame( 1, $this->whodat_calls );
+		$this->assertSame( 'AUTHENTICATION_ERROR', $response['errors'][0]['category'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_retry_when_the_refresh_is_refused(): void {
+		$merchant              = $this->connect( $this->not_due() );
+		$this->whodat_response = [ 'error' => 'invalid_grant' ];
+
+		$response = Requests::get( 'locations' );
+
+		$this->assertCount( 1, $this->square_calls );
+		$this->assertSame( 'AUTHENTICATION_ERROR', $response['errors'][0]['category'] );
+		$this->assertTrue( $merchant->is_token_invalid() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_leave_errors_that_are_not_about_authentication_alone(): void {
+		$this->connect( $this->not_due() );
+
+		$this->square_response_override = [ 'errors' => [ [ 'category' => 'INVALID_REQUEST_ERROR', 'code' => 'BAD_REQUEST' ] ] ];
+
+		$response = Requests::get( 'locations' );
+
+		$this->assertCount( 1, $this->square_calls );
+		$this->assertSame( 0, $this->whodat_calls );
+		$this->assertSame( 'INVALID_REQUEST_ERROR', $response['errors'][0]['category'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_detect_an_unauthorized_raw_response(): void {
+		$merchant = $this->connect( $this->not_due() );
+
+		$response = Requests::get( 'locations', [], [], true );
+
+		$this->assertSame(
+			[
+				'Bearer ' . tec_tickets_tests_get_fake_merchant_data()['access_token'],
+				'Bearer refreshed-access-token',
+			],
+			$this->square_calls
+		);
+		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+	}
+
+	/**
+	 * A rotated token must not be answered from the cache the old one filled.
+	 *
+	 * @test
+	 */
+	public function it_should_key_the_request_cache_by_access_token(): void {
+		$merchant             = $this->connect( $this->not_due() );
+		$this->accepted_token = tec_tickets_tests_get_fake_merchant_data()['access_token'];
+
+		$first = Requests::get_with_cache( 'locations' );
+		$this->assertArrayHasKey( 'locations', $first );
+		$this->assertCount( 1, $this->square_calls );
+
+		// Same token: served from cache.
+		Requests::get_with_cache( 'locations' );
+		$this->assertCount( 1, $this->square_calls );
+
+		// Rotated token: the cache key changes, so Square is asked again.
+		$merchant->save_refreshed_tokens(
+			[
+				'access_token' => 'another-access-token',
+				'expires_at'   => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ),
+			]
+		);
+		$this->accepted_token = 'another-access-token';
+
+		Requests::get_with_cache( 'locations' );
+		$this->assertCount( 2, $this->square_calls );
+		$this->assertSame( 'Bearer another-access-token', end( $this->square_calls ) );
+		$this->assertSame( 0, $this->whodat_calls );
+	}
+}

--- a/tests/square_integration/Requests_Test.php
+++ b/tests/square_integration/Requests_Test.php
@@ -84,8 +84,10 @@ class Requests_Test extends WPTestCase {
 		self::$current = $this;
 		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
 
-		// The suite bootstrap turns any error or warning log into an exception; these tests assert on
-		// failure paths, which log on purpose. Lifted by name so the rest of $wp_filter stays untouched.
+		/**
+		 * The suite bootstrap turns any error or warning log into an exception; these tests assert on
+		 * failure paths, which log on purpose. Lifted by name so the rest of $wp_filter stays untouched.
+		 */
 		remove_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10 );
 	}
 

--- a/tests/square_integration/Requests_Test.php
+++ b/tests/square_integration/Requests_Test.php
@@ -3,6 +3,8 @@
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
+use Tribe__Utils__Array as Arr;
 
 class Requests_Test extends WPTestCase {
 	/**
@@ -101,7 +103,7 @@ class Requests_Test extends WPTestCase {
 		add_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10, 3 );
 
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 		delete_option( 'tec_tickets_commerce_square_token_refresh_lock_' . $merchant->get_mode() );
 		tribe_cache()->reset();
@@ -144,7 +146,7 @@ class Requests_Test extends WPTestCase {
 			return $pre;
 		}
 
-		$authorization        = (string) ( $args['headers']['Authorization'] ?? '' );
+		$authorization        = Arr::get( $args, [ 'headers', 'Authorization' ], '' );
 		$this->square_calls[] = $authorization;
 
 		if ( null !== $this->square_response_override ) {
@@ -189,7 +191,7 @@ class Requests_Test extends WPTestCase {
 	 */
 	protected function connect( array $overrides = [] ): Merchant {
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		delete_option( 'tec_tickets_commerce_square_token_refresh_lock_' . $merchant->get_mode() );
 		$merchant->save_signup_data( array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides ) );
 		tribe_cache()->reset();

--- a/tests/square_integration/Token/Refresh_Lock_Test.php
+++ b/tests/square_integration/Token/Refresh_Lock_Test.php
@@ -3,6 +3,7 @@
 namespace TEC\Tickets\Commerce\Gateways\Square\Token;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Common\StellarWP\DB\DB;
 use TEC\Tickets\Commerce\Gateways\Square\Merchant;
 
 class Refresh_Lock_Test extends WPTestCase {
@@ -86,12 +87,22 @@ class Refresh_Lock_Test extends WPTestCase {
 		$merchant   = tribe( Merchant::class );
 		$option_key = 'tec_tickets_commerce_square_signup_data_' . $merchant->get_mode();
 
-		// Stands in for the process holding the lock committing its refreshed credentials.
-		add_filter(
-			"option_{$option_key}",
-			static function ( $data ) {
-				return array_merge( is_array( $data ) ? $data : [], [ 'access_token' => 'renewed-by-the-winner' ] );
-			}
+		$committed                 = tec_tickets_tests_get_fake_merchant_data();
+		$committed['access_token'] = 'renewed-by-the-winner';
+
+		/*
+		 * Stands in for the process holding the lock committing its refreshed credentials. Written
+		 * straight to the row so this process's object cache stays stale, which is the state a waiter
+		 * is actually in; going through update_option() would prime the cache here and let the wait
+		 * succeed without ever re-reading anything.
+		 */
+		DB::query(
+			DB::prepare(
+				'UPDATE %i SET option_value = %s WHERE option_name = %s',
+				DB::prefix( 'options' ),
+				maybe_serialize( $committed ),
+				$option_key
+			)
 		);
 
 		$this->assertTrue( $this->lock()->wait_for_holder( tec_tickets_tests_get_fake_merchant_data()['access_token'] ) );

--- a/tests/square_integration/Token/Refresh_Lock_Test.php
+++ b/tests/square_integration/Token/Refresh_Lock_Test.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+
+class Refresh_Lock_Test extends WPTestCase {
+	/**
+	 * @after
+	 */
+	public function restore_merchant_data(): void {
+		delete_option( $this->get_lock_key() );
+		tribe( Merchant::class )->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_take_a_free_lock(): void {
+		$this->assertTrue( $this->lock()->acquire() );
+		$this->assertNotEmpty( get_option( $this->get_lock_key() ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_take_a_lock_another_process_holds(): void {
+		add_option( $this->get_lock_key(), time() . ':somebody-else', '', 'no' );
+
+		$this->assertFalse( $this->lock()->acquire() );
+	}
+
+	/**
+	 * A process that died mid-refresh must not hold refreshes off forever.
+	 *
+	 * @test
+	 */
+	public function it_should_take_over_an_abandoned_lock(): void {
+		// Older than Refresh_Lock's 60 second timeout, by enough that a slow run cannot close the gap.
+		add_option( $this->get_lock_key(), ( time() - 300 ) . ':abandoned', '', 'no' );
+
+		$this->assertTrue( $this->lock()->acquire() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_release_a_lock_it_holds(): void {
+		$lock = $this->lock();
+
+		$this->assertTrue( $lock->acquire() );
+
+		$lock->release();
+
+		$this->assertFalse( get_option( $this->get_lock_key() ) );
+	}
+
+	/**
+	 * A process whose lock was taken over must not delete the row the new holder is working under, or a
+	 * third process walks straight in while the second is still mid-refresh.
+	 *
+	 * @test
+	 */
+	public function it_should_not_release_a_lock_it_no_longer_holds(): void {
+		$lock = $this->lock();
+
+		$this->assertTrue( $lock->acquire() );
+
+		// Whoever took over stamped its own value over this process's.
+		$takeover = time() . ':somebody-else';
+		update_option( $this->get_lock_key(), $takeover );
+
+		$lock->release();
+
+		$this->assertSame( $takeover, get_option( $this->get_lock_key() ) );
+	}
+
+	/**
+	 * Under load every concurrent request finds the same expired token. If losing the lock race were an
+	 * immediate failure, one shopper would get the refresh and the rest a failed checkout.
+	 *
+	 * @test
+	 */
+	public function it_should_wait_for_the_lock_holder_to_commit_new_credentials(): void {
+		$merchant   = tribe( Merchant::class );
+		$option_key = 'tec_tickets_commerce_square_signup_data_' . $merchant->get_mode();
+
+		// Stands in for the process holding the lock committing its refreshed credentials.
+		add_filter(
+			"option_{$option_key}",
+			static function ( $data ) {
+				return array_merge( is_array( $data ) ? $data : [], [ 'access_token' => 'renewed-by-the-winner' ] );
+			}
+		);
+
+		$this->assertTrue( $this->lock()->wait_for_holder( tec_tickets_tests_get_fake_merchant_data()['access_token'] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_give_up_waiting_on_a_lock_holder_that_never_finishes(): void {
+		$merchant = tribe( Merchant::class );
+
+		$this->assertFalse( $this->lock()->wait_for_holder( $merchant->get_access_token() ) );
+	}
+
+	protected function get_lock_key(): string {
+		return 'tec_tickets_commerce_square_token_refresh_lock_' . tribe( Merchant::class )->get_mode();
+	}
+
+	protected function lock(): Refresh_Lock {
+		return tribe( Refresh_Lock::class );
+	}
+
+}

--- a/tests/square_integration/Token/Refresh_Status_Test.php
+++ b/tests/square_integration/Token/Refresh_Status_Test.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Token;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Gateways\Square\Merchant;
+
+class Refresh_Status_Test extends WPTestCase {
+	/**
+	 * @after
+	 */
+	public function restore_status(): void {
+		tribe( Refresh_Status::class )->delete();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_report_an_empty_status_for_a_fresh_connection(): void {
+		$status = $this->status()->get();
+
+		$this->assertSame( 0, $status['failures'] );
+		$this->assertSame( '', $status['invalid_at'] );
+		$this->assertFalse( $this->status()->is_invalid() );
+		$this->assertNull( $this->status()->get_last_attempt_timestamp() );
+		$this->assertNull( $this->status()->get_first_failure_timestamp() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_count_consecutive_transient_failures(): void {
+		$status = $this->status();
+
+		$this->assertSame( 1, $status->record_transient_failure() );
+		$this->assertSame( 2, $status->record_transient_failure() );
+		$this->assertSame( 2, $status->get_failure_count() );
+
+		// The run started with the first one, not the latest.
+		$first_failure = $status->get_first_failure_timestamp();
+
+		// Seconds of tolerance, so a slow run between the write and the assertion cannot fail this.
+		$this->assertEqualsWithDelta( time(), $first_failure, 5 );
+
+		$status->record_transient_failure();
+
+		$this->assertSame( $first_failure, $status->get_first_failure_timestamp() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_clear_the_failure_run_on_success(): void {
+		$status = $this->status();
+
+		$status->record_transient_failure();
+		$status->record_permanent_failure( 401 );
+
+		$this->assertTrue( $status->is_invalid() );
+
+		$status->record_success();
+
+		$this->assertFalse( $status->is_invalid() );
+		$this->assertSame( 0, $status->get_failure_count() );
+		$this->assertNull( $status->get_first_failure_timestamp() );
+	}
+
+	/**
+	 * The last attempt is the only throttle a connection with no known expiration has, so a success
+	 * must not clear it along with the failure bookkeeping.
+	 *
+	 * @test
+	 */
+	public function it_should_keep_the_last_attempt_across_a_success(): void {
+		$status = $this->status();
+
+		$status->record_attempt();
+		$recorded = $status->get_last_attempt_timestamp();
+
+		// Seconds of tolerance, as above.
+		$this->assertEqualsWithDelta( time(), $recorded, 5 );
+
+		$status->record_success();
+
+		$this->assertSame( $recorded, $status->get_last_attempt_timestamp() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_read_a_corrupt_stored_status_as_empty(): void {
+		$status = $this->status();
+
+		$status->update( [ 'failures' => 3 ] );
+
+		$this->assertSame( 3, $status->get_failure_count() );
+
+		update_option( $this->stored_option_name(), 'not-an-array' );
+
+		$this->assertSame( 0, $status->get_failure_count() );
+	}
+
+	/**
+	 * The sandbox and live connections fail independently, so neither may read the other's state.
+	 *
+	 * @test
+	 */
+	public function it_should_scope_the_status_to_the_gateway_mode(): void {
+		$merchant = tribe( Merchant::class );
+		$original = $merchant->get_mode();
+		$status   = $this->status();
+
+		try {
+			$merchant->set_mode( 'live' );
+			$status->update( [ 'failures' => 4 ] );
+
+			$merchant->set_mode( 'sandbox' );
+
+			$this->assertSame( 0, $status->get_failure_count() );
+
+			$status->delete();
+			$merchant->set_mode( 'live' );
+
+			$this->assertSame( 4, $status->get_failure_count() );
+		} finally {
+			$status->delete();
+			$merchant->set_mode( $original );
+		}
+	}
+
+	/**
+	 * The only place the stored option name is spelled out, so that a test can seed a value the write
+	 * API cannot produce.
+	 */
+	private function stored_option_name(): string {
+		return 'tec_tickets_commerce_square_token_status_' . tribe( Merchant::class )->get_mode();
+	}
+
+	protected function status(): Refresh_Status {
+		return tribe( Refresh_Status::class );
+	}
+
+}

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -8,7 +8,7 @@ use WP_Hook;
 
 class Token_Refresher_Test extends WPTestCase {
 	/**
-	 * The bodies WhoDat will answer with, one per call.
+	 * The answers WhoDat will give, one per call, each [ code, body ] or a WP_Error.
 	 *
 	 * @var array
 	 */
@@ -20,6 +20,13 @@ class Token_Refresher_Test extends WPTestCase {
 	 * @var array
 	 */
 	protected array $whodat_calls = [];
+
+	/**
+	 * What the token status endpoint reports about the stored access token.
+	 *
+	 * @var array
+	 */
+	protected array $token_status = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 
 	/**
 	 * The tribe_log hook as it was before the test replaced it.
@@ -44,6 +51,7 @@ class Token_Refresher_Test extends WPTestCase {
 	public function intercept_requests(): void {
 		$this->whodat_responses = [];
 		$this->whodat_calls     = [];
+		$this->token_status     = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 
 		self::$current = $this;
 		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
@@ -102,9 +110,22 @@ class Token_Refresher_Test extends WPTestCase {
 			return $pre;
 		}
 
+		if ( false !== strpos( $url, 'oauth/token/status' ) ) {
+			return $this->build_response( 200, $this->token_status );
+		}
+
 		$parsed = [];
 		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $parsed );
-		$this->whodat_calls[] = $parsed;
+
+		$body = $args['body'] ?? [];
+
+		if ( is_string( $body ) ) {
+			$parsed_body = [];
+			parse_str( $body, $parsed_body );
+			$body = $parsed_body;
+		}
+
+		$this->whodat_calls[] = array_merge( $parsed, is_array( $body ) ? $body : [] );
 
 		$response = array_shift( $this->whodat_responses );
 
@@ -112,10 +133,27 @@ class Token_Refresher_Test extends WPTestCase {
 			return $response;
 		}
 
+		[ $code, $payload ] = $response;
+
+		return $this->build_response( $code, $payload );
+	}
+
+	/**
+	 * Builds an HTTP response array.
+	 *
+	 * @param int   $code The response code.
+	 * @param mixed $body The response body; a string is sent through as-is.
+	 *
+	 * @return array
+	 */
+	protected function build_response( int $code, $body ): array {
 		return [
 			'headers'  => [],
-			'body'     => wp_json_encode( $response ),
-			'response' => [ 'code' => 200, 'message' => 'OK' ],
+			'body'     => is_string( $body ) ? $body : wp_json_encode( $body ),
+			'response' => [
+				'code'    => $code,
+				'message' => 200 === $code ? 'OK' : 'Error',
+			],
 			'cookies'  => [],
 			'filename' => null,
 		];
@@ -159,6 +197,26 @@ class Token_Refresher_Test extends WPTestCase {
 		];
 	}
 
+	/**
+	 * A successful refresh answer.
+	 *
+	 * @return array
+	 */
+	protected function refresh_ok(): array {
+		return [ 200, $this->fresh_credentials() ];
+	}
+
+	/**
+	 * The HTML error page the endpoint really answers a rejected refresh token with.
+	 *
+	 * @param int $code The response code.
+	 *
+	 * @return array
+	 */
+	protected function refresh_error_page( int $code ): array {
+		return [ $code, '<!DOCTYPE html><html><head><title>Server Error</title></head><body></body></html>' ];
+	}
+
 	protected function expiring_soon(): array {
 		return [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + HOUR_IN_SECONDS ) ];
 	}
@@ -180,14 +238,15 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_refresh_a_token_that_is_about_to_expire(): void {
 		$merchant                = $this->connect( $this->expiring_soon() );
-		$credentials             = $this->fresh_credentials();
-		$this->whodat_responses[] = $credentials;
+		$credentials              = $this->fresh_credentials();
+		$this->whodat_responses[] = [ 200, $credentials ];
 
 		$this->assertTrue( $this->refresher()->should_refresh() );
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
 
 		$this->assertCount( 1, $this->whodat_calls );
 		$this->assertSame( 'refresh_token', $this->whodat_calls[0]['grant_type'] );
+		$this->assertSame( tribe( Merchant::class )->get_mode(), $this->whodat_calls[0]['mode'] );
 		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $this->whodat_calls[0]['refresh_token'] );
 
 		$this->assertSame( $credentials['access_token'], $merchant->get_access_token() );
@@ -202,7 +261,7 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_refresh_a_token_that_has_already_expired(): void {
 		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - DAY_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
 		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
@@ -213,7 +272,7 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_refresh_a_connection_with_no_recorded_expiration(): void {
 		$merchant                 = $this->connect( [], [ 'expires_at' ] );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
 		$this->assertCount( 1, $this->whodat_calls );
@@ -225,8 +284,8 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_throttle_a_connection_with_no_recorded_expiration(): void {
 		$this->connect( [], [ 'expires_at' ] );
-		// A response with neither credentials nor a recognised error is treated as a blip.
-		$this->whodat_responses[] = [];
+		// A 200 that carries no credentials is treated as a blip.
+		$this->whodat_responses[] = [ 200, [] ];
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 		$this->assertCount( 1, $this->whodat_calls );
@@ -247,19 +306,23 @@ class Token_Refresher_Test extends WPTestCase {
 	}
 
 	/**
+	 * The endpoint answers a rejected refresh token with an HTML 500, so the only way to tell a rejection
+	 * from an outage is to ask Square whether it still accepts the stored token.
+	 *
 	 * @test
 	 */
-	public function it_should_mark_the_connection_unavailable_when_square_refuses_the_refresh(): void {
+	public function it_should_mark_the_connection_unavailable_when_the_token_is_also_rejected(): void {
 		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = [
-			'error'             => 'invalid_grant',
-			'error_description' => 'Authorization code is expired.',
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = [
+			'type'    => 'UNAUTHORIZED',
+			'message' => 'This request could not be authorized.',
 		];
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 
 		$this->assertTrue( $merchant->is_token_invalid() );
-		$this->assertSame( 'invalid_grant', $merchant->get_token_status()['error'] );
+		$this->assertSame( '500', $merchant->get_token_status()['error'] );
 		$this->assertFalse( $merchant->is_connected() );
 
 		// The credentials stay put so support can still see what is stored.
@@ -270,19 +333,30 @@ class Token_Refresher_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
-	public function it_should_treat_a_square_authentication_error_body_as_unrecoverable(): void {
+	public function it_should_mark_the_connection_unavailable_when_the_request_is_turned_down(): void {
 		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = [
-			'errors' => [
-				[
-					'category' => 'AUTHENTICATION_ERROR',
-					'code'     => 'UNAUTHORIZED',
-				],
-			],
-		];
+		$this->whodat_responses[] = $this->refresh_error_page( 422 );
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
 		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertFalse( $merchant->is_connected() );
+	}
+
+	/**
+	 * A failing refresh while Square still honours the token is a blip, not a disconnection.
+	 *
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_while_the_token_still_works(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 1, (int) $merchant->get_token_status()['failures'] );
 	}
 
 	/**
@@ -301,18 +375,14 @@ class Token_Refresher_Test extends WPTestCase {
 	}
 
 	/**
+	 * A transport failure says nothing about the credentials, even when the token is also unreachable.
+	 *
 	 * @test
 	 */
-	public function it_should_not_mark_the_connection_unavailable_on_a_square_server_error(): void {
+	public function it_should_not_mark_the_connection_unavailable_when_nothing_can_be_reached(): void {
 		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = [
-			'errors' => [
-				[
-					'category' => 'API_ERROR',
-					'code'     => 'INTERNAL_SERVER_ERROR',
-				],
-			],
-		];
+		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
+		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 		$this->assertFalse( $merchant->is_token_invalid() );
@@ -324,7 +394,7 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_back_off_after_a_transient_failure(): void {
 		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
 
 		$this->refresher()->refresh_if_needed();
 		$this->assertCount( 1, $this->whodat_calls );
@@ -334,7 +404,7 @@ class Token_Refresher_Test extends WPTestCase {
 
 		// Move the attempt far enough into the past for the backoff to lapse.
 		$merchant->update_token_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
 		$this->assertCount( 2, $this->whodat_calls );
@@ -359,7 +429,7 @@ class Token_Refresher_Test extends WPTestCase {
 	public function it_should_not_refresh_while_another_process_holds_the_lock(): void {
 		$this->connect( $this->expiring_soon() );
 		add_option( $this->get_lock_key(), (string) time(), '', 'no' );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 		$this->assertCount( 0, $this->whodat_calls );
@@ -373,7 +443,7 @@ class Token_Refresher_Test extends WPTestCase {
 	public function it_should_take_over_an_abandoned_lock(): void {
 		$this->connect( $this->expiring_soon() );
 		add_option( $this->get_lock_key(), (string) ( time() - 300 ), '', 'no' );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
 		$this->assertCount( 1, $this->whodat_calls );
@@ -384,13 +454,13 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_release_the_lock_whatever_the_outcome(): void {
 		$this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->refresher()->refresh_if_needed();
 		$this->assertFalse( get_option( $this->get_lock_key() ) );
 
 		$this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = [ 'error' => 'invalid_grant' ];
+		$this->whodat_responses[] = $this->refresh_error_page( 422 );
 
 		$this->refresher()->refresh_if_needed();
 		$this->assertFalse( get_option( $this->get_lock_key() ) );
@@ -401,7 +471,7 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_refresh_on_demand_regardless_of_the_expiration(): void {
 		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->fresh_credentials();
+		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertFalse( $this->refresher()->should_refresh() );
 		$this->assertTrue( $this->refresher()->refresh_now( 'square_unauthorized' ) );

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Gateways\Square;
+
+use Codeception\TestCase\WPTestCase;
+use WP_Error;
+use WP_Hook;
+
+class Token_Refresher_Test extends WPTestCase {
+	/**
+	 * The bodies WhoDat will answer with, one per call.
+	 *
+	 * @var array
+	 */
+	protected array $whodat_responses = [];
+
+	/**
+	 * The query args WhoDat was called with, one entry per call.
+	 *
+	 * @var array
+	 */
+	protected array $whodat_calls = [];
+
+	/**
+	 * The tribe_log hook as it was before the test replaced it.
+	 *
+	 * @var mixed
+	 */
+	protected $previous_log_hook;
+
+	/**
+	 * The instance the shared filter callback should route to.
+	 *
+	 * WordPress restores $wp_filter after the @\after methods run, which puts an instance callback back
+	 * once the instance is gone. A static callback keeps a single, stable registration instead.
+	 *
+	 * @var ?self
+	 */
+	protected static $current;
+
+	/**
+	 * @before
+	 */
+	public function intercept_requests(): void {
+		$this->whodat_responses = [];
+		$this->whodat_calls     = [];
+
+		self::$current = $this;
+		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
+
+		// The suite bootstrap turns any error or warning log into an exception; these tests assert on
+		// failure paths, which log on purpose.
+		global $wp_filter;
+		$this->previous_log_hook = $wp_filter['tribe_log'] ?? null;
+		$wp_filter['tribe_log']  = new WP_Hook(); // phpcs:ignore
+	}
+
+	/**
+	 * @after
+	 */
+	public function restore_state(): void {
+		remove_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10 );
+		self::$current = null;
+
+		global $wp_filter;
+		if ( null === $this->previous_log_hook ) {
+			unset( $wp_filter['tribe_log'] );
+		} else {
+			$wp_filter['tribe_log'] = $this->previous_log_hook; // phpcs:ignore
+		}
+
+		$merchant = tribe( Merchant::class );
+		$merchant->delete_token_status();
+		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
+		delete_option( $this->get_lock_key() );
+	}
+
+	/**
+	 * Answers WhoDat calls from the queued responses.
+	 *
+	 * @param mixed  $pre  The short-circuit value.
+	 * @param array  $args The request arguments.
+	 * @param string $url  The request URL.
+	 *
+	 * @return mixed
+	 */
+	public static function route_request( $pre, $args, $url ) {
+		return self::$current ? self::$current->answer_whodat( $pre, $args, $url ) : $pre;
+	}
+
+	/**
+	 * Answers WhoDat calls from the queued responses.
+	 *
+	 * @param mixed  $pre  The short-circuit value.
+	 * @param array  $args The request arguments.
+	 * @param string $url  The request URL.
+	 *
+	 * @return mixed
+	 */
+	public function answer_whodat( $pre, $args, $url ) {
+		if ( false === strpos( $url, 'whodat' ) ) {
+			return $pre;
+		}
+
+		$parsed = [];
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $parsed );
+		$this->whodat_calls[] = $parsed;
+
+		$response = array_shift( $this->whodat_responses );
+
+		if ( $response instanceof WP_Error ) {
+			return $response;
+		}
+
+		return [
+			'headers'  => [],
+			'body'     => wp_json_encode( $response ),
+			'response' => [ 'code' => 200, 'message' => 'OK' ],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	}
+
+	protected function get_lock_key(): string {
+		return 'tec_tickets_commerce_square_token_refresh_lock_' . tribe( Merchant::class )->get_mode();
+	}
+
+	protected function refresher(): Token_Refresher {
+		return tribe( Token_Refresher::class );
+	}
+
+	/**
+	 * Puts the connection into a known state.
+	 *
+	 * @param array    $overrides Signup data overrides.
+	 * @param string[] $remove    Signup data keys to drop.
+	 */
+	protected function connect( array $overrides = [], array $remove = [] ): Merchant {
+		$merchant = tribe( Merchant::class );
+		$merchant->delete_token_status();
+		delete_option( $this->get_lock_key() );
+
+		$data = array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides );
+
+		foreach ( $remove as $key ) {
+			unset( $data[ $key ] );
+		}
+
+		$merchant->save_signup_data( $data );
+
+		return $merchant;
+	}
+
+	protected function fresh_credentials(): array {
+		return [
+			'access_token'  => 'refreshed-access-token',
+			'refresh_token' => 'refreshed-refresh-token',
+			'expires_at'    => gmdate( 'Y-m-d\TH:i:s\Z', time() + 30 * DAY_IN_SECONDS ),
+		];
+	}
+
+	protected function expiring_soon(): array {
+		return [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + HOUR_IN_SECONDS ) ];
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_refresh_a_token_that_is_not_due(): void {
+		$merchant = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
+
+		$this->assertFalse( $this->refresher()->should_refresh() );
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 0, $this->whodat_calls );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_a_token_that_is_about_to_expire(): void {
+		$merchant                = $this->connect( $this->expiring_soon() );
+		$credentials             = $this->fresh_credentials();
+		$this->whodat_responses[] = $credentials;
+
+		$this->assertTrue( $this->refresher()->should_refresh() );
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertSame( 'refresh_token', $this->whodat_calls[0]['grant_type'] );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $this->whodat_calls[0]['refresh_token'] );
+
+		$this->assertSame( $credentials['access_token'], $merchant->get_access_token() );
+		$this->assertSame( $credentials['refresh_token'], $merchant->get_refresh_token() );
+		$this->assertSame( $credentials['expires_at'], get_option( $merchant->get_signup_data_key() )['expires_at'] );
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertSame( 0, (int) $merchant->get_token_status()['failures'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_a_token_that_has_already_expired(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - DAY_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_a_connection_with_no_recorded_expiration(): void {
+		$merchant                 = $this->connect( [], [ 'expires_at' ] );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertNotNull( $merchant->get_token_expiration() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_throttle_a_connection_with_no_recorded_expiration(): void {
+		$this->connect( [], [ 'expires_at' ] );
+		// A response with neither credentials nor a recognised error is treated as a blip.
+		$this->whodat_responses[] = [];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_refresh_without_a_refresh_token(): void {
+		$this->connect( array_merge( $this->expiring_soon(), [ 'refresh_token' => '' ] ) );
+
+		$this->assertFalse( $this->refresher()->should_refresh() );
+		$this->assertFalse( $this->refresher()->refresh_now() );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_mark_the_connection_unavailable_when_square_refuses_the_refresh(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = [
+			'error'             => 'invalid_grant',
+			'error_description' => 'Authorization code is expired.',
+		];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertSame( 'invalid_grant', $merchant->get_token_status()['error'] );
+		$this->assertFalse( $merchant->is_connected() );
+
+		// The credentials stay put so support can still see what is stored.
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $merchant->get_refresh_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_treat_a_square_authentication_error_body_as_unrecoverable(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = [
+			'errors' => [
+				[
+					'category' => 'AUTHENTICATION_ERROR',
+					'code'     => 'UNAUTHORIZED',
+				],
+			],
+		];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertTrue( $merchant->is_token_invalid() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_on_a_transport_failure(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 1, (int) $merchant->get_token_status()['failures'] );
+		$this->assertNotEmpty( $merchant->get_token_status()['last_attempt_at'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_on_a_square_server_error(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = [
+			'errors' => [
+				[
+					'category' => 'API_ERROR',
+					'code'     => 'INTERNAL_SERVER_ERROR',
+				],
+			],
+		];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_back_off_after_a_transient_failure(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+
+		// Move the attempt far enough into the past for the backoff to lapse.
+		$merchant->update_token_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 2, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_retry_once_the_connection_is_marked_unavailable(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		$merchant->update_token_status( [ 'invalid_at' => gmdate( 'Y-m-d H:i:s' ) ] );
+
+		$this->assertFalse( $this->refresher()->should_refresh() );
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertFalse( $this->refresher()->refresh_now() );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_refresh_while_another_process_holds_the_lock(): void {
+		$this->connect( $this->expiring_soon() );
+		add_option( $this->get_lock_key(), (string) time(), '', 'no' );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * A process that died mid-refresh must not hold refreshes off forever.
+	 *
+	 * @test
+	 */
+	public function it_should_take_over_an_abandoned_lock(): void {
+		$this->connect( $this->expiring_soon() );
+		add_option( $this->get_lock_key(), (string) ( time() - 300 ), '', 'no' );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_release_the_lock_whatever_the_outcome(): void {
+		$this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertFalse( get_option( $this->get_lock_key() ) );
+
+		$this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = [ 'error' => 'invalid_grant' ];
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertFalse( get_option( $this->get_lock_key() ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_on_demand_regardless_of_the_expiration(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->fresh_credentials();
+
+		$this->assertFalse( $this->refresher()->should_refresh() );
+		$this->assertTrue( $this->refresher()->refresh_now( 'square_unauthorized' ) );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+	}
+}

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -459,26 +459,32 @@ class Token_Refresher_Test extends WPTestCase {
 	 * @param string $timezone The site timezone to run under.
 	 */
 	public function it_should_back_off_whatever_the_site_timezone( string $timezone ): void {
-		update_option( 'timezone_string', $timezone );
+		$original_timezone = get_option( 'timezone_string' );
 
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		try {
+			update_option( 'timezone_string', $timezone );
 
-		$this->refresher()->refresh_if_needed();
-		$this->assertCount( 1, $this->whodat_calls );
+			$merchant                 = $this->connect( $this->expiring_soon() );
+			$this->whodat_responses[] = $this->refresh_error_page( 500 );
 
-		// The invariant the intervals rest on: what was written reads back as now, not as now +/- offset.
-		$this->assertEqualsWithDelta( time(), strtotime( $merchant->get_refresh_status()['last_attempt_at'] ), 5 );
+			$this->refresher()->refresh_if_needed();
+			$this->assertCount( 1, $this->whodat_calls );
 
-		// Well inside the first backoff step, so nothing may go out.
-		$this->refresher()->refresh_if_needed();
-		$this->assertCount( 1, $this->whodat_calls );
+			// The invariant the intervals rest on: what was written reads back as now, not as now +/- offset.
+			$this->assertEqualsWithDelta( time(), strtotime( $merchant->get_refresh_status()['last_attempt_at'] ), 5 );
 
-		$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_ok();
+			// Well inside the first backoff step, so nothing may go out.
+			$this->refresher()->refresh_if_needed();
+			$this->assertCount( 1, $this->whodat_calls );
 
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 2, $this->whodat_calls );
+			$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ] );
+			$this->whodat_responses[] = $this->refresh_ok();
+
+			$this->assertTrue( $this->refresher()->refresh_if_needed() );
+			$this->assertCount( 2, $this->whodat_calls );
+		} finally {
+			update_option( 'timezone_string', $original_timezone );
+		}
 	}
 
 	/**
@@ -690,11 +696,12 @@ class Token_Refresher_Test extends WPTestCase {
 		$this->assertTrue( $refresher->take_lock() );
 
 		// Whoever took over stamped its own value over this process's.
-		update_option( $this->get_lock_key(), time() . ':somebody-else' );
+		$takeover_time = time();
+		update_option( $this->get_lock_key(), $takeover_time . ':somebody-else' );
 
 		$refresher->give_lock_back();
 
-		$this->assertSame( time() . ':somebody-else', get_option( $this->get_lock_key() ) );
+		$this->assertSame( $takeover_time . ':somebody-else', get_option( $this->get_lock_key() ) );
 	}
 
 	/**

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -23,7 +23,7 @@ class Token_Refresher_Test extends WPTestCase {
 	/**
 	 * What the token status endpoint reports about the stored access token, decoded or as a raw body.
 	 *
-	 * @var mixed
+	 * @var array|string
 	 */
 	protected $token_status = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -4,7 +4,6 @@ namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use Codeception\TestCase\WPTestCase;
 use WP_Error;
-use WP_Hook;
 
 class Token_Refresher_Test extends WPTestCase {
 	/**
@@ -29,13 +28,6 @@ class Token_Refresher_Test extends WPTestCase {
 	protected array $token_status = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 
 	/**
-	 * The tribe_log hook as it was before the test replaced it.
-	 *
-	 * @var mixed
-	 */
-	protected $previous_log_hook;
-
-	/**
 	 * The instance the shared filter callback should route to.
 	 *
 	 * WordPress restores $wp_filter after the @\after methods run, which puts an instance callback back
@@ -57,10 +49,8 @@ class Token_Refresher_Test extends WPTestCase {
 		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
 
 		// The suite bootstrap turns any error or warning log into an exception; these tests assert on
-		// failure paths, which log on purpose.
-		global $wp_filter;
-		$this->previous_log_hook = $wp_filter['tribe_log'] ?? null;
-		$wp_filter['tribe_log']  = new WP_Hook(); // phpcs:ignore
+		// failure paths, which log on purpose. Lifted by name so the rest of $wp_filter stays untouched.
+		remove_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10 );
 	}
 
 	/**
@@ -70,15 +60,10 @@ class Token_Refresher_Test extends WPTestCase {
 		remove_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10 );
 		self::$current = null;
 
-		global $wp_filter;
-		if ( null === $this->previous_log_hook ) {
-			unset( $wp_filter['tribe_log'] );
-		} else {
-			$wp_filter['tribe_log'] = $this->previous_log_hook; // phpcs:ignore
-		}
+		add_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10, 3 );
 
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_token_status();
+		$merchant->delete_refresh_status();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 		delete_option( $this->get_lock_key() );
 	}
@@ -125,7 +110,11 @@ class Token_Refresher_Test extends WPTestCase {
 			$body = $parsed_body;
 		}
 
-		$this->whodat_calls[] = array_merge( $parsed, is_array( $body ) ? $body : [] );
+		$this->whodat_calls[] = array_merge(
+			$parsed,
+			is_array( $body ) ? $body : [],
+			[ '_method' => $args['method'] ?? '' ]
+		);
 
 		$response = array_shift( $this->whodat_responses );
 
@@ -175,7 +164,7 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	protected function connect( array $overrides = [], array $remove = [] ): Merchant {
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_token_status();
+		$merchant->delete_refresh_status();
 		delete_option( $this->get_lock_key() );
 
 		$data = array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides );
@@ -253,7 +242,7 @@ class Token_Refresher_Test extends WPTestCase {
 		$this->assertSame( $credentials['refresh_token'], $merchant->get_refresh_token() );
 		$this->assertSame( $credentials['expires_at'], get_option( $merchant->get_signup_data_key() )['expires_at'] );
 		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertSame( 0, (int) $merchant->get_token_status()['failures'] );
+		$this->assertSame( 0, (int) $merchant->get_refresh_status()['failures'] );
 	}
 
 	/**
@@ -322,7 +311,7 @@ class Token_Refresher_Test extends WPTestCase {
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 
 		$this->assertTrue( $merchant->is_token_invalid() );
-		$this->assertSame( '500', $merchant->get_token_status()['error'] );
+		$this->assertSame( '500', $merchant->get_refresh_status()['error'] );
 		$this->assertFalse( $merchant->is_connected() );
 
 		// The credentials stay put so support can still see what is stored.
@@ -335,7 +324,63 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	public function it_should_mark_the_connection_unavailable_when_the_request_is_turned_down(): void {
 		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 422 );
+		$this->whodat_responses[] = $this->refresh_error_page( 401 );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertFalse( $merchant->is_connected() );
+	}
+
+	/**
+	 * A rate limit says nothing about the credentials, and the endpoint answers a genuine rejection with
+	 * a 500 anyway. Disconnecting on a 429 would take out every site behind the same limiter at once.
+	 *
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_on_a_rate_limit(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 429 );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 1, $merchant->get_refresh_failure_count() );
+	}
+
+	/**
+	 * The status endpoint reports on the access token, which has expired by definition on this path, so
+	 * it says UNAUTHORIZED whether the grant is gone or WhoDat is merely down. Only failures that keep
+	 * repeating over more than a day settle it.
+	 *
+	 * @test
+	 */
+	public function it_should_not_disconnect_an_expired_token_on_a_single_outage(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_disconnect_an_expired_token_once_the_failures_persist(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
+
+		$merchant->update_refresh_status(
+			[
+				'failures'         => 5,
+				'first_failure_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+			]
+		);
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 
@@ -356,7 +401,7 @@ class Token_Refresher_Test extends WPTestCase {
 
 		$this->assertFalse( $merchant->is_token_invalid() );
 		$this->assertTrue( $merchant->is_connected() );
-		$this->assertSame( 1, (int) $merchant->get_token_status()['failures'] );
+		$this->assertSame( 1, (int) $merchant->get_refresh_status()['failures'] );
 	}
 
 	/**
@@ -370,8 +415,8 @@ class Token_Refresher_Test extends WPTestCase {
 
 		$this->assertFalse( $merchant->is_token_invalid() );
 		$this->assertTrue( $merchant->is_connected() );
-		$this->assertSame( 1, (int) $merchant->get_token_status()['failures'] );
-		$this->assertNotEmpty( $merchant->get_token_status()['last_attempt_at'] );
+		$this->assertSame( 1, (int) $merchant->get_refresh_status()['failures'] );
+		$this->assertNotEmpty( $merchant->get_refresh_status()['last_attempt_at'] );
 	}
 
 	/**
@@ -390,6 +435,105 @@ class Token_Refresher_Test extends WPTestCase {
 	}
 
 	/**
+	 * The endpoint answers 405 to a GET, so this is not a detail of how the request is built.
+	 *
+	 * @test
+	 */
+	public function it_should_send_the_refresh_as_a_post(): void {
+		$this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->refresher()->refresh_if_needed();
+
+		$this->assertSame( 'POST', $this->whodat_calls[0]['_method'] );
+	}
+
+	/**
+	 * The timestamps are written by the refresher and read back with strtotime(), which WordPress pins
+	 * to UTC. Building them in the site timezone instead skews every interval by the site's offset:
+	 * west of UTC the backoff never engages, east of it a single blip suppresses refreshes for a day.
+	 *
+	 * @test
+	 * @dataProvider timezone_provider
+	 *
+	 * @param string $timezone The site timezone to run under.
+	 */
+	public function it_should_back_off_whatever_the_site_timezone( string $timezone ): void {
+		update_option( 'timezone_string', $timezone );
+
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+
+		// The invariant the intervals rest on: what was written reads back as now, not as now +/- offset.
+		$this->assertEqualsWithDelta( time(), strtotime( $merchant->get_refresh_status()['last_attempt_at'] ), 5 );
+
+		// Well inside the first backoff step, so nothing may go out.
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 2, $this->whodat_calls );
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public function timezone_provider(): array {
+		return [
+			'UTC'               => [ 'UTC' ],
+			'west of UTC'       => [ 'America/Los_Angeles' ],
+			'east of UTC'       => [ 'Pacific/Auckland' ],
+			'half hour offset'  => [ 'Asia/Kolkata' ],
+		];
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_count_every_consecutive_failure(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+
+		foreach ( range( 1, 3 ) as $attempt ) {
+			$this->whodat_responses[] = $this->refresh_error_page( 500 );
+			$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
+
+			$this->refresher()->refresh_if_needed();
+
+			$this->assertSame( $attempt, $merchant->get_refresh_failure_count() );
+		}
+
+		// The window the persistence check measures starts at the first failure, not the latest.
+		$this->assertNotEmpty( $merchant->get_refresh_status()['first_failure_at'] );
+	}
+
+	/**
+	 * A response with no usable expiration leaves the connection in the "unknown expiration" state. If a
+	 * success also wiped the attempt timestamp, that state would refresh once per Square API call.
+	 *
+	 * @test
+	 */
+	public function it_should_not_refresh_repeatedly_when_the_response_carries_no_expiration(): void {
+		$this->connect( $this->expiring_soon() );
+
+		$credentials = $this->fresh_credentials();
+		unset( $credentials['expires_at'] );
+		$this->whodat_responses[] = [ 200, $credentials ];
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->assertFalse( $this->refresher()->should_refresh() );
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_back_off_after_a_transient_failure(): void {
@@ -403,7 +547,7 @@ class Token_Refresher_Test extends WPTestCase {
 		$this->assertCount( 1, $this->whodat_calls );
 
 		// Move the attempt far enough into the past for the backoff to lapse.
-		$merchant->update_token_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
+		$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
 		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
@@ -413,14 +557,47 @@ class Token_Refresher_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
-	public function it_should_not_retry_once_the_connection_is_marked_unavailable(): void {
+	public function it_should_not_retry_a_rejected_connection_straight_away(): void {
 		$merchant = $this->connect( $this->expiring_soon() );
-		$merchant->update_token_status( [ 'invalid_at' => gmdate( 'Y-m-d H:i:s' ) ] );
+		$merchant->update_refresh_status(
+			[
+				'invalid_at'      => gmdate( 'Y-m-d H:i:s' ),
+				'last_attempt_at' => gmdate( 'Y-m-d H:i:s' ),
+			]
+		);
 
 		$this->assertFalse( $this->refresher()->should_refresh() );
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 		$this->assertFalse( $this->refresher()->refresh_now() );
 		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * Being marked unavailable has to be reversible without database surgery: the verdict can be wrong,
+	 * and a merchant can re-authorize on Square's side without ever touching WordPress.
+	 *
+	 * @test
+	 */
+	public function it_should_recheck_a_rejected_connection_and_recover(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		$merchant->update_refresh_status(
+			[
+				'invalid_at'      => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+				'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+				'failures'        => 6,
+			]
+		);
+
+		$this->assertFalse( $merchant->is_connected() );
+
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 0, $merchant->get_refresh_failure_count() );
 	}
 
 	/**
@@ -436,17 +613,88 @@ class Token_Refresher_Test extends WPTestCase {
 	}
 
 	/**
+	 * Under load every concurrent request finds the same expired token. If losing the lock race were an
+	 * immediate failure, one shopper would get the refresh and the rest a failed checkout.
+	 *
+	 * @test
+	 */
+	public function it_should_wait_for_the_lock_holder_before_failing_a_forced_refresh(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		$waiter   = new class( $merchant, tribe( WhoDat::class ) ) extends Token_Refresher {
+			public function wait( string $previous_token ): bool {
+				return $this->wait_for_lock_holder( $previous_token );
+			}
+		};
+
+		$option_key = 'tec_tickets_commerce_square_signup_data_' . $merchant->get_mode();
+
+		// Stands in for the process holding the lock committing its refreshed credentials.
+		add_filter(
+			"option_{$option_key}",
+			static function ( $data ) {
+				return array_merge( (array) $data, [ 'access_token' => 'renewed-by-the-winner' ] );
+			}
+		);
+
+		$this->assertTrue( $waiter->wait( tec_tickets_tests_get_fake_merchant_data()['access_token'] ) );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_give_up_waiting_on_a_lock_holder_that_never_finishes(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		$waiter   = new class( $merchant, tribe( WhoDat::class ) ) extends Token_Refresher {
+			public function wait( string $previous_token ): bool {
+				return $this->wait_for_lock_holder( $previous_token );
+			}
+		};
+
+		$this->assertFalse( $waiter->wait( $merchant->get_access_token() ) );
+	}
+
+	/**
 	 * A process that died mid-refresh must not hold refreshes off forever.
 	 *
 	 * @test
 	 */
 	public function it_should_take_over_an_abandoned_lock(): void {
 		$this->connect( $this->expiring_soon() );
-		add_option( $this->get_lock_key(), (string) ( time() - 300 ), '', 'no' );
+		add_option( $this->get_lock_key(), ( time() - 300 ) . ':abandoned', '', 'no' );
 		$this->whodat_responses[] = $this->refresh_ok();
 
 		$this->assertTrue( $this->refresher()->refresh_if_needed() );
 		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
+	 * A process whose lock was taken over must not delete the row the new holder is working under, or a
+	 * third process walks straight in while the second is still mid-refresh.
+	 *
+	 * @test
+	 */
+	public function it_should_not_release_a_lock_it_no_longer_holds(): void {
+		$this->connect( $this->expiring_soon() );
+
+		$refresher = new class( tribe( Merchant::class ), tribe( WhoDat::class ) ) extends Token_Refresher {
+			public function take_lock(): bool {
+				return $this->create_lock();
+			}
+
+			public function give_lock_back(): void {
+				$this->release_lock();
+			}
+		};
+
+		$this->assertTrue( $refresher->take_lock() );
+
+		// Whoever took over stamped its own value over this process's.
+		update_option( $this->get_lock_key(), time() . ':somebody-else' );
+
+		$refresher->give_lock_back();
+
+		$this->assertSame( time() . ':somebody-else', get_option( $this->get_lock_key() ) );
 	}
 
 	/**
@@ -456,7 +704,8 @@ class Token_Refresher_Test extends WPTestCase {
 		$this->connect( $this->expiring_soon() );
 		$this->whodat_responses[] = $this->refresh_ok();
 
-		$this->refresher()->refresh_if_needed();
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
 		$this->assertFalse( get_option( $this->get_lock_key() ) );
 
 		$this->connect( $this->expiring_soon() );

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -21,11 +21,11 @@ class Token_Refresher_Test extends WPTestCase {
 	protected array $whodat_calls = [];
 
 	/**
-	 * What the token status endpoint reports about the stored access token.
+	 * What the token status endpoint reports about the stored access token, decoded or as a raw body.
 	 *
-	 * @var array
+	 * @var mixed
 	 */
-	protected array $token_status = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
+	protected $token_status = [ 'scopes' => [ 'PAYMENTS_WRITE' ] ];
 
 	/**
 	 * The instance the shared filter callback should route to.
@@ -360,6 +360,25 @@ class Token_Refresher_Test extends WPTestCase {
 		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
 		$this->whodat_responses[] = $this->refresh_error_page( 500 );
 		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * A JSON scalar decodes to a scalar, and the status reader is typed to an array. Reading one has to
+	 * come back as unknown rather than throw or count as a refusal.
+	 *
+	 * @test
+	 */
+	public function it_should_read_a_scalar_status_body_as_unknown(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = '"UNAUTHORIZED"';
+
+		$this->assertNull( tribe( WhoDat::class )->is_token_accepted( true ) );
 
 		$this->assertFalse( $this->refresher()->refresh_if_needed() );
 

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -546,6 +546,39 @@ class Token_Refresher_Test extends WPTestCase {
 	}
 
 	/**
+	 * @test
+	 */
+	public function it_should_retry_a_rejected_connection_on_an_explicit_recheck(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		$this->reject_connection();
+
+		$this->assertTrue( $this->policy()->is_backing_off() );
+		$this->assertFalse( $merchant->is_connected() );
+		$this->assertCount( 0, $this->whodat_calls );
+
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $merchant->is_connected( true ) );
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertSame( $this->fresh_credentials()['access_token'], $merchant->get_access_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_keep_a_rejected_connection_rejected_when_the_recheck_fails(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		$this->reject_connection();
+
+		$this->whodat_responses[] = $this->refresh_error_page( 401 );
+
+		$this->assertFalse( $merchant->is_connected( true ) );
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertTrue( $merchant->is_token_invalid() );
+	}
+
+	/**
 	 * Answers WhoDat calls from the queued responses.
 	 *
 	 * @param mixed  $pre  The short-circuit value.
@@ -623,6 +656,20 @@ class Token_Refresher_Test extends WPTestCase {
 			'cookies'  => [],
 			'filename' => null,
 		];
+	}
+
+	/**
+	 * Puts the connection in the state a refusal Square just handed back leaves it in.
+	 */
+	protected function reject_connection(): void {
+		$now = gmdate( 'Y-m-d H:i:s' );
+
+		tribe( Refresh_Status::class )->update(
+			[
+				'invalid_at'      => $now,
+				'last_attempt_at' => $now,
+			]
+		);
 	}
 
 	protected function get_lock_key(): string {

--- a/tests/square_integration/Token_Refresher_Test.php
+++ b/tests/square_integration/Token_Refresher_Test.php
@@ -3,6 +3,8 @@
 namespace TEC\Tickets\Commerce\Gateways\Square;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Policy;
+use TEC\Tickets\Commerce\Gateways\Square\Token\Refresh_Status;
 use WP_Error;
 
 class Token_Refresher_Test extends WPTestCase {
@@ -48,8 +50,10 @@ class Token_Refresher_Test extends WPTestCase {
 		self::$current = $this;
 		add_filter( 'pre_http_request', [ __CLASS__, 'route_request' ], 10, 3 );
 
-		// The suite bootstrap turns any error or warning log into an exception; these tests assert on
-		// failure paths, which log on purpose. Lifted by name so the rest of $wp_filter stays untouched.
+		/*
+		 * The suite bootstrap turns any error or warning log into an exception; these tests assert on
+		 * failure paths, which log on purpose. Lifted by name so the rest of $wp_filter stays untouched.
+		 */
 		remove_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10 );
 	}
 
@@ -63,9 +67,482 @@ class Token_Refresher_Test extends WPTestCase {
 		add_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10, 3 );
 
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		$merchant->save_signup_data( tec_tickets_tests_get_fake_merchant_data() );
 		delete_option( $this->get_lock_key() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_refresh_a_token_that_is_not_due(): void {
+		$merchant = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
+
+		$this->assertFalse( $this->policy()->should_refresh() );
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 0, $this->whodat_calls );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_a_token_that_is_about_to_expire(): void {
+		$merchant                = $this->connect( $this->expiring_soon() );
+		$credentials              = $this->fresh_credentials();
+		$this->whodat_responses[] = [ 200, $credentials ];
+
+		$this->assertTrue( $this->policy()->should_refresh() );
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertSame( 'refresh_token', $this->whodat_calls[0]['grant_type'] );
+		$this->assertSame( tribe( Merchant::class )->get_mode(), $this->whodat_calls[0]['mode'] );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $this->whodat_calls[0]['refresh_token'] );
+
+		$this->assertSame( $credentials['access_token'], $merchant->get_access_token() );
+		$this->assertSame( $credentials['refresh_token'], $merchant->get_refresh_token() );
+		$this->assertSame( $credentials['expires_at'], get_option( $merchant->get_signup_data_key() )['expires_at'] );
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertSame( 0, tribe( Refresh_Status::class )->get_failure_count() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_a_token_that_has_already_expired(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - DAY_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_a_connection_with_no_recorded_expiration(): void {
+		$merchant                 = $this->connect( [], [ 'expires_at' ] );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertNotNull( $merchant->get_token_expiration() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_throttle_a_connection_with_no_recorded_expiration(): void {
+		$this->connect( [], [ 'expires_at' ] );
+		// A 200 that carries no credentials is treated as a blip.
+		$this->whodat_responses[] = [ 200, [] ];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_refresh_without_a_refresh_token(): void {
+		$this->connect( array_merge( $this->expiring_soon(), [ 'refresh_token' => '' ] ) );
+
+		$this->assertFalse( $this->policy()->should_refresh() );
+		$this->assertFalse( $this->refresher()->refresh_now() );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * The endpoint answers a rejected refresh token with an HTML 500, so the only way to tell a rejection
+	 * from an outage is to ask Square whether it still accepts the stored token.
+	 *
+	 * @test
+	 */
+	public function it_should_mark_the_connection_unavailable_when_the_token_is_also_rejected(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = [
+			'type'    => 'UNAUTHORIZED',
+			'message' => 'This request could not be authorized.',
+		];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertSame( 500, tribe( Refresh_Status::class )->get()['error'] );
+		$this->assertFalse( $merchant->is_connected() );
+
+		// The credentials stay put so support can still see what is stored.
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
+		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $merchant->get_refresh_token() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_mark_the_connection_unavailable_when_the_request_is_turned_down(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 401 );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertFalse( $merchant->is_connected() );
+	}
+
+	/**
+	 * A rate limit says nothing about the credentials, and the endpoint answers a genuine rejection with
+	 * a 500 anyway. Disconnecting on a 429 would take out every site behind the same limiter at once.
+	 *
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_on_a_rate_limit(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 429 );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 1, tribe( Refresh_Status::class )->get_failure_count() );
+	}
+
+	/**
+	 * The status endpoint reports on the access token, which has expired by definition on this path, so
+	 * it says UNAUTHORIZED whether the grant is gone or WhoDat is merely down. Only failures that keep
+	 * repeating over more than a day settle it.
+	 *
+	 * @test
+	 */
+	public function it_should_not_disconnect_an_expired_token_on_a_single_outage(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * A JSON scalar decodes to a scalar, and the status reader is typed to an array. Reading one has to
+	 * come back as unknown rather than throw or count as a refusal.
+	 *
+	 * @test
+	 */
+	public function it_should_read_a_scalar_status_body_as_unknown(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = '"UNAUTHORIZED"';
+
+		$who_dat = tribe( WhoDat::class );
+
+		$this->assertNull( $who_dat->interpret_token_status( $who_dat->get_fresh_token_status() ) );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_disconnect_an_expired_token_once_the_failures_persist(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
+
+		tribe( Refresh_Status::class )->update(
+			[
+				'failures'         => 5,
+				'first_failure_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+			]
+		);
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertTrue( $merchant->is_token_invalid() );
+		$this->assertFalse( $merchant->is_connected() );
+	}
+
+	/**
+	 * A failing refresh while Square still honours the token is a blip, not a disconnection.
+	 *
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_while_the_token_still_works(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 1, tribe( Refresh_Status::class )->get_failure_count() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_on_a_transport_failure(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 1, tribe( Refresh_Status::class )->get_failure_count() );
+		$this->assertNotEmpty( tribe( Refresh_Status::class )->get()['last_attempt_at'] );
+	}
+
+	/**
+	 * A transport failure says nothing about the credentials, even when the token is also unreachable.
+	 *
+	 * @test
+	 */
+	public function it_should_not_mark_the_connection_unavailable_when_nothing_can_be_reached(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
+		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+	}
+
+	/**
+	 * The endpoint answers 405 to a GET, so this is not a detail of how the request is built.
+	 *
+	 * @test
+	 */
+	public function it_should_send_the_refresh_as_a_post(): void {
+		$this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->refresher()->refresh_if_needed();
+
+		$this->assertSame( 'POST', $this->whodat_calls[0]['_method'] );
+	}
+
+	/**
+	 * The timestamps are written by the refresher and read back with strtotime(), which WordPress pins
+	 * to UTC. Building them in the site timezone instead skews every interval by the site's offset:
+	 * west of UTC the backoff never engages, east of it a single blip suppresses refreshes for a day.
+	 *
+	 * @test
+	 * @dataProvider timezone_provider
+	 *
+	 * @param string $timezone The site timezone to run under.
+	 */
+	public function it_should_back_off_whatever_the_site_timezone( string $timezone ): void {
+		$original_timezone = get_option( 'timezone_string' );
+
+		try {
+			update_option( 'timezone_string', $timezone );
+
+			$merchant                 = $this->connect( $this->expiring_soon() );
+			$this->whodat_responses[] = $this->refresh_error_page( 500 );
+
+			$this->refresher()->refresh_if_needed();
+			$this->assertCount( 1, $this->whodat_calls );
+
+			// The invariant the intervals rest on: what was written reads back as now, not as now +/- offset.
+			$this->assertEqualsWithDelta( time(), strtotime( tribe( Refresh_Status::class )->get()['last_attempt_at'] ), 5 );
+
+			// Well inside the first backoff step, so nothing may go out.
+			$this->refresher()->refresh_if_needed();
+			$this->assertCount( 1, $this->whodat_calls );
+
+			tribe( Refresh_Status::class )->update( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ] );
+			$this->whodat_responses[] = $this->refresh_ok();
+
+			$this->assertTrue( $this->refresher()->refresh_if_needed() );
+			$this->assertCount( 2, $this->whodat_calls );
+		} finally {
+			update_option( 'timezone_string', $original_timezone );
+		}
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public function timezone_provider(): array {
+		return [
+			'UTC'               => [ 'UTC' ],
+			'west of UTC'       => [ 'America/Los_Angeles' ],
+			'east of UTC'       => [ 'Pacific/Auckland' ],
+			'half hour offset'  => [ 'Asia/Kolkata' ],
+		];
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_count_every_consecutive_failure(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+
+		foreach ( range( 1, 3 ) as $attempt ) {
+			$this->whodat_responses[] = $this->refresh_error_page( 500 );
+			tribe( Refresh_Status::class )->update( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
+
+			$this->refresher()->refresh_if_needed();
+
+			$this->assertSame( $attempt, tribe( Refresh_Status::class )->get_failure_count() );
+		}
+
+		// The window the persistence check measures starts at the first failure, not the latest.
+		$this->assertNotEmpty( tribe( Refresh_Status::class )->get()['first_failure_at'] );
+	}
+
+	/**
+	 * A response with no usable expiration leaves the connection in the "unknown expiration" state. If a
+	 * success also wiped the attempt timestamp, that state would refresh once per Square API call.
+	 *
+	 * @test
+	 */
+	public function it_should_not_refresh_repeatedly_when_the_response_carries_no_expiration(): void {
+		$this->connect( $this->expiring_soon() );
+
+		$credentials = $this->fresh_credentials();
+		unset( $credentials['expires_at'] );
+		$this->whodat_responses[] = [ 200, $credentials ];
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->assertFalse( $this->policy()->should_refresh() );
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_back_off_after_a_transient_failure(): void {
+		$merchant                 = $this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 500 );
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertCount( 1, $this->whodat_calls );
+
+		// Move the attempt far enough into the past for the backoff to lapse.
+		tribe( Refresh_Status::class )->update( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 2, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_retry_a_rejected_connection_straight_away(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		tribe( Refresh_Status::class )->update(
+			[
+				'invalid_at'      => gmdate( 'Y-m-d H:i:s' ),
+				'last_attempt_at' => gmdate( 'Y-m-d H:i:s' ),
+			]
+		);
+
+		$this->assertFalse( $this->policy()->should_refresh() );
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertFalse( $this->refresher()->refresh_now() );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * Being marked unavailable has to be reversible without database surgery: the verdict can be wrong,
+	 * and a merchant can re-authorize on Square's side without ever touching WordPress.
+	 *
+	 * @test
+	 */
+	public function it_should_recheck_a_rejected_connection_and_recover(): void {
+		$merchant = $this->connect( $this->expiring_soon() );
+		tribe( Refresh_Status::class )->update(
+			[
+				'invalid_at'      => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+				'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
+				'failures'        => 6,
+			]
+		);
+
+		$this->assertFalse( $merchant->is_connected() );
+
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+
+		$this->assertFalse( $merchant->is_token_invalid() );
+		$this->assertTrue( $merchant->is_connected() );
+		$this->assertSame( 0, tribe( Refresh_Status::class )->get_failure_count() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_refresh_while_another_process_holds_the_lock(): void {
+		$this->connect( $this->expiring_soon() );
+		add_option( $this->get_lock_key(), time() . ':held-by-somebody-else', '', 'no' );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertFalse( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 0, $this->whodat_calls );
+	}
+
+	/**
+	 * A process that died mid-refresh must not hold refreshes off forever.
+	 *
+	 * @test
+	 */
+	public function it_should_take_over_an_abandoned_lock(): void {
+		$this->connect( $this->expiring_soon() );
+		add_option( $this->get_lock_key(), ( time() - 300 ) . ':abandoned', '', 'no' );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_release_the_lock_whatever_the_outcome(): void {
+		$this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertTrue( $this->refresher()->refresh_if_needed() );
+		$this->assertCount( 1, $this->whodat_calls );
+		$this->assertFalse( get_option( $this->get_lock_key() ) );
+
+		$this->connect( $this->expiring_soon() );
+		$this->whodat_responses[] = $this->refresh_error_page( 422 );
+
+		$this->refresher()->refresh_if_needed();
+		$this->assertFalse( get_option( $this->get_lock_key() ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_refresh_on_demand_regardless_of_the_expiration(): void {
+		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
+		$this->whodat_responses[] = $this->refresh_ok();
+
+		$this->assertFalse( $this->policy()->should_refresh() );
+		$this->assertTrue( $this->refresher()->refresh_now( 'square_unauthorized' ) );
+		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
 	}
 
 	/**
@@ -100,7 +577,7 @@ class Token_Refresher_Test extends WPTestCase {
 		}
 
 		$parsed = [];
-		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $parsed );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ) ?: '', $parsed );
 
 		$body = $args['body'] ?? [];
 
@@ -156,6 +633,10 @@ class Token_Refresher_Test extends WPTestCase {
 		return tribe( Token_Refresher::class );
 	}
 
+	protected function policy(): Refresh_Policy {
+		return tribe( Refresh_Policy::class );
+	}
+
 	/**
 	 * Puts the connection into a known state.
 	 *
@@ -164,7 +645,7 @@ class Token_Refresher_Test extends WPTestCase {
 	 */
 	protected function connect( array $overrides = [], array $remove = [] ): Merchant {
 		$merchant = tribe( Merchant::class );
-		$merchant->delete_refresh_status();
+		tribe( Refresh_Status::class )->delete();
 		delete_option( $this->get_lock_key() );
 
 		$data = array_merge( tec_tickets_tests_get_fake_merchant_data(), $overrides );
@@ -210,546 +691,4 @@ class Token_Refresher_Test extends WPTestCase {
 		return [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + HOUR_IN_SECONDS ) ];
 	}
 
-	/**
-	 * @test
-	 */
-	public function it_should_not_refresh_a_token_that_is_not_due(): void {
-		$merchant = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
-
-		$this->assertFalse( $this->refresher()->should_refresh() );
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 0, $this->whodat_calls );
-		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_refresh_a_token_that_is_about_to_expire(): void {
-		$merchant                = $this->connect( $this->expiring_soon() );
-		$credentials              = $this->fresh_credentials();
-		$this->whodat_responses[] = [ 200, $credentials ];
-
-		$this->assertTrue( $this->refresher()->should_refresh() );
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-
-		$this->assertCount( 1, $this->whodat_calls );
-		$this->assertSame( 'refresh_token', $this->whodat_calls[0]['grant_type'] );
-		$this->assertSame( tribe( Merchant::class )->get_mode(), $this->whodat_calls[0]['mode'] );
-		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $this->whodat_calls[0]['refresh_token'] );
-
-		$this->assertSame( $credentials['access_token'], $merchant->get_access_token() );
-		$this->assertSame( $credentials['refresh_token'], $merchant->get_refresh_token() );
-		$this->assertSame( $credentials['expires_at'], get_option( $merchant->get_signup_data_key() )['expires_at'] );
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertSame( 0, (int) $merchant->get_refresh_status()['failures'] );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_refresh_a_token_that_has_already_expired(): void {
-		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - DAY_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_refresh_a_connection_with_no_recorded_expiration(): void {
-		$merchant                 = $this->connect( [], [ 'expires_at' ] );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-		$this->assertNotNull( $merchant->get_token_expiration() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_throttle_a_connection_with_no_recorded_expiration(): void {
-		$this->connect( [], [ 'expires_at' ] );
-		// A 200 that carries no credentials is treated as a blip.
-		$this->whodat_responses[] = [ 200, [] ];
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_not_refresh_without_a_refresh_token(): void {
-		$this->connect( array_merge( $this->expiring_soon(), [ 'refresh_token' => '' ] ) );
-
-		$this->assertFalse( $this->refresher()->should_refresh() );
-		$this->assertFalse( $this->refresher()->refresh_now() );
-		$this->assertCount( 0, $this->whodat_calls );
-	}
-
-	/**
-	 * The endpoint answers a rejected refresh token with an HTML 500, so the only way to tell a rejection
-	 * from an outage is to ask Square whether it still accepts the stored token.
-	 *
-	 * @test
-	 */
-	public function it_should_mark_the_connection_unavailable_when_the_token_is_also_rejected(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
-		$this->token_status       = [
-			'type'    => 'UNAUTHORIZED',
-			'message' => 'This request could not be authorized.',
-		];
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertTrue( $merchant->is_token_invalid() );
-		$this->assertSame( '500', $merchant->get_refresh_status()['error'] );
-		$this->assertFalse( $merchant->is_connected() );
-
-		// The credentials stay put so support can still see what is stored.
-		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['access_token'], $merchant->get_access_token() );
-		$this->assertSame( tec_tickets_tests_get_fake_merchant_data()['refresh_token'], $merchant->get_refresh_token() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_mark_the_connection_unavailable_when_the_request_is_turned_down(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 401 );
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertTrue( $merchant->is_token_invalid() );
-		$this->assertFalse( $merchant->is_connected() );
-	}
-
-	/**
-	 * A rate limit says nothing about the credentials, and the endpoint answers a genuine rejection with
-	 * a 500 anyway. Disconnecting on a 429 would take out every site behind the same limiter at once.
-	 *
-	 * @test
-	 */
-	public function it_should_not_mark_the_connection_unavailable_on_a_rate_limit(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 429 );
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-		$this->assertSame( 1, $merchant->get_refresh_failure_count() );
-	}
-
-	/**
-	 * The status endpoint reports on the access token, which has expired by definition on this path, so
-	 * it says UNAUTHORIZED whether the grant is gone or WhoDat is merely down. Only failures that keep
-	 * repeating over more than a day settle it.
-	 *
-	 * @test
-	 */
-	public function it_should_not_disconnect_an_expired_token_on_a_single_outage(): void {
-		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
-		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-	}
-
-	/**
-	 * A JSON scalar decodes to a scalar, and the status reader is typed to an array. Reading one has to
-	 * come back as unknown rather than throw or count as a refusal.
-	 *
-	 * @test
-	 */
-	public function it_should_read_a_scalar_status_body_as_unknown(): void {
-		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
-		$this->token_status       = '"UNAUTHORIZED"';
-
-		$this->assertNull( tribe( WhoDat::class )->is_token_accepted( true ) );
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_disconnect_an_expired_token_once_the_failures_persist(): void {
-		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'c', time() - HOUR_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
-		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
-
-		$merchant->update_refresh_status(
-			[
-				'failures'         => 5,
-				'first_failure_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
-			]
-		);
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertTrue( $merchant->is_token_invalid() );
-		$this->assertFalse( $merchant->is_connected() );
-	}
-
-	/**
-	 * A failing refresh while Square still honours the token is a blip, not a disconnection.
-	 *
-	 * @test
-	 */
-	public function it_should_not_mark_the_connection_unavailable_while_the_token_still_works(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-		$this->assertSame( 1, (int) $merchant->get_refresh_status()['failures'] );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_not_mark_the_connection_unavailable_on_a_transport_failure(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-		$this->assertSame( 1, (int) $merchant->get_refresh_status()['failures'] );
-		$this->assertNotEmpty( $merchant->get_refresh_status()['last_attempt_at'] );
-	}
-
-	/**
-	 * A transport failure says nothing about the credentials, even when the token is also unreachable.
-	 *
-	 * @test
-	 */
-	public function it_should_not_mark_the_connection_unavailable_when_nothing_can_be_reached(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = new WP_Error( 'http_request_failed', 'Connection timed out' );
-		$this->token_status       = [ 'type' => 'UNAUTHORIZED' ];
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-	}
-
-	/**
-	 * The endpoint answers 405 to a GET, so this is not a detail of how the request is built.
-	 *
-	 * @test
-	 */
-	public function it_should_send_the_refresh_as_a_post(): void {
-		$this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->refresher()->refresh_if_needed();
-
-		$this->assertSame( 'POST', $this->whodat_calls[0]['_method'] );
-	}
-
-	/**
-	 * The timestamps are written by the refresher and read back with strtotime(), which WordPress pins
-	 * to UTC. Building them in the site timezone instead skews every interval by the site's offset:
-	 * west of UTC the backoff never engages, east of it a single blip suppresses refreshes for a day.
-	 *
-	 * @test
-	 * @dataProvider timezone_provider
-	 *
-	 * @param string $timezone The site timezone to run under.
-	 */
-	public function it_should_back_off_whatever_the_site_timezone( string $timezone ): void {
-		$original_timezone = get_option( 'timezone_string' );
-
-		try {
-			update_option( 'timezone_string', $timezone );
-
-			$merchant                 = $this->connect( $this->expiring_soon() );
-			$this->whodat_responses[] = $this->refresh_error_page( 500 );
-
-			$this->refresher()->refresh_if_needed();
-			$this->assertCount( 1, $this->whodat_calls );
-
-			// The invariant the intervals rest on: what was written reads back as now, not as now +/- offset.
-			$this->assertEqualsWithDelta( time(), strtotime( $merchant->get_refresh_status()['last_attempt_at'] ), 5 );
-
-			// Well inside the first backoff step, so nothing may go out.
-			$this->refresher()->refresh_if_needed();
-			$this->assertCount( 1, $this->whodat_calls );
-
-			$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ] );
-			$this->whodat_responses[] = $this->refresh_ok();
-
-			$this->assertTrue( $this->refresher()->refresh_if_needed() );
-			$this->assertCount( 2, $this->whodat_calls );
-		} finally {
-			update_option( 'timezone_string', $original_timezone );
-		}
-	}
-
-	/**
-	 * @return array<string, string[]>
-	 */
-	public function timezone_provider(): array {
-		return [
-			'UTC'               => [ 'UTC' ],
-			'west of UTC'       => [ 'America/Los_Angeles' ],
-			'east of UTC'       => [ 'Pacific/Auckland' ],
-			'half hour offset'  => [ 'Asia/Kolkata' ],
-		];
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_count_every_consecutive_failure(): void {
-		$merchant = $this->connect( $this->expiring_soon() );
-
-		foreach ( range( 1, 3 ) as $attempt ) {
-			$this->whodat_responses[] = $this->refresh_error_page( 500 );
-			$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
-
-			$this->refresher()->refresh_if_needed();
-
-			$this->assertSame( $attempt, $merchant->get_refresh_failure_count() );
-		}
-
-		// The window the persistence check measures starts at the first failure, not the latest.
-		$this->assertNotEmpty( $merchant->get_refresh_status()['first_failure_at'] );
-	}
-
-	/**
-	 * A response with no usable expiration leaves the connection in the "unknown expiration" state. If a
-	 * success also wiped the attempt timestamp, that state would refresh once per Square API call.
-	 *
-	 * @test
-	 */
-	public function it_should_not_refresh_repeatedly_when_the_response_carries_no_expiration(): void {
-		$this->connect( $this->expiring_soon() );
-
-		$credentials = $this->fresh_credentials();
-		unset( $credentials['expires_at'] );
-		$this->whodat_responses[] = [ 200, $credentials ];
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-
-		$this->assertFalse( $this->refresher()->should_refresh() );
-		$this->refresher()->refresh_if_needed();
-		$this->assertCount( 1, $this->whodat_calls );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_back_off_after_a_transient_failure(): void {
-		$merchant                 = $this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 500 );
-
-		$this->refresher()->refresh_if_needed();
-		$this->assertCount( 1, $this->whodat_calls );
-
-		$this->refresher()->refresh_if_needed();
-		$this->assertCount( 1, $this->whodat_calls );
-
-		// Move the attempt far enough into the past for the backoff to lapse.
-		$merchant->update_refresh_status( [ 'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 2, $this->whodat_calls );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_not_retry_a_rejected_connection_straight_away(): void {
-		$merchant = $this->connect( $this->expiring_soon() );
-		$merchant->update_refresh_status(
-			[
-				'invalid_at'      => gmdate( 'Y-m-d H:i:s' ),
-				'last_attempt_at' => gmdate( 'Y-m-d H:i:s' ),
-			]
-		);
-
-		$this->assertFalse( $this->refresher()->should_refresh() );
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-		$this->assertFalse( $this->refresher()->refresh_now() );
-		$this->assertCount( 0, $this->whodat_calls );
-	}
-
-	/**
-	 * Being marked unavailable has to be reversible without database surgery: the verdict can be wrong,
-	 * and a merchant can re-authorize on Square's side without ever touching WordPress.
-	 *
-	 * @test
-	 */
-	public function it_should_recheck_a_rejected_connection_and_recover(): void {
-		$merchant = $this->connect( $this->expiring_soon() );
-		$merchant->update_refresh_status(
-			[
-				'invalid_at'      => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
-				'last_attempt_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ),
-				'failures'        => 6,
-			]
-		);
-
-		$this->assertFalse( $merchant->is_connected() );
-
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-
-		$this->assertFalse( $merchant->is_token_invalid() );
-		$this->assertTrue( $merchant->is_connected() );
-		$this->assertSame( 0, $merchant->get_refresh_failure_count() );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_not_refresh_while_another_process_holds_the_lock(): void {
-		$this->connect( $this->expiring_soon() );
-		add_option( $this->get_lock_key(), (string) time(), '', 'no' );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertFalse( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 0, $this->whodat_calls );
-	}
-
-	/**
-	 * Under load every concurrent request finds the same expired token. If losing the lock race were an
-	 * immediate failure, one shopper would get the refresh and the rest a failed checkout.
-	 *
-	 * @test
-	 */
-	public function it_should_wait_for_the_lock_holder_before_failing_a_forced_refresh(): void {
-		$merchant = $this->connect( $this->expiring_soon() );
-		$waiter   = new class( $merchant, tribe( WhoDat::class ) ) extends Token_Refresher {
-			public function wait( string $previous_token ): bool {
-				return $this->wait_for_lock_holder( $previous_token );
-			}
-		};
-
-		$option_key = 'tec_tickets_commerce_square_signup_data_' . $merchant->get_mode();
-
-		// Stands in for the process holding the lock committing its refreshed credentials.
-		add_filter(
-			"option_{$option_key}",
-			static function ( $data ) {
-				return array_merge( (array) $data, [ 'access_token' => 'renewed-by-the-winner' ] );
-			}
-		);
-
-		$this->assertTrue( $waiter->wait( tec_tickets_tests_get_fake_merchant_data()['access_token'] ) );
-		$this->assertCount( 0, $this->whodat_calls );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_give_up_waiting_on_a_lock_holder_that_never_finishes(): void {
-		$merchant = $this->connect( $this->expiring_soon() );
-		$waiter   = new class( $merchant, tribe( WhoDat::class ) ) extends Token_Refresher {
-			public function wait( string $previous_token ): bool {
-				return $this->wait_for_lock_holder( $previous_token );
-			}
-		};
-
-		$this->assertFalse( $waiter->wait( $merchant->get_access_token() ) );
-	}
-
-	/**
-	 * A process that died mid-refresh must not hold refreshes off forever.
-	 *
-	 * @test
-	 */
-	public function it_should_take_over_an_abandoned_lock(): void {
-		$this->connect( $this->expiring_soon() );
-		add_option( $this->get_lock_key(), ( time() - 300 ) . ':abandoned', '', 'no' );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-	}
-
-	/**
-	 * A process whose lock was taken over must not delete the row the new holder is working under, or a
-	 * third process walks straight in while the second is still mid-refresh.
-	 *
-	 * @test
-	 */
-	public function it_should_not_release_a_lock_it_no_longer_holds(): void {
-		$this->connect( $this->expiring_soon() );
-
-		$refresher = new class( tribe( Merchant::class ), tribe( WhoDat::class ) ) extends Token_Refresher {
-			public function take_lock(): bool {
-				return $this->create_lock();
-			}
-
-			public function give_lock_back(): void {
-				$this->release_lock();
-			}
-		};
-
-		$this->assertTrue( $refresher->take_lock() );
-
-		// Whoever took over stamped its own value over this process's.
-		$takeover_time = time();
-		update_option( $this->get_lock_key(), $takeover_time . ':somebody-else' );
-
-		$refresher->give_lock_back();
-
-		$this->assertSame( $takeover_time . ':somebody-else', get_option( $this->get_lock_key() ) );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_release_the_lock_whatever_the_outcome(): void {
-		$this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertTrue( $this->refresher()->refresh_if_needed() );
-		$this->assertCount( 1, $this->whodat_calls );
-		$this->assertFalse( get_option( $this->get_lock_key() ) );
-
-		$this->connect( $this->expiring_soon() );
-		$this->whodat_responses[] = $this->refresh_error_page( 422 );
-
-		$this->refresher()->refresh_if_needed();
-		$this->assertFalse( get_option( $this->get_lock_key() ) );
-	}
-
-	/**
-	 * @test
-	 */
-	public function it_should_refresh_on_demand_regardless_of_the_expiration(): void {
-		$merchant                 = $this->connect( [ 'expires_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() + 25 * DAY_IN_SECONDS ) ] );
-		$this->whodat_responses[] = $this->refresh_ok();
-
-		$this->assertFalse( $this->refresher()->should_refresh() );
-		$this->assertTrue( $this->refresher()->refresh_now( 'square_unauthorized' ) );
-		$this->assertSame( 'refreshed-access-token', $merchant->get_access_token() );
-	}
 }

--- a/tests/square_integration/__snapshots__/Notices_Controller_Test__it_should_render_token_invalid_notice__0.snapshot.html
+++ b/tests/square_integration/__snapshots__/Notices_Controller_Test__it_should_render_token_invalid_notice__0.snapshot.html
@@ -1,0 +1,1 @@
+<p><strong>Square connection expired</strong></p><p>Square would not renew the credentials for this site, so ticket sales through Square are paused. Reconnect your Square account to start selling again.</p><p><a href="http://wordpress.test/wp-admin/admin.php?page=tec-tickets-settings&#038;tab=square" class="button button-primary">Reconnect Square</a></p>

--- a/tests/square_integration/__snapshots__/Notices_Controller_Test__it_should_render_token_refresh_failing_notice__0.snapshot.html
+++ b/tests/square_integration/__snapshots__/Notices_Controller_Test__it_should_render_token_refresh_failing_notice__0.snapshot.html
@@ -1,0 +1,1 @@
+<p><strong>Square connection could not be renewed</strong></p><p>The last few attempts to renew your Square credentials did not go through. Ticket sales through Square still work for now, but they will stop once the current credentials expire.</p>

--- a/tests/square_integration/_bootstrap.php
+++ b/tests/square_integration/_bootstrap.php
@@ -60,14 +60,18 @@ tribe_update_option( Webhooks::OPTION_WEBHOOK, $webhook );
 // Enable pretty permalinks.
 update_option( 'permalink_structure', '/%postname%/' );
 
-// When we have logs of level error, critical, warning, throw an exception.
-add_action( 'tribe_log', static function ( $level, $message, $context ) {
+// When we have logs of level error, critical, warning, throw an exception. Kept in a global so that the
+// tests asserting on failure paths can lift it by name: emptying $wp_filter['tribe_log'] instead risks
+// being caught in WordPress's one-time hook snapshot, which would silently disarm this for a whole run.
+$GLOBALS['tec_tickets_square_log_guard'] = static function ( $level, $message, $context ) {
 	if ( ! in_array( $level, [ 'error', 'critical', 'warning' ], true ) ) {
 		return;
 	}
 
 	throw new RuntimeException( 'Triggered log: ' . $message . ' with context: ' . wp_json_encode( $context, JSON_SNAPSHOT_OPTIONS ) );
-} );
+};
+
+add_action( 'tribe_log', $GLOBALS['tec_tickets_square_log_guard'], 10, 3 );
 
 tec_tickets_tests_enable_gateway_id_generation();
 

--- a/tests/square_integration/_bootstrap.php
+++ b/tests/square_integration/_bootstrap.php
@@ -40,6 +40,9 @@ function tec_tickets_tests_get_fake_merchant_data(): array {
 		'merchant_country'  => 'US',
 		'merchant_currency' => 'USD',
 		'whodat_signature'  => 'whodat-signature',
+		// Fixed, not relative: this function is re-called inside assertions. Far enough out that no
+		// suite drifts into the token refresh window and starts making outbound requests.
+		'expires_at'        => '2099-01-01T00:00:00Z',
 	];
 }
 

--- a/tests/square_integration/_bootstrap.php
+++ b/tests/square_integration/_bootstrap.php
@@ -40,8 +40,10 @@ function tec_tickets_tests_get_fake_merchant_data(): array {
 		'merchant_country'  => 'US',
 		'merchant_currency' => 'USD',
 		'whodat_signature'  => 'whodat-signature',
-		// Fixed, not relative: this function is re-called inside assertions. Far enough out that no
-		// suite drifts into the token refresh window and starts making outbound requests.
+		/**
+		 * Fixed, not relative: this function is re-called inside assertions. Far enough out that no
+		 * suite drifts into the token refresh window and starts making outbound requests.
+		 */
 		'expires_at'        => '2099-01-01T00:00:00Z',
 	];
 }
@@ -60,9 +62,11 @@ tribe_update_option( Webhooks::OPTION_WEBHOOK, $webhook );
 // Enable pretty permalinks.
 update_option( 'permalink_structure', '/%postname%/' );
 
-// When we have logs of level error, critical, warning, throw an exception. Kept in a global so that the
-// tests asserting on failure paths can lift it by name: emptying $wp_filter['tribe_log'] instead risks
-// being caught in WordPress's one-time hook snapshot, which would silently disarm this for a whole run.
+/**
+ * When we have logs of level error, critical, warning, throw an exception. Kept in a global so that the
+ * tests asserting on failure paths can lift it by name: emptying $wp_filter['tribe_log'] instead risks
+ * being caught in WordPress's one-time hook snapshot, which would silently disarm this for a whole run.
+ */
 $GLOBALS['tec_tickets_square_log_guard'] = static function ( $level, $message, $context ) {
 	if ( ! in_array( $level, [ 'error', 'critical', 'warning' ], true ) ) {
 		return;


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1468]

### 🗒️ Description


Square access tokens expire about 30 days after they are minted, and nothing renewed them. Checkout started failing at Square's authorization layer while the admin still reported the gateway as connected, and the only recovery was disconnect and reconnect. `WhoDat::refresh_token()` already existed with zero callers, and the `expires_at` the OAuth callback stores was never read.

**The fix.** `Square\Requests::request()` renews the token before signing a request whose expiration is due, and retries once when Square rejects it anyway. That path was chosen over a scheduled action because it still runs on a site whose cron queue is stalled, which is where the reports come from.

**What only surfaced against the live service.** Running this against WhoDat with a Square sandbox account turned up two things:

- The refresh endpoint answers `GET` with **405 Method Not Allowed** and only accepts `POST`. The existing method sent a GET, so it could never have worked.
- A rejected refresh token comes back as an **HTML 500**, not a machine readable error, so the response body cannot tell a dead connection apart from a WhoDat outage. Failures are judged by status code instead. A 401 or 403 is final on its own; anything else has to be corroborated by `oauth/token/status`. That endpoint reports on the *access* token, which on this path is expired by definition, so its refusal only carries information while the access token is still inside its own lifetime. Otherwise a rejection is final only once five failures have piled up over more than a day. A transport failure never marks the connection unavailable, it only feeds an exponential backoff.

**When renewal fails.** The connection is marked unavailable: `Merchant::is_connected()` returns false, the settings screen shows the connect panel rather than a false "Connected", the gateway drops off checkout, and an admin notice explains it with a reconnect link. That is a long backoff rather than a dead end. It is rechecked every 12 hours, with an `admin_init` trigger so a site with no traffic heals without anyone touching the settings.

**Notes for review.**

- Square's status is stored in a new mode-scoped option rather than through `Merchant::set_merchant_unauthorized()`. Those option names are byte-identical to Stripe's and are not mode-scoped, so writing them from Square would flip Stripe's state, which `Stripe\Hooks::handle_stripe_errors()` reads.
- `check_account_status()` was reading an `error` key the status endpoint does not return, so even an explicit `is_connected( true )` recheck reported a revoked token as connected. It now reads the `type` and `message` shape the endpoint actually sends.
- The refresh takes a cross-process lock so parallel requests do not stampede the endpoint. Confirmed against the live service that the refresh token does not rotate, so a lost race is harmless.
- Connections made before `expires_at` was tracked are never treated as expired. They retry at most twice a day until a refresh teaches them a real expiration, and the 401 path covers them meanwhile.


### 🎥 Artifacts

https://www.loom.com/share/5bb28e2887f7457b8cf04f8a68d9fb5d

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.



