### PR TITLE
[SMTNC-2412] Document the planning requirement and how to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ happen to be standing in.
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`tec-openspec` skill](https://github.com/stellarwp/skills) covers the
+[`tec-openspec` skill](https://github.com/stellarwp/skills-se) covers the
 workflow itself — writing a proposal worth reviewing, keeping it current, and
 archiving it once (after the last repository merges, not per repo). Install it with:
 
-The below will work only once the `stellarwp/skills` becomes public.
+The below will work only once the `stellarwp/skills-se` becomes public.
 
 ```
-/plugin marketplace add stellarwp/skills
-/plugin install nexcess
+/plugin marketplace add stellarwp/skills-se
+/plugin install nexcess-se
 ```
 
 ## Running the tests

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ store as `tec-plans`.
 
 ### Working on a ticket
 
-1. **Create the change before writing code**, named after the ticket:
-   `openspec new change SOFT-1234 --store tec-plans --description "what this does"`
+1. **Create the change before writing code**, named after the ticket in lower
+   case. OpenSpec requires kebab-case and rejects anything else, so the ticket
+   `SOFT-1234` becomes the change `soft-1234`:
+   `openspec new change soft-1234 --store tec-plans --description "what this does"`
 2. Write the proposal, then commit and push it in the plans repo.
 3. Branch as usual: `feat/SOFT-1234/short-desc`.
 4. Implement. If the work shows the plan was wrong — it often does — update the

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ store instead: [`the-events-calendar/plans`](https://github.com/the-events-calen
 npm install -g @fission-ai/openspec
 git clone git@github.com:the-events-calendar/plans.git ~/repos/tec-plans
 openspec store register ~/repos/tec-plans --id tec-plans
+openspec config set defaultStore tec-plans
 ```
 
 The clone path is yours to choose. The `--id` is not — every command refers to the
@@ -69,12 +70,14 @@ Commands that read or write plans take `--store tec-plans`: `new change`,
 `doctor`. The `openspec store` commands manage registrations instead and take
 `--id`, which is why the setup block above uses that.
 
-Nothing sets a default store for you — the skills repo's `install.sh` is
-org-wide and does not know you work on TEC. Without the flag the command writes
-the change into whatever repository you happen to be standing in. A developer who
-only works on TEC may run `openspec config set defaultStore tec-plans` once as a
-personal convenience; the flag stays in every example because the next machine
-will not have it.
+Setting the store as OpenSpec's global default is part of the setup, not an
+optional extra. The stock OpenSpec skills and the `/opsx:*` commands know
+nothing about our store and act on whatever root resolves from the current
+directory, and this repository has no `openspec/` root of its own — so without
+the default they fail, or land the change in a stray root. The org-wide skills
+repo's `install.sh` deliberately does not set it: it serves every StellarWP
+brand. Confirm with `openspec context`, which should print `Using OpenSpec root:
+tec-plans`. Pass the flag anyway; it is right whether or not the default is set.
 
 ### Where the rest is written down
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ happen to be standing in.
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`openspec` skill](https://github.com/stellarwp/skills) covers the
+[`tec-openspec` skill](https://github.com/stellarwp/skills) covers the
 workflow itself — writing a proposal worth reviewing, keeping it current, and
 archiving it once (after the last repository merges, not per repo). Install it with:
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,51 @@ Support requests on this repository will be closed on sight.
 
 ## Contributing to Event Tickets
 If you have a patch or have stumbled upon an issue with Event Tickets core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/the-events-calendar/event-tickets/blob/master/CONTRIBUTING.md) for more information how you can do this.
+
+## Specs and planning
+
+Work on this repository is planned before it is written, using
+[OpenSpec](https://github.com/Fission-AI/OpenSpec). **This is enforced** — every
+pull request is checked for a plan.
+
+Plans do not live here. A TEC feature routinely spans several repositories, so a
+spec kept in one of them is invisible from the others. They all live in one shared
+store instead: [`the-events-calendar/plans`](https://github.com/the-events-calendar/plans).
+
+### First time only
+
+```bash
+npm install -g @fission-ai/openspec
+git clone git@github.com:the-events-calendar/plans.git ~/repos/tec-plans
+openspec store register ~/repos/tec-plans --id tec-plans
+```
+
+The clone path is yours to choose. The `--id` is not — every command refers to the
+store as `tec-plans`.
+
+### Working on a ticket
+
+1. **Create the change before writing code**, named after the ticket:
+   `openspec new change SOFT-1234 --store tec-plans --description "what this does"`
+2. Write the proposal, then commit and push it in the plans repo.
+3. Branch as usual: `feat/SOFT-1234/short-desc`.
+4. Implement. If the work shows the plan was wrong — it often does — update the
+   change rather than letting the plan and the code drift apart.
+5. Open the PR. The template asks for the change ID, and CI checks the plan exists
+   and is still active.
+
+Every `openspec` command takes `--store tec-plans`. There is no default and no
+repo-side link, so omitting it writes the change into whatever repository you
+happen to be standing in.
+
+### Where the rest is written down
+
+This section covers what is specific to working here. The
+[`tec-openspec` skill](https://github.com/the-events-calendar/skills) covers the
+workflow itself — writing a proposal worth reviewing, keeping it current, and
+archiving it once (after the last repository merges, not per repo). Install it with:
+
+```
+/plugin marketplace add the-events-calendar/skills
+/plugin install tec
+```

--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ happen to be standing in.
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`tec-openspec` skill](https://github.com/the-events-calendar/skills) covers the
+[`openspec` skill](https://github.com/stellarwp/skills) covers the
 workflow itself — writing a proposal worth reviewing, keeping it current, and
 archiving it once (after the last repository merges, not per repo). Install it with:
 
+The below will work only once the `stellarwp/skills` becomes public.
+
 ```
-/plugin marketplace add the-events-calendar/skills
-/plugin install tec
+/plugin marketplace add stellarwp/skills
+/plugin install nexcess
 ```
 
 ## Running the tests
@@ -89,9 +91,9 @@ Event Tickets does not test alone. CI clones **the-events-calendar as a sibling 
 ```bash
 # 1. One parent directory holding every plugin side by side.
 mkdir -p ~/plugins && cd ~/plugins
-git clone --recurse-submodules git@github.com:the-events-calendar/event-tickets.git
-git clone --recurse-submodules git@github.com:the-events-calendar/the-events-calendar.git
-git clone --recurse-submodules git@github.com:the-events-calendar/events-pro.git   # ct1_*/ft_*/slr_ecp_* only
+git clone --recursive git@github.com:the-events-calendar/event-tickets.git
+git clone --recursive git@github.com:the-events-calendar/the-events-calendar.git
+git clone --recursive git@github.com:the-events-calendar/events-pro.git   # ct1_*/ft_*/slr_ecp_* only
 git clone https://github.com/stellarwp/slic.git
 # => ~/plugins/{event-tickets,the-events-calendar,events-pro,slic}
 

--- a/README.md
+++ b/README.md
@@ -77,3 +77,83 @@ archiving it once (after the last repository merges, not per repo). Install it w
 /plugin marketplace add the-events-calendar/skills
 /plugin install tec
 ```
+
+## Running the tests
+
+PHP tests are Codeception/wp-browser suites run inside Docker by [slic](https://github.com/stellarwp/slic), the same runner CI uses.
+
+### Setup
+
+Event Tickets does not test alone. CI clones **the-events-calendar as a sibling directory** of `event-tickets` (plus `events-pro` for the CT1/FT suites) and points slic at the shared parent. This layout is the thing people get wrong — the suites activate `the-events-calendar/the-events-calendar.php` by path relative to the plugins directory.
+
+```bash
+# 1. One parent directory holding every plugin side by side.
+mkdir -p ~/plugins && cd ~/plugins
+git clone --recurse-submodules git@github.com:the-events-calendar/event-tickets.git
+git clone --recurse-submodules git@github.com:the-events-calendar/the-events-calendar.git
+git clone --recurse-submodules git@github.com:the-events-calendar/events-pro.git   # ct1_*/ft_*/slr_ecp_* only
+git clone https://github.com/stellarwp/slic.git
+# => ~/plugins/{event-tickets,the-events-calendar,events-pro,slic}
+
+# 2. Point slic at that parent.
+./slic/slic here
+./slic/slic build-subdir off
+./slic/slic xdebug off
+
+# 3. Install deps for every plugin AND every common, in this order.
+./slic/slic use the-events-calendar        && ./slic/slic composer install --no-dev
+./slic/slic use the-events-calendar/common && ./slic/slic composer install --no-dev
+./slic/slic use events-pro                 && ./slic/slic composer install --no-dev   # if cloned
+./slic/slic use event-tickets/common       && ./slic/slic composer install --no-dev
+./slic/slic use event-tickets              && ./slic/slic composer install
+
+# 4. Start WordPress and the themes the suites expect.
+./slic/slic up wordpress
+./slic/slic wp theme install twentytwenty --activate
+./slic/slic wp theme install kadence       # square_integration runs on this theme
+```
+
+`slic use event-tickets` must come last — it selects the plugin whose suites run.
+
+### Running a suite
+
+```bash
+cd ~/plugins && ./slic/slic use event-tickets
+
+./slic/slic run integration                                              # whole suite
+./slic/slic run integration tests/integration/RSVP_Tickets_Test.php      # one file
+./slic/slic run integration tests/integration/RSVP_Tickets_Test.php:test_ticket_with_stock
+./slic/slic run wpunit --filter test_ticket_stock                        # by name
+```
+
+Never run `slic run` with no suite — WordPress globals leak across suites and everything fails.
+
+### Suites
+
+Every suite below runs on each PR that touches PHP files. `acceptance` is commented out of the CI matrix and is not run.
+
+| Suite | Covers | Workflow |
+|---|---|---|
+| `functional` | Browser-less request/response tests (WPBrowser + DB dump) | tests-php.yml |
+| `integration` | Core ET integration tests with TEC active | tests-php.yml |
+| `wpunit` | Unit-level tests booted inside WordPress | tests-php.yml |
+| `restv1` | Legacy `tribe/tickets/v1` REST API | tests-php.yml |
+| `rest_tec_v1_integration` | New `tec/v1` REST API; CI also Spectral-lints the OpenAPI docs | tests-php.yml |
+| `views_integration` | Template/view rendering | tests-php.yml |
+| `commerce_integration` | Tickets Commerce: orders, gateways, checkout | tests-php.yml |
+| `slr_integration` | Seating (layouts/reservations) with TEC | tests-php.yml |
+| `square_integration` | Square gateway, on the Kadence theme | tests-php.yml |
+| `ct1_integration` | Custom Tables v1 with TEC + ECP | tests-php-ct1.yml |
+| `slr_ecp_integration` | Seating combined with Events Calendar Pro | tests-php-ct1.yml |
+| `order_modifiers_integration` | Fees, coupons, other order modifiers | tests-php-ct1.yml |
+| `ft_smoketest` | Flexible Tickets smoke tests against a seeded dump | tests-php-ft.yml |
+| `ft_integration` | Flexible Tickets / Series Passes with TEC + ECP | tests-php-ft.yml |
+| `ft_ct1_migration` | Flexible Tickets migration onto CT1 tables | tests-php-ft.yml |
+| `acceptance` | Chrome/WebDriver e2e (`slic up chrome`, `slic npm run build`) | none |
+
+### How this differs from CI
+
+- CI pins WordPress with `slic wp core update --force --version=6.8`; locally the container's shipped version is fine unless chasing a version-specific failure.
+- CI appends `--ext DotReporter` (compact logs) and installs `twentytwentyfour` as well; neither matters locally.
+- CI runs `slic npm install && slic npm run build` only for `acceptance`, which is disabled.
+- CI checks out sibling plugins on a matching branch via its `smart-checkout` action; locally check out the branches you need by hand.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,14 @@ store as `tec-plans`.
 5. Open the PR. The template asks for the change ID, and CI checks the plan exists
    and is still active.
 
-Every `openspec` command takes `--store tec-plans`. There is no default and no
-repo-side link, so omitting it writes the change into whatever repository you
+Commands that read or write plans take `--store tec-plans`: `new change`,
+`status`, `instructions`, `list`, `show`, `validate`, `archive`, `context` and
+`doctor`. The `openspec store` commands manage registrations instead and take
+`--id`, which is why the setup block above uses that.
+
+A machine that has run the skills repo's `install.sh` has OpenSpec's
+`defaultStore` set to `tec-plans` and resolves without the flag. Pass it anyway:
+a machine without that setting writes the change into whatever repository you
 happen to be standing in.
 
 ### Where the rest is written down
@@ -77,7 +83,7 @@ archiving it once (after the last repository merges, not per repo). Install it w
 
 The below will work only once the `stellarwp/skills-se` becomes public.
 
-```
+```text
 /plugin marketplace add stellarwp/skills-se
 /plugin install nexcess-se
 ```

--- a/README.md
+++ b/README.md
@@ -69,17 +69,20 @@ Commands that read or write plans take `--store tec-plans`: `new change`,
 `doctor`. The `openspec store` commands manage registrations instead and take
 `--id`, which is why the setup block above uses that.
 
-A machine that has run the skills repo's `install.sh` has OpenSpec's
-`defaultStore` set to `tec-plans` and resolves without the flag. Pass it anyway:
-a machine without that setting writes the change into whatever repository you
-happen to be standing in.
+Nothing sets a default store for you — the skills repo's `install.sh` is
+org-wide and does not know you work on TEC. Without the flag the command writes
+the change into whatever repository you happen to be standing in. A developer who
+only works on TEC may run `openspec config set defaultStore tec-plans` once as a
+personal convenience; the flag stays in every example because the next machine
+will not have it.
 
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`tec-openspec` skill](https://github.com/stellarwp/skills-se) covers the
-workflow itself — writing a proposal worth reviewing, keeping it current, and
-archiving it once (after the last repository merges, not per repo). Install it with:
+[`openspec-workflow` skill](https://github.com/stellarwp/skills-se) covers the
+workflow itself — writing a proposal worth reviewing and keeping it current — and
+its TEC extension, `tec-openspec`, covers the shared store, the ticket-ID naming,
+and archiving once (after the last repository merges, not per repo). Install it with:
 
 The below will work only once the `stellarwp/skills-se` becomes public.
 


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2412](https://linear.app/nexcess/issue/SMTNC-2412)

Part of [SMTNC-2410](https://linear.app/nexcess/issue/SMTNC-2410), Enforce OpenSpec for TEC products.

### 📋 Plan

_None._ This is part of the change that introduces the plan requirement, so it predates the store having entries.

### 🗒️ Description

Documents that work on this repository is planned before it is written, and that plans live in the shared [`the-events-calendar/plans`](https://github.com/the-events-calendar/plans) store rather than here.

A TEC feature routinely spans several repositories — a change lands in `event-tickets`, its extension in `event-tickets-plus`, the shared piece in `tribe-common`. A spec kept in any one of them is invisible from the other two, which is why there is one store instead of one per repo.

The section covers what is specific to working here: first-time store setup, the per-ticket flow, and the fact that every `openspec` command needs `--store tec-plans` because there is no default and no repo-side link. It deliberately does **not** repeat the workflow itself — writing a good proposal, keeping it current, archiving it once after the last repo merges — because that lives in the `tec-openspec` skill and duplicating it guarantees drift.

**The section is byte-identical across all 16 active TEC repositories.** Please keep it that way; edits belong in all of them or none.

### 🎥 Artifacts

_Not applicable — documentation only._

### ✔️ Verification

Documentation only. No code paths, build config or workflows touched in this PR.
The repository's existing readme was **appended to**; nothing else in it was changed.

The CI check that enforces this arrives separately, via the sync group added in [the-events-calendar/actions#37](https://github.com/the-events-calendar/actions/pull/37). This PR is only the documentation.

### ✔️ Checklist
- [ ] There is an OpenSpec plan for this work in `tec-plans` — no, see above.
- [ ] Ran `npm run changelog` — not applicable, documentation only.
- [x] Base branch checked against the repository's actual default branch.
- [ ] Code is covered by tests — not applicable, no code changed.

### 🤖 AI usage

Claude Opus 5 wrote this documentation section and opened this PR, in a working session with me. The section is identical across all active TEC repositories by design. No human has reviewed the wording yet — that is what this review is for.

---

### 🧪 Second commit: how to run the tests

Adds a `## Running the tests` section giving the same steps CI follows — taken from this repository's own test workflows, not written from memory. Setup, dependency installation, the run command, a suites table marking which suites CI runs on every PR, and a short note on what CI does that you do not need locally.

One set of instructions for both humans and agents, as requested — copy-pasteable, no "see the wiki".

**Verification:** every command was transcribed from the workflow files, not invented. I did not execute the suites — the commands are read from CI, so treat them as accurate to what CI does rather than as a passing local run.
