### PR TITLE
[SMTNC-1902] ETP App Fails to List Attendees When attendees Key Returns an Object Instead of an Array

### DIFF
--- a/changelog/smtnc-1902-etp-app-fails-to-list-attendees-when-attendees-key-returns.yaml
+++ b/changelog/smtnc-1902-etp-app-fails-to-list-attendees-when-attendees-key-returns.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where the attendees REST API archive could return a
+  JSON object instead of an array when an attendee could not be formatted,
+  preventing the Event Tickets Plus App from listing attendees.
+timestamp: 2026-09-08T01:02:58.757Z

--- a/changelog/smtnc-1902-etp-app-fails-to-list-attendees-when-attendees-key-returns.yaml
+++ b/changelog/smtnc-1902-etp-app-fails-to-list-attendees-when-attendees-key-returns.yaml
@@ -1,6 +1,6 @@
 significance: patch
 type: fix
-entry: Resolved an issue where the attendees REST API archive could return a
-  JSON object instead of an array when an attendee could not be formatted,
-  preventing the Event Tickets Plus App from listing attendees.
+entry: Resolved an issue where the tickets and attendees REST API archives could return a
+  JSON object instead of an array when an entry could not be formatted, preventing the
+  Event Tickets Plus App from listing attendees.
 timestamp: 2026-09-08T01:02:58.757Z

--- a/src/Tribe/REST/V1/Archive_List.php
+++ b/src/Tribe/REST/V1/Archive_List.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Reindexing for the REST archive lists.
+ *
+ * @since TBD
+ *
+ * @package Tribe\Tickets
+ */
+
+// phpcs:disable StellarWP.Classes.ValidClassName.NotSnakeCase -- Carries the double-underscore naming the rest of this directory uses.
+
+/**
+ * Class Tribe__Tickets__REST__V1__Archive_List
+ *
+ * @since TBD
+ */
+final class Tribe__Tickets__REST__V1__Archive_List {
+	/**
+	 * Reindexes an archive list so it always encodes as a JSON array.
+	 *
+	 * Entries the repository could not format are dropped while their original keys are kept, and a
+	 * filter can re-key the list again; either way the gaps make the list encode as a JSON object and
+	 * consumers expecting an array stop rendering it.
+	 *
+	 * No native types: the value is deliberately untyped so a non-array reaches the caller unchanged
+	 * instead of fataling, and `mixed` is not available on the PHP 7.4 this plugin still supports.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $items The archive list to reindex.
+	 *
+	 * @return mixed The list reindexed from zero, or the value untouched when it is not an array.
+	 */
+	public static function reindex( $items ) {
+		return is_array( $items ) ? array_values( $items ) : $items;
+	}
+}

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -82,6 +82,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 	 * @param WP_REST_Request $request
 	 *
 	 * @since 4.12.0 Returns 401 Unauthorized if Event Tickets Plus is not loaded.
+	 * @since TBD Reindexes the attendees so the response always encodes them as a JSON array.
 	 *
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 */
@@ -181,7 +182,13 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 		$data['rest_url']    = add_query_arg( $query_args, $main->get_url( '/attendees/' ) );
 		$data['total']       = $found;
 		$data['total_pages'] = $total_pages;
-		$data['attendees']   = $attendees;
+
+		/*
+		 * Attendees the provider cannot hydrate are dropped from the fetched set, which leaves gaps in
+		 * its keys; encoded as-is those gaps turn the list into a JSON object and consumers expecting an
+		 * array stop rendering it.
+		 */
+		$data['attendees'] = array_values( $attendees );
 
 		$headers = [
 			'X-ET-TOTAL'       => $data['total'],

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -182,13 +182,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 		$data['rest_url']    = add_query_arg( $query_args, $main->get_url( '/attendees/' ) );
 		$data['total']       = $found;
 		$data['total_pages'] = $total_pages;
-
-		/*
-		 * Attendees the provider cannot hydrate are dropped from the fetched set, which leaves gaps in
-		 * its keys; encoded as-is those gaps turn the list into a JSON object and consumers expecting an
-		 * array stop rendering it.
-		 */
-		$data['attendees'] = array_values( $attendees );
+		$data['attendees']   = $attendees;
 
 		$headers = [
 			'X-ET-TOTAL'       => $data['total'],
@@ -204,6 +198,11 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 		 * @param WP_REST_Request $request The request object for this endpoint.
 		 */
 		$data = apply_filters( 'tec_tickets_rest_attendee_archive_data', $data, $request );
+
+		/* Reindexed last so the array shape holds for whatever the filter returned. */
+		if ( isset( $data['attendees'] ) ) {
+			$data['attendees'] = Tribe__Tickets__REST__V1__Archive_List::reindex( $data['attendees'] );
+		}
 
 		return new WP_REST_Response( $data, 200, $headers );
 	}

--- a/src/Tribe/REST/V1/Endpoints/Ticket_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Ticket_Archive.php
@@ -79,6 +79,8 @@ class Tribe__Tickets__REST__V1__Endpoints__Ticket_Archive
 	/**
 	 * Handles GET requests on the endpoint.
 	 *
+	 * @since TBD Reindexes the tickets so the response always encodes them as a JSON array.
+	 *
 	 * @param WP_REST_Request $request
 	 *
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
@@ -228,7 +230,9 @@ class Tribe__Tickets__REST__V1__Endpoints__Ticket_Archive
 		 * @param array           $tickets The tickets returned by the REST API.
 		 * @param WP_REST_Request $request The request object.
 		 */
-		$data['tickets'] = apply_filters( 'tec_tickets_rest_api_archive_results', $tickets, $request );
+		$data['tickets'] = Tribe__Tickets__REST__V1__Archive_List::reindex(
+			apply_filters( 'tec_tickets_rest_api_archive_results', $tickets, $request )
+		);
 
 		$headers = array(
 			'X-ET-TOTAL'       => $data['total'],

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -777,6 +777,8 @@ class Tribe__Tickets__REST__V1__Post_Repository
 	/**
 	 * Returns a ticket attendees list.
 	 *
+	 * @since TBD Reindexes the attendees so they always encode as a JSON array.
+	 *
 	 * @param int $ticket_id The ticket ID.
 	 *
 	 * @return array|bool An array of ticket attendees or `false` on failure.
@@ -800,7 +802,9 @@ class Tribe__Tickets__REST__V1__Post_Repository
 			$query->where( 'meta_equals', Tribe__Tickets__RSVP::ATTENDEE_RSVP_KEY, 'yes' );
 		}
 
-		return $query->all();
+		$attendees = $query->all();
+
+		return Tribe__Tickets__REST__V1__Archive_List::reindex( $attendees );
 	}
 
 	/**

--- a/tests/integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Test.php
+++ b/tests/integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Test.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tribe\Tickets\REST\V1\Endpoints;
+
+use Codeception\TestCase\WPTestCase;
+use Faker\Factory;
+use Faker\Generator;
+use TEC\Tickets\Commerce\Attendee;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive as Archive;
+use WP_REST_Request;
+
+class Attendee_Archive_Test extends WPTestCase {
+	use Attendee_Maker;
+	use Ticket_Maker;
+
+	/**
+	 * @var Generator
+	 */
+	protected $faker;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->faker = Factory::create();
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_a_list_when_every_attendee_can_be_formatted(): void {
+		$attendee_count = $this->faker->numberBetween( 2, 8 );
+		[ $event_id ]   = $this->create_event_with_attendees( $attendee_count );
+
+		$data = $this->get_archive( $event_id, $attendee_count );
+
+		$this->assertCount( $attendee_count, $data['attendees'] );
+		$this->assertSame( range( 0, $attendee_count - 1 ), array_keys( $data['attendees'] ) );
+		$this->assertStringContainsString( '"attendees":[', wp_json_encode( $data ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_a_list_when_an_attendee_cannot_be_formatted(): void {
+		/* At least three, so the unformattable attendee sits between two good ones. */
+		$attendee_count           = $this->faker->numberBetween( 3, 8 );
+		[ $event_id, $attendees ] = $this->create_event_with_attendees( $attendee_count );
+
+		/* Severing the ticket relation leaves the provider unable to hydrate the attendee. */
+		delete_post_meta( $attendees[ intdiv( $attendee_count, 2 ) ], Attendee::$ticket_relation_meta_key );
+
+		$data     = $this->get_archive( $event_id, $attendee_count );
+		$expected = $attendee_count - 1;
+
+		$this->assertCount( $expected, $data['attendees'] );
+		$this->assertSame(
+			range( 0, $expected - 1 ),
+			array_keys( $data['attendees'] ),
+			'A skipped attendee must not leave a gap in the keys.'
+		);
+		$this->assertStringContainsString( '"attendees":[', wp_json_encode( $data ) );
+	}
+
+	/**
+	 * @param int $attendee_count How many attendees to attach to the ticket.
+	 *
+	 * @return array{0: int, 1: array<int>} The event ID and the attendee IDs.
+	 */
+	private function create_event_with_attendees( int $attendee_count ): array {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => $this->faker->sentence( 3 ),
+				'status'     => 'publish',
+				'start_date' => '2030-07-14 12:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$ticket_id = $this->create_tc_ticket( $event_id );
+
+		return [ $event_id, $this->create_many_attendees_for_ticket( $attendee_count, $ticket_id, $event_id ) ];
+	}
+
+	/**
+	 * @param int $event_id The event to fetch the attendees of.
+	 * @param int $per_page How many attendees to request.
+	 *
+	 * @return array{rest_url: string, total: int, total_pages: int, attendees: array<int,array>} The archive response data.
+	 */
+	private function get_archive( int $event_id, int $per_page ): array {
+		$request = new WP_REST_Request( 'GET', '' );
+		$request->set_param( 'post_id', $event_id );
+		$request->set_param( 'per_page', $per_page );
+		$request->set_param( 'page', 1 );
+
+		$archive = new Archive(
+			tribe( 'tickets.rest-v1.messages' ),
+			tribe( 'tickets.rest-v1.repository' ),
+			tribe( 'tickets.rest-v1.validator' )
+		);
+
+		return $archive->get( $request )->get_data();
+	}
+}

--- a/tests/integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Test.php
+++ b/tests/integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Test.php
@@ -66,6 +66,31 @@ class Attendee_Archive_Test extends WPTestCase {
 	}
 
 	/**
+	 * @test
+	 */
+	public function it_should_return_a_list_when_a_filter_rekeys_the_attendees(): void {
+		$attendee_count = $this->faker->numberBetween( 2, 8 );
+		[ $event_id ]   = $this->create_event_with_attendees( $attendee_count );
+
+		add_filter(
+			'tec_tickets_rest_attendee_archive_data',
+			static function ( $data ) {
+				$data['attendees'] = array_combine(
+					range( 100, 99 + count( $data['attendees'] ) ),
+					$data['attendees']
+				);
+
+				return $data;
+			}
+		);
+
+		$data = $this->get_archive( $event_id, $attendee_count );
+
+		$this->assertSame( range( 0, $attendee_count - 1 ), array_keys( $data['attendees'] ) );
+		$this->assertStringContainsString( '"attendees":[', wp_json_encode( $data ) );
+	}
+
+	/**
 	 * @param int $attendee_count How many attendees to attach to the ticket.
 	 *
 	 * @return array{0: int, 1: array<int>} The event ID and the attendee IDs.
@@ -94,15 +119,30 @@ class Attendee_Archive_Test extends WPTestCase {
 	private function get_archive( int $event_id, int $per_page ): array {
 		$request = new WP_REST_Request( 'GET', '' );
 		$request->set_param( 'post_id', $event_id );
+		/* $per_page covers every seeded attendee, so there is exactly one page to ask for. */
 		$request->set_param( 'per_page', $per_page );
 		$request->set_param( 'page', 1 );
+		/*
+		 * The attendees are created within the same second, so the default date sort ties and the
+		 * skipped one can land last, where no gap forms and the test would pass with the bug present.
+		 */
+		$request->set_param( 'orderby', 'id' );
+		$request->set_param( 'order', 'ASC' );
 
-		$archive = new Archive(
+		return $this->make_instance()->get( $request )->get_data();
+	}
+
+	/**
+	 * The sibling tests in this directory pass Prophecy doubles through the same factory; these
+	 * exercise the real repository end to end, so they take the container's services instead.
+	 *
+	 * @return Archive The endpoint under test.
+	 */
+	private function make_instance(): Archive {
+		return new Archive(
 			tribe( 'tickets.rest-v1.messages' ),
 			tribe( 'tickets.rest-v1.repository' ),
 			tribe( 'tickets.rest-v1.validator' )
 		);
-
-		return $archive->get( $request )->get_data();
 	}
 }

--- a/tests/integration/Tribe/Tickets/REST/V1/Endpoints/Ticket_Archive_Shape_Test.php
+++ b/tests/integration/Tribe/Tickets/REST/V1/Endpoints/Ticket_Archive_Shape_Test.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tribe\Tickets\REST\V1\Endpoints;
+
+use Codeception\TestCase\WPTestCase;
+use Faker\Factory;
+use Faker\Generator;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe__Tickets__REST__V1__Endpoints__Ticket_Archive as Archive;
+use WP_REST_Request;
+
+class Ticket_Archive_Shape_Test extends WPTestCase {
+	use Ticket_Maker;
+
+	/**
+	 * @var Generator
+	 */
+	protected $faker;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->faker = Factory::create();
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_a_list_when_every_ticket_can_be_formatted(): void {
+		$ticket_count = $this->faker->numberBetween( 2, 6 );
+		[ $event_id ] = $this->create_event_with_tickets( $ticket_count );
+
+		$data = $this->get_archive( $event_id, $ticket_count );
+
+		$this->assertCount( $ticket_count, $data['tickets'] );
+		$this->assertSame( range( 0, $ticket_count - 1 ), array_keys( $data['tickets'] ) );
+		$this->assertStringContainsString( '"tickets":[', wp_json_encode( $data ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_a_list_when_a_filter_rekeys_the_tickets(): void {
+		$ticket_count = $this->faker->numberBetween( 2, 6 );
+		[ $event_id ] = $this->create_event_with_tickets( $ticket_count );
+
+		add_filter(
+			'tec_tickets_rest_api_archive_results',
+			static function ( $tickets ) {
+				return array_combine( range( 100, 99 + count( $tickets ) ), $tickets );
+			}
+		);
+
+		$data = $this->get_archive( $event_id, $ticket_count );
+
+		$this->assertSame( range( 0, $ticket_count - 1 ), array_keys( $data['tickets'] ) );
+		$this->assertStringContainsString( '"tickets":[', wp_json_encode( $data ) );
+	}
+
+	/**
+	 * @param int $ticket_count How many tickets to attach to the event.
+	 *
+	 * @return array{0: int, 1: array<int>} The event ID and the ticket IDs.
+	 */
+	private function create_event_with_tickets( int $ticket_count ): array {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => $this->faker->sentence( 3 ),
+				'status'     => 'publish',
+				'start_date' => '2030-07-14 12:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$tickets = [];
+		foreach ( range( 1, $ticket_count ) as $ignored ) {
+			$tickets[] = $this->create_tc_ticket( $event_id );
+		}
+
+		return [ $event_id, $tickets ];
+	}
+
+	/**
+	 * @param int $event_id The event to fetch the tickets of.
+	 * @param int $per_page How many tickets to request.
+	 *
+	 * @return array{rest_url: string, total: int, total_pages: int, tickets: array<int,array>} The archive response data.
+	 */
+	private function get_archive( int $event_id, int $per_page ): array {
+		$request = new WP_REST_Request( 'GET', '' );
+		$request->set_param( 'include_post', $event_id );
+		/* $per_page covers every seeded ticket, so there is exactly one page to ask for. */
+		$request->set_param( 'per_page', $per_page );
+		$request->set_param( 'page', 1 );
+
+		return $this->make_instance()->get( $request )->get_data();
+	}
+
+	/**
+	 * The sibling tests in this directory pass Prophecy doubles through the same factory; these
+	 * exercise the real repository end to end, so they take the container's services instead.
+	 *
+	 * @return Archive The endpoint under test.
+	 */
+	private function make_instance(): Archive {
+		return new Archive(
+			tribe( 'tickets.rest-v1.messages' ),
+			tribe( 'tickets.rest-v1.repository' ),
+			tribe( 'tickets.rest-v1.validator' )
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1902](https://linear.app/nexcess/issue/SMTNC-1902/etp-app-fails-to-list-attendees-when-attendees-key-returns-an-object)

### 🎥 Artifacts

https://www.loom.com/share/b168fc7ade7745fa9317e8792a54da19

### 🗒️ Description

Reindexes the attendees in the REST attendees archive response so it always encodes as a JSON array, even when an attendee the ticket provider cannot hydrate is skipped and leaves a gap in the keys.

### ⚠️ Blockers

None.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
