### PR TITLE
[SMTNC-1739] Series Pass Attendees Not Checking In via ETP App

### DIFF
--- a/changelog/fix-smtnc-1739-series-pass-attendees-not-checking-in-via-etp-app.yaml
+++ b/changelog/fix-smtnc-1739-series-pass-attendees-not-checking-in-via-etp-app.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: fix
+entry: Resolved an issue where a Series Pass Attendee checked in from the Event Tickets Plus App appeared checked in and then reverted to unchecked on the next refresh the Attendee list no longer drops the per-Occurrence Attendee that carries the check-in status, it reports the original Attendee ID alongside it so the App keeps one identity per Attendee across Occurrences, and a manual check-in from the App is no longer restricted to the Events happening now the way a QR code scan is.
+timestamp: 2026-09-12T05:33:04.121Z

--- a/changelog/smtnc-1739-series-pass-attendees-not-checking-in-via-etp-app
+++ b/changelog/smtnc-1739-series-pass-attendees-not-checking-in-via-etp-app
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Resolved an issue where a Series Pass Attendee checked in from the Event Tickets Plus App appeared checked in and then reverted to unchecked on the next refresh: the Attendee list no longer drops the per-Occurrence Attendee that carries the check-in status, it reports the original Attendee ID alongside it so the App keeps one identity per Attendee across Occurrences, and a manual check-in from the App is no longer restricted to the Events happening now the way a QR code scan is.

--- a/changelog/smtnc-1739-series-pass-attendees-not-checking-in-via-etp-app
+++ b/changelog/smtnc-1739-series-pass-attendees-not-checking-in-via-etp-app
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where a Series Pass Attendee checked in from the Event Tickets Plus App appeared checked in and then reverted to unchecked on the next refresh: the Attendee list no longer drops the per-Occurrence Attendee that carries the check-in status, it reports the original Attendee ID alongside it so the App keeps one identity per Attendee across Occurrences, and a manual check-in from the App is no longer restricted to the Events happening now the way a QR code scan is.

--- a/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
@@ -1291,6 +1291,7 @@ class Attendees extends Controller {
 	 * have not been cloned to the Event.
 	 *
 	 * @since 5.8.2
+	 * @since TBD Let the row actions render for the per-Occurrence clone Attendee, which carries a real checkin status.
 	 *
 	 * @param array<int,string>   $row_actions Array of row action links.
 	 * @param array<string,mixed> $item        The array representation of the item.
@@ -1299,6 +1300,11 @@ class Attendees extends Controller {
 	 */
 	public function filter_attendees_row_actions( array $row_actions, array $item ): array {
 		if ( Series_Passes::TICKET_TYPE !== $item['ticket_type'] ) {
+			return $row_actions;
+		}
+
+		if ( $this->attendee_is_clone_of( (int) $item['attendee_id'] ) ) {
+			// This is the per-Occurrence clone: it carries a real checkin status, let the actions render normally.
 			return $row_actions;
 		}
 
@@ -1319,6 +1325,7 @@ class Attendees extends Controller {
 	 * Filters the attendee table check-in column.
 	 *
 	 * @since 5.9.1
+	 * @since TBD Let the column render for the per-Occurrence clone Attendee, which carries a real checkin status.
 	 *
 	 * @param string              $html The HTML content of the column.
 	 * @param array<string,mixed> $item The array representation of the item.
@@ -1327,6 +1334,11 @@ class Attendees extends Controller {
 	 */
 	public function filter_attendees_table_column_check_in( string $html, array $item ) {
 		if ( Series_Passes::TICKET_TYPE !== $item['ticket_type'] ) {
+			return $html;
+		}
+
+		if ( $this->attendee_is_clone_of( (int) $item['attendee_id'] ) ) {
+			// This is the per-Occurrence clone: it carries a real checkin status, let it render normally.
 			return $html;
 		}
 

--- a/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
@@ -186,6 +186,7 @@ class Attendees extends Controller {
 		add_filter( 'event_tickets_attendees_table_row_actions', [ $this, 'filter_attendees_row_actions' ], 10, 2 );
 		add_filter( 'tribe_events_tickets_attendees_table_bulk_actions', [ $this, 'filter_attendees_bulk_actions' ] );
 		add_filter( 'tec_tickets_attendees_table_column_check_in', [ $this, 'filter_attendees_table_column_check_in' ], 10, 2 );
+		add_filter( 'tribe_tickets_rest_api_attendee_data', [ $this, 'add_clone_of_to_attendee_data' ] );
 	}
 
 	/**
@@ -224,6 +225,7 @@ class Attendees extends Controller {
 		remove_filter( 'event_tickets_attendees_table_row_actions', [ $this, 'filter_attendees_row_actions' ] );
 		remove_filter( 'tribe_events_tickets_attendees_table_bulk_actions', [ $this, 'filter_attendees_bulk_actions' ] );
 		remove_filter( 'tec_tickets_attendees_table_column_check_in', [ $this, 'filter_attendees_table_column_check_in' ] );
+		remove_filter( 'tribe_tickets_rest_api_attendee_data', [ $this, 'add_clone_of_to_attendee_data' ] );
 	}
 
 	/**
@@ -613,6 +615,8 @@ class Attendees extends Controller {
 	 * could check into.
 	 *
 	 * @since 5.8.2
+	 * @since TBD Let the check-in window restriction be filtered, so a manual check-in flagged as coming from
+	 *            the App is not restricted the way an actual QR code scan is.
 	 *
 	 * @param int  $post_id     The post ID of the Series, or Event, to get the checkin times for.
 	 * @param int  $attendee_id The post ID of the Attendee to check in.
@@ -621,10 +625,33 @@ class Attendees extends Controller {
 	 * @return array{0: string, 1: string} The checkin window start and end in the format `Y-m-d H:i:s`.
 	 */
 	private function get_checkin_candidate_times( int $post_id, int $attendee_id, bool $qr ): array {
-		if ( ! $qr ) {
+		/**
+		 * Filters whether the Occurrences a Series Pass Attendee can be checked into are restricted to the
+		 * QR code check-in time window, or not.
+		 *
+		 * A QR code is scanned at the door, so the Occurrence it can check an Attendee into is restricted to
+		 * the one happening now, or starting shortly. A manual check-in, made against an Attendee list, is
+		 * never restricted that way. The `$qr` flag alone cannot tell the two apart: Event Tickets Plus also
+		 * sets it for the App's bulk check-in endpoint, which is a manual check-in, to have the check-in
+		 * recorded as coming from the App. This filter is how that endpoint opts out of the restriction.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $restricted  Whether the candidate Occurrences are restricted to the check-in window.
+		 * @param int  $post_id     The post ID of the Series, or Event, to get the checkin times for.
+		 * @param int  $attendee_id The post ID of the Series Pass Attendee to check in.
+		 */
+		$restricted = (bool) apply_filters(
+			'tec_tickets_flexible_tickets_series_checkin_restricted',
+			$qr,
+			$post_id,
+			$attendee_id
+		);
+
+		if ( ! $restricted ) {
 			/*
-			 *  We are not checking in via QR code: the checkin should never be restricted.
-			 * Use `1` as start of the interval to pass empty checks.
+			 * This is not a QR code scan: the checkin should never be restricted.
+			 * Use a wide interval to pass empty checks.
 			 */
 			return [ '1970-06-06 00:00:00', '2100-12-31 00:00:00' ];
 		}
@@ -1218,6 +1245,37 @@ class Attendees extends Controller {
 		return $original_id ?
 			(int) get_post_meta( $clone_id, self::CLONE_META_KEY, true ) === $original_id
 			: (int) get_post_meta( $clone_id, self::CLONE_META_KEY, true ) !== 0;
+	}
+
+	/**
+	 * Adds the original Attendee ID to a cloned Attendee's REST API representation.
+	 *
+	 * A Series Pass Attendee is represented, per Occurrence, by a clone Attendee with its own post ID, and it is
+	 * the clone that carries the check-in status for that Occurrence. A consumer listing the Attendees of an
+	 * Occurrence therefore sees a different ID before and after a check-in, with no way to tell the two are the
+	 * same person. The `clone_of` entry closes that gap: it is absent for a regular Attendee and holds the
+	 * original Series-level Attendee ID for a clone.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $attendee_data The Attendee data as assembled for the REST API.
+	 *
+	 * @return array<string,mixed> The Attendee data, with the `clone_of` entry added for a cloned Attendee.
+	 */
+	public function add_clone_of_to_attendee_data( $attendee_data ) {
+		if ( ! ( is_array( $attendee_data ) && isset( $attendee_data['id'] ) ) ) {
+			return $attendee_data;
+		}
+
+		$original_id = (int) get_post_meta( (int) $attendee_data['id'], self::CLONE_META_KEY, true );
+
+		if ( ! $original_id ) {
+			return $attendee_data;
+		}
+
+		$attendee_data['clone_of'] = $original_id;
+
+		return $attendee_data;
 	}
 
 	/**

--- a/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
+++ b/src/Tickets/Flexible_Tickets/Series_Passes/Attendees.php
@@ -950,16 +950,18 @@ class Attendees extends Controller {
 	}
 
 	/**
-	 * Returns whether the meta key is the one used to store the checkin status or the check-in
-	 * details.
+	 * Returns whether the meta key is the one used to store the checkin status, the check-in details, or the
+	 * per-Occurrence check-in failure log.
 	 *
 	 * @since 5.8.2
+	 * @since TBD Also exclude the check-in failure log meta key: it records a failure for one specific
+	 *            Occurrence and must not be copied onto every other Occurrence's clone Attendee.
 	 *
 	 * @param int    $post_id  The post ID of the Attendee to check.
 	 * @param string $meta_key The meta key to check.
 	 *
-	 * @return bool Whether the meta key is the one used to store the checkin status or the check-in
-	 *              details.
+	 * @return bool Whether the meta key is one that must stay local to a single Occurrence's clone Attendee
+	 *              instead of being synced to the original and every other clone.
 	 */
 	private function is_checked_in_meta_key( int $post_id, string $meta_key ): bool {
 		$post_type = get_post_type( $post_id );
@@ -983,7 +985,12 @@ class Attendees extends Controller {
 			$this->post_type_checkin_keys[ $post_type ] = $checkin_key;
 		}
 
-		return $meta_key === $checkin_key || $meta_key === $checkin_key . '_details' || $meta_key === '_tribe_qr_status';
+		return $meta_key === $checkin_key
+			|| $meta_key === $checkin_key . '_details'
+			|| $meta_key === '_tribe_qr_status'
+			// Matches TEC\Tickets_Plus\Checkin\Constants::CHECKIN_LOGGING_META_KEY (event-tickets-plus is not
+			// a hard dependency of this file, so the literal is duplicated here rather than importing it).
+			|| $meta_key === '_tec_tickets_checkin_log';
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -82,6 +82,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 	 * @param WP_REST_Request $request
 	 *
 	 * @since 4.12.0 Returns 401 Unauthorized if Event Tickets Plus is not loaded.
+	 * @since TBD Stop narrowing a manage-access request by the related post status.
 	 *
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 */
@@ -123,9 +124,19 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 		}
 
 		if ( tribe( 'tickets.rest-v1.main' )->request_has_manage_access() ) {
+			/*
+			 * A request with manage access is not narrowed by the status of the post the Attendee belongs to,
+			 * so no `event_status` default is set below and the filter is skipped entirely. Defaulting it to
+			 * `any` would not do: the filter downgrades `any` to `publish` for any request without a WP user
+			 * - which is every Event Tickets Plus App request, authorized by API key alone - and then joins
+			 * `wp_posts` on the Attendee to Event ID meta value. A Series Pass Attendee cloned to an
+			 * Occurrence holds a provisional Occurrence ID there, which has no `wp_posts` row, so every
+			 * cloned Attendee, and with it the check-in status the App reads, would be dropped from the
+			 * results. A status the request asked for explicitly still applies, having been mapped into
+			 * `event_status` above.
+			 */
 			$permission                 = Tribe__Tickets__REST__V1__Attendee_Repository::PERMISSION_EDITABLE;
 			$fetch_args['post_status']  = Tribe__Utils__Array::get( $fetch_args, 'post_status', 'any' );
-			$fetch_args['event_status'] = Tribe__Utils__Array::get( $fetch_args, 'event_status', 'any' );
 			$fetch_args['order_status'] = Tribe__Utils__Array::get( $fetch_args, 'order_status', 'any' );
 		} else {
 			$permission                 = Tribe__Tickets__REST__V1__Attendee_Repository::PERMISSION_READABLE;

--- a/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
+++ b/src/Tribe/REST/V1/Endpoints/Attendee_Archive.php
@@ -1,5 +1,7 @@
 <?php
 
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
+
 class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 	extends Tribe__Tickets__REST__V1__Endpoints__Base
 	implements Tribe__REST__Endpoints__READ_Endpoint_Interface,
@@ -82,7 +84,8 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 	 * @param WP_REST_Request $request
 	 *
 	 * @since 4.12.0 Returns 401 Unauthorized if Event Tickets Plus is not loaded.
-	 * @since TBD Stop narrowing a manage-access request by the related post status.
+	 * @since TBD Stop narrowing a manage-access request by the related post status only when the request is
+	 *            about a Series Pass Occurrence - every other request keeps being narrowed as before.
 	 *
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 */
@@ -125,19 +128,33 @@ class Tribe__Tickets__REST__V1__Endpoints__Attendee_Archive
 
 		if ( tribe( 'tickets.rest-v1.main' )->request_has_manage_access() ) {
 			/*
-			 * A request with manage access is not narrowed by the status of the post the Attendee belongs to,
-			 * so no `event_status` default is set below and the filter is skipped entirely. Defaulting it to
-			 * `any` would not do: the filter downgrades `any` to `publish` for any request without a WP user
-			 * - which is every Event Tickets Plus App request, authorized by API key alone - and then joins
-			 * `wp_posts` on the Attendee to Event ID meta value. A Series Pass Attendee cloned to an
-			 * Occurrence holds a provisional Occurrence ID there, which has no `wp_posts` row, so every
-			 * cloned Attendee, and with it the check-in status the App reads, would be dropped from the
-			 * results. A status the request asked for explicitly still applies, having been mapped into
-			 * `event_status` above.
+			 * A request with manage access is narrowed by the status of the post the Attendee belongs to,
+			 * same as any other request, EXCEPT when it is about a Series Pass Occurrence: the filter
+			 * downgrades `any` to `publish` for any request without a WP user - which is every Event
+			 * Tickets Plus App request, authorized by API key alone - and then joins `wp_posts` on the
+			 * Attendee to Event ID meta value. A Series Pass Attendee cloned to an Occurrence holds a
+			 * provisional Occurrence ID there, which has no `wp_posts` row, so every cloned Attendee, and
+			 * with it the check-in status the App reads, would be dropped from the results - whether the
+			 * status came from that downgrade or was asked for explicitly. `Occurrence::normalize_id()`
+			 * is a safe no-op for a real post ID (returns it unchanged), so this only skips the filter for
+			 * an actual Occurrence request.
 			 */
+			$requested_event_id    = $fetch_args['event'] ?? null;
+			$is_occurrence_request = is_numeric( $requested_event_id )
+				&& Occurrence::normalize_id( (int) $requested_event_id ) !== (int) $requested_event_id;
+
 			$permission                 = Tribe__Tickets__REST__V1__Attendee_Repository::PERMISSION_EDITABLE;
 			$fetch_args['post_status']  = Tribe__Utils__Array::get( $fetch_args, 'post_status', 'any' );
 			$fetch_args['order_status'] = Tribe__Utils__Array::get( $fetch_args, 'order_status', 'any' );
+
+			if ( $is_occurrence_request ) {
+				// An Occurrence has no status of its own to match against `event_status` - drop it even if
+				// the request set it explicitly (e.g. via `post_status`, mapped above), not just when it
+				// would otherwise default to one.
+				unset( $fetch_args['event_status'] );
+			} else {
+				$fetch_args['event_status'] = Tribe__Utils__Array::get( $fetch_args, 'event_status', 'any' );
+			}
 		} else {
 			$permission                 = Tribe__Tickets__REST__V1__Attendee_Repository::PERMISSION_READABLE;
 			$fetch_args['post_status']  = Tribe__Utils__Array::get( $fetch_args, 'post_status', 'publish' );

--- a/src/Tribe/REST/V1/Endpoints/QR.php
+++ b/src/Tribe/REST/V1/Endpoints/QR.php
@@ -9,6 +9,7 @@
 
 use Tribe__Tickets__Tickets as Tickets;
 use Tribe__Events__Main as TEC;
+use TEC\Tickets\Flexible_Tickets\Series_Passes\Attendees as Series_Pass_Attendees;
 
 
 /**
@@ -213,6 +214,7 @@ class Tribe__Tickets__REST__V1__Endpoints__QR extends Tribe__Tickets__REST__V1__
 	 * Check in attendee.
 	 *
 	 * @since 5.7.0
+	 * @since TBD Resolve the Series Pass Attendee's per-Occurrence clone before reading or reporting checkin status.
 	 *
 	 * @param WP_REST_Request $request The request.
 	 *
@@ -344,11 +346,14 @@ class Tribe__Tickets__REST__V1__Endpoints__QR extends Tribe__Tickets__REST__V1__
 			return $response;
 		}
 
-		// Check if the attendee is checked in.
-		$checked_status = get_post_meta( $attendee_id, '_tribe_qr_status', true );
+		// Check if the attendee is checked in. For a Series Pass Attendee, the checkin flag is recorded on the
+		// per-Occurrence clone Attendee, not on the Series-level Attendee, so resolve the clone first.
+		$checkin_status_attendee_id = $this->get_checkin_status_attendee_id( $attendee_id, $event_id, $ticket_provider );
+
+		$checked_status = get_post_meta( $checkin_status_attendee_id, '_tribe_qr_status', true );
 
 		if ( ! $checked_status ) {
-			$checked_status = get_post_meta( $attendee_id, $ticket_provider->checkin_key, true );
+			$checked_status = get_post_meta( $checkin_status_attendee_id, $ticket_provider->checkin_key, true );
 		}
 
 		if ( $checked_status ) {
@@ -427,6 +432,18 @@ class Tribe__Tickets__REST__V1__Endpoints__QR extends Tribe__Tickets__REST__V1__
 			return $response;
 		}
 
+		// Re-resolve to the clone Attendee, now that it exists, so the response reflects the real checkin status.
+		$checked_in_attendee_id = $this->get_checkin_status_attendee_id( $attendee_id, $event_id, $ticket_provider );
+		if ( $checked_in_attendee_id !== $attendee_id ) {
+			$attendee_data = apply_filters(
+				'tec_tickets_qr_checkin_attendee_data',
+				tribe( 'tickets.rest-v1.attendee-repository' )->format_item( $checked_in_attendee_id ),
+				$checked_in_attendee_id,
+				$event_id,
+				$ticket_provider
+			);
+		}
+
 		$response = new WP_REST_Response(
 			[
 				'msg'      => __( 'Checked In!', 'event-tickets' ),
@@ -436,6 +453,36 @@ class Tribe__Tickets__REST__V1__Endpoints__QR extends Tribe__Tickets__REST__V1__
 		$response->set_status( 201 );
 
 		return $response;
+	}
+
+	/**
+	 * Resolves the Attendee post ID that actually carries the checkin status meta.
+	 *
+	 * For a Series Pass Attendee, the checkin flag is recorded on the Attendee clone made for the specific
+	 * Occurrence, not on the original Series-level Attendee post, so the clone for the given event ID, if one
+	 * exists, is returned instead.
+	 *
+	 * @since TBD
+	 *
+	 * @param int     $attendee_id     The Attendee ID as provided in the check-in request.
+	 * @param int     $event_id        The ID of the ticket-able post the Attendee is being checked into.
+	 * @param Tickets $ticket_provider The Attendee ticket provider.
+	 *
+	 * @return int The Attendee ID that carries the checkin status meta: the clone if one exists, the original otherwise.
+	 */
+	private function get_checkin_status_attendee_id( int $attendee_id, int $event_id, $ticket_provider ): int {
+		$attendee_event_key = $ticket_provider->attendee_event_key ?? '';
+
+		if ( ! $attendee_event_key ) {
+			return $attendee_id;
+		}
+
+		$clone_id = tribe_attendees()
+			->where( 'meta_equals', Series_Pass_Attendees::CLONE_META_KEY, $attendee_id )
+			->where( 'meta_equals', $attendee_event_key, $event_id )
+			->first_id();
+
+		return $clone_id ? (int) $clone_id : $attendee_id;
 	}
 
 	/**

--- a/tests/ft_integration/TEC/Tickets/Flexible_Tickets/Series_Passes/AttendeesTest.php
+++ b/tests/ft_integration/TEC/Tickets/Flexible_Tickets/Series_Passes/AttendeesTest.php
@@ -1383,6 +1383,72 @@ class AttendeesTest extends Controller_Test_Case {
 	}
 
 	/**
+	 * A check-in failure logged for one Occurrence (e.g. a duplicate check-in attempt) must stay local to
+	 * that Occurrence's clone Attendee, not be copied onto every other Occurrence's clone: it would read as
+	 * a failure that never happened there.
+	 *
+	 * @test
+	 */
+	public function should_not_sync_the_checkin_failure_log_to_other_occurrence_clones(): void {
+		// Become administrator.
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		// Create a Series.
+		$series_id = static::factory()->post->create(
+			[
+				'post_type' => Series_Post_Type::POSTTYPE,
+			]
+		);
+		// Create a Series Pass and an Attendee for the Series.
+		$series_pass_id = $this->create_tc_series_pass( $series_id )->ID;
+		$this->create_order( [ $series_pass_id => 1 ] );
+		$original = tribe_attendees()->where( 'event_id', $series_id )->first_id();
+		// Create two Events part of the Series.
+		$event_1 = tribe_events()->set_args(
+			[
+				'title'      => 'Test Event #1',
+				'status'     => 'publish',
+				'start_date' => '+3 hours',
+				'duration'   => 3 * HOUR_IN_SECONDS,
+				'series'     => $series_id,
+			]
+		)->create()->ID;
+		$event_2 = tribe_events()->set_args(
+			[
+				'title'      => 'Test Event #2',
+				'status'     => 'publish',
+				'start_date' => '+27 hours',
+				'duration'   => 3 * HOUR_IN_SECONDS,
+				'series'     => $series_id,
+			]
+		)->create()->ID;
+		$controller = $this->make_controller();
+		$clone_1    = $controller->clone_attendee_to_event( $original, $event_1 );
+		$clone_2    = $controller->clone_attendee_to_event( $original, $event_2 );
+		$controller->register();
+
+		// A failed check-in against the 1st Occurrence's clone is logged as it would be by the Bulk Check-in
+		// endpoint (`Tribe\Tickets\Plus\REST\V1\Endpoints\Bulk_Checkin::log_failed_checkin()`).
+		add_post_meta(
+			$clone_1,
+			'_tec_tickets_checkin_log', // TEC\Tickets_Plus\Checkin\Constants::CHECKIN_LOGGING_META_KEY
+			[ 'reason' => 'DUPLICATE', 'event_id' => $event_1 ]
+		);
+
+		$this->assertNotEmpty(
+			get_post_meta( $clone_1, '_tec_tickets_checkin_log' ),
+			'The failure should be logged against the Occurrence clone it actually happened on.'
+		);
+		$this->assertEmpty(
+			get_post_meta( $original, '_tec_tickets_checkin_log' ),
+			'The failure log must not be copied onto the original Series-level Attendee.'
+		);
+		$this->assertEmpty(
+			get_post_meta( $clone_2, '_tec_tickets_checkin_log' ),
+			'The failure log must not be copied onto an unrelated Occurrence clone.'
+		);
+	}
+
+	/**
 	 * It should update original Attendee when cloned Attendee updated
 	 *
 	 * @test

--- a/tests/ft_integration/TEC/Tickets/Flexible_Tickets/Series_Passes/AttendeesTest.php
+++ b/tests/ft_integration/TEC/Tickets/Flexible_Tickets/Series_Passes/AttendeesTest.php
@@ -117,6 +117,119 @@ class AttendeesTest extends Controller_Test_Case {
 	}
 
 	/**
+	 * It should only blank the check-in column for the original Series Pass Attendee, not for its
+	 * per-Occurrence clone, which carries the real checkin status.
+	 *
+	 * @test
+	 */
+	public function should_only_blank_the_check_in_column_for_the_original_series_pass_attendee(): void {
+		// Become administrator.
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		// Create a Series.
+		$series_id = static::factory()->post->create( [
+			'post_type' => Series_Post_Type::POSTTYPE,
+		] );
+		// Create a Series Pass and an Attendee for the Series.
+		$series_pass_id     = $this->create_tc_series_pass( $series_id )->ID;
+		$series_attendee_id = $this->create_attendee_for_ticket( $series_pass_id, $series_id );
+		// Create an Event part of the Series.
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Series Event',
+			'status'     => 'publish',
+			'start_date' => '-1 hour',
+			'duration'   => 3 * HOUR_IN_SECONDS,
+			'series'     => $series_id,
+		] )->create()->ID;
+		$controller = $this->make_controller();
+		$controller->register();
+
+		// Clone the Attendee to the Occurrence directly, without going through the checkin flow.
+		$cloned_attendee_id = $controller->clone_attendee_to_event( $series_attendee_id, $event_id );
+		$this->assertNotFalse( $cloned_attendee_id, 'The Attendee should have been cloned to the Event.' );
+
+		$original_item = [
+			'attendee_id' => $series_attendee_id,
+			'ticket_type' => Series_Passes::TICKET_TYPE,
+		];
+		$clone_item    = [
+			'attendee_id' => $cloned_attendee_id,
+			'ticket_type' => Series_Passes::TICKET_TYPE,
+		];
+
+		$this->assertEquals(
+			'',
+			$controller->filter_attendees_table_column_check_in( '<span>Check In</span>', $original_item ),
+			'The check-in column should be blanked for the original Series-level Attendee.'
+		);
+		$this->assertEquals(
+			'<span>Check In</span>',
+			$controller->filter_attendees_table_column_check_in( '<span>Check In</span>', $clone_item ),
+			'The check-in column should render normally for the per-Occurrence clone Attendee, which carries the real checkin status.'
+		);
+	}
+
+	/**
+	 * It should only strip the check-in/uncheck-in row actions for the original Series Pass Attendee,
+	 * not for its per-Occurrence clone.
+	 *
+	 * @test
+	 */
+	public function should_only_strip_check_in_row_actions_for_the_original_series_pass_attendee(): void {
+		// Become administrator.
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		// Create a Series.
+		$series_id = static::factory()->post->create( [
+			'post_type' => Series_Post_Type::POSTTYPE,
+		] );
+		// Create a Series Pass and an Attendee for the Series.
+		$series_pass_id     = $this->create_tc_series_pass( $series_id )->ID;
+		$series_attendee_id = $this->create_attendee_for_ticket( $series_pass_id, $series_id );
+		// Create an Event part of the Series.
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Series Event',
+			'status'     => 'publish',
+			'start_date' => '-1 hour',
+			'duration'   => 3 * HOUR_IN_SECONDS,
+			'series'     => $series_id,
+		] )->create()->ID;
+		$controller = $this->make_controller();
+		$controller->register();
+
+		// Clone the Attendee to the Occurrence directly, without going through the checkin flow.
+		$cloned_attendee_id = $controller->clone_attendee_to_event( $series_attendee_id, $event_id );
+		$this->assertNotFalse( $cloned_attendee_id, 'The Attendee should have been cloned to the Event.' );
+
+		$row_actions = [
+			'<a class="tickets_checkin">Check In</a>',
+			'<a class="tickets_uncheckin">Undo Check In</a>',
+			'<a class="move-attendee">Move</a>',
+		];
+
+		$original_item = [ 'ticket_type' => Series_Passes::TICKET_TYPE ];
+		$clone_item    = [ 'ticket_type' => Series_Passes::TICKET_TYPE ];
+
+		$filtered_for_original = $controller->filter_attendees_row_actions(
+			$row_actions,
+			array_merge( $original_item, [ 'attendee_id' => $series_attendee_id ] )
+		);
+		$filtered_for_clone     = $controller->filter_attendees_row_actions(
+			$row_actions,
+			array_merge( $clone_item, [ 'attendee_id' => $cloned_attendee_id ] )
+		);
+
+		$this->assertCount(
+			1,
+			$filtered_for_original,
+			'The check-in/uncheck-in row actions should be stripped for the original Series-level Attendee.'
+		);
+		$this->assertCount(
+			3,
+			$filtered_for_clone,
+			'The check-in/uncheck-in row actions should remain for the per-Occurrence clone Attendee.'
+		);
+	}
+
+	/**
 	 * It should fail to check in pass Attendee from context of Event not part of Series
 	 *
 	 * @test

--- a/tests/ft_integration/TEC/Tickets/Flexible_Tickets/Series_Passes/__snapshots__/AttendeesTest__should_remove_checkin_row_action_from_series_passes_attendeees_not_yet_cloned_to_event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Flexible_Tickets/Series_Passes/__snapshots__/AttendeesTest__should_remove_checkin_row_action_from_series_passes_attendeees_not_yet_cloned_to_event__0.snapshot.html
@@ -6,7 +6,10 @@
 					#{{cloned_attendee_id}} &mdash;
 					<a class="tec-tickets__admin-table-attendees-purchaser-email-link" href="mailto:{{attendee_email}}">{{attendee_email}}</a>
 				</div>
-			<div class="row-actions"><span class="trash"><a href="?action=delete_attendee&#038;nonce=1234567890&#038;attendee={{cloned_attendee_id}}|TECTicketsCommerceModule">Delete</a></span></div>
+			<div class="row-actions"><span class="inline">
+					<a href="#" class="tickets_checkin" data-attendee-id="{{cloned_attendee_id}}" data-event-id="{{event_id}}" data-provider="TEC\Tickets\Commerce\Module">Check In</a>
+					<a href="#" class="tickets_uncheckin" data-attendee-id="{{cloned_attendee_id}}" data-event-id="{{event_id}}" data-provider="TEC\Tickets\Commerce\Module">Undo Check In</a>
+				</span> | <span class="trash"><a href="?action=delete_attendee&#038;nonce=1234567890&#038;attendee={{cloned_attendee_id}}|TECTicketsCommerceModule">Delete</a></span></div>
 
 
 				<div class="purchaser_name tec-tickets__admin-table-attendees-purchaser-name">

--- a/tests/ft_integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Series_Pass_Test.php
+++ b/tests/ft_integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Series_Pass_Test.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Exercises the Attendee archive REST endpoint against Series Pass Attendees to prove that a request
+ * authorized by API key alone, and therefore carrying no WP user - which is every Event Tickets Plus
+ * App request - is served the per-Occurrence clone Attendee that holds the check-in status for the
+ * Occurrence it asked about, and can tell that clone apart from a regular Attendee.
+ */
+
+namespace Tribe\Tickets\REST\V1\Endpoints;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
+use TEC\Events_Pro\Custom_Tables\V1\Series\Post_Type as Series_Post_Type;
+use TEC\Tickets\Flexible_Tickets\Series_Passes\Attendees;
+use TEC\Tickets\Flexible_Tickets\Series_Passes\Series_Passes;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use WP_REST_Request;
+
+class Attendee_Archive_Series_Pass_Test extends Controller_Test_Case {
+	use Ticket_Maker;
+	use Order_Maker;
+
+	protected string $controller_class = Attendees::class;
+
+	/**
+	 * The API key the requests are authorized with.
+	 *
+	 * @var string
+	 */
+	private string $api_key = 'test-api-key';
+
+	/**
+	 * @before
+	 */
+	public function set_up_api_key_request(): void {
+		tribe_update_option( 'tickets-plus-qr-options-api-key', $this->api_key );
+
+		// The API key is read off the request vars, not off the `WP_REST_Request`.
+		$_GET['api_key']     = $this->api_key;
+		$_REQUEST['api_key'] = $this->api_key;
+
+		if ( ! did_action( 'rest_api_init' ) ) {
+			do_action( 'rest_api_init' );
+		}
+	}
+
+	/**
+	 * @after
+	 */
+	public function tear_down_api_key_request(): void {
+		unset( $_GET['api_key'], $_REQUEST['api_key'] );
+	}
+
+	/**
+	 * Creates a Series Pass Attendee and a recurring Event, part of the Series, with 3 Occurrences.
+	 *
+	 * @return array{0: int, 1: array<int>} The Series Pass Attendee ID and the Occurrence provisional IDs.
+	 */
+	private function make_series_pass_attendee_with_occurrences(): array {
+		$series_id = static::factory()->post->create(
+			[
+				'post_type' => Series_Post_Type::POSTTYPE,
+			]
+		);
+		$pass_id   = $this->create_tc_ticket( $series_id, 1, [ 'ticket_type' => Series_Passes::TICKET_TYPE ] );
+		$this->create_order( [ $pass_id => 1 ] );
+
+		$attendee_id = tribe_attendees()->where( 'event', $series_id )->first_id();
+		$this->assertNotEmpty( $attendee_id, 'A Series Pass Attendee should have been created.' );
+
+		$recurring_event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Recurring Event in Series',
+				'status'     => 'publish',
+				'start_date' => '-1 hour',
+				'duration'   => 3 * HOUR_IN_SECONDS,
+				'recurrence' => 'RRULE:FREQ=DAILY;COUNT=3',
+				'series'     => $series_id,
+			]
+		)->create()->ID;
+
+		$provisional_ids = Occurrence::where( 'post_id', '=', $recurring_event_id )
+			->map( fn( Occurrence $occurrence ) => (int) $occurrence->provisional_id );
+
+		$this->assertCount( 3, $provisional_ids, 'The recurring Event should have 3 Occurrences.' );
+
+		return [ (int) $attendee_id, array_values( $provisional_ids ) ];
+	}
+
+	/**
+	 * Fetches the Attendee archive for an Occurrence the way the App does: by provisional ID, authorized
+	 * by API key, with no logged in user.
+	 *
+	 * @param int $provisional_id The provisional ID of the Occurrence to fetch the Attendees of.
+	 *
+	 * @return array<array<string,mixed>> The Attendee entries in the response.
+	 */
+	private function fetch_occurrence_attendees( int $provisional_id ): array {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/tribe/tickets/v1/attendees' );
+		$request->set_param( 'api_key', $this->api_key );
+		$request->set_param( 'post_id', $provisional_id );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 25 );
+		$request->set_param( 'order_status', 'public' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'The Attendee archive request should succeed.' );
+
+		return $response->get_data()['attendees'];
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_list_the_original_series_pass_attendee_for_an_occurrence_not_yet_checked_into(): void {
+		[ $attendee_id, $provisional_ids ] = $this->make_series_pass_attendee_with_occurrences();
+
+		$this->make_controller()->register();
+
+		foreach ( $provisional_ids as $provisional_id ) {
+			$attendees = $this->fetch_occurrence_attendees( $provisional_id );
+
+			$this->assertCount( 1, $attendees, "Occurrence {$provisional_id} should list the Series Pass Attendee." );
+			$this->assertEquals( $attendee_id, $attendees[0]['id'] );
+			$this->assertFalse( $attendees[0]['checked_in'] );
+			$this->assertArrayNotHasKey(
+				'clone_of',
+				$attendees[0],
+				'An Attendee that is not a clone should carry no `clone_of` entry.'
+			);
+		}
+	}
+
+	/**
+	 * The check-in status of a Series Pass Attendee lives on the clone Attendee made for the Occurrence,
+	 * so the archive has to return that clone. It used to be dropped: the clone is related to its
+	 * Occurrence by provisional ID, which has no `wp_posts` row for the related post status filter to
+	 * match, and that filter applies to any request without a WP user.
+	 *
+	 * @test
+	 */
+	public function should_list_the_per_occurrence_clone_attendee_once_it_has_been_checked_into(): void {
+		[ $attendee_id, $provisional_ids ] = $this->make_series_pass_attendee_with_occurrences();
+
+		$this->make_controller()->register();
+
+		// Check the Attendee into the last Occurrence, the one furthest outside the QR check-in window.
+		$checked_in_id  = end( $provisional_ids );
+		$not_checked_in = reset( $provisional_ids );
+
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		tribe_tickets_get_ticket_provider( $attendee_id )->checkin( $attendee_id, false, $checked_in_id );
+
+		$checked_in_attendees = $this->fetch_occurrence_attendees( $checked_in_id );
+
+		$this->assertCount( 1, $checked_in_attendees, 'The checked into Occurrence should list one Attendee.' );
+		$this->assertTrue(
+			$checked_in_attendees[0]['checked_in'],
+			'The Occurrence the Attendee was checked into should report the Attendee as checked in.'
+		);
+		$this->assertEquals(
+			$attendee_id,
+			$checked_in_attendees[0]['clone_of'],
+			'The clone Attendee should point back at the original Series Pass Attendee.'
+		);
+		$this->assertNotEquals(
+			$attendee_id,
+			$checked_in_attendees[0]['id'],
+			'The clone Attendee has its own post ID.'
+		);
+
+		$other_attendees = $this->fetch_occurrence_attendees( $not_checked_in );
+
+		$this->assertCount( 1, $other_attendees, 'Every other Occurrence should still list the Attendee.' );
+		$this->assertEquals( $attendee_id, $other_attendees[0]['id'] );
+		$this->assertFalse(
+			$other_attendees[0]['checked_in'],
+			'Checking in for one Occurrence should not check the Attendee into the others.'
+		);
+	}
+}

--- a/tests/ft_integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Series_Pass_Test.php
+++ b/tests/ft_integration/Tribe/Tickets/REST/V1/Endpoints/Attendee_Archive_Series_Pass_Test.php
@@ -99,6 +99,11 @@ class Attendee_Archive_Series_Pass_Test extends Controller_Test_Case {
 	private function fetch_occurrence_attendees( int $provisional_id ): array {
 		wp_set_current_user( 0 );
 
+		// Re-assert the API key request vars: creating the order/ticket in setup goes through a simulated
+		// checkout that clears $_GET/$_REQUEST, wiping what the `@before` hook set.
+		$_GET['api_key']     = $this->api_key;
+		$_REQUEST['api_key'] = $this->api_key;
+
 		$request = new WP_REST_Request( 'GET', '/tribe/tickets/v1/attendees' );
 		$request->set_param( 'api_key', $this->api_key );
 		$request->set_param( 'post_id', $provisional_id );
@@ -180,6 +185,102 @@ class Attendee_Archive_Series_Pass_Test extends Controller_Test_Case {
 		$this->assertFalse(
 			$other_attendees[0]['checked_in'],
 			'Checking in for one Occurrence should not check the Attendee into the others.'
+		);
+	}
+
+	/**
+	 * The manage-access branch only needs to skip `event_status` filtering for an actual Occurrence
+	 * request - it must not stop mattering just because the request happens to explicitly ask for a
+	 * status. The recurring Event backing this Occurrence really is published, so an explicit, correct
+	 * `post_status=publish` filter must not be the thing that hides the clone Attendee.
+	 *
+	 * @test
+	 */
+	public function should_list_the_checked_in_clone_attendee_when_the_request_explicitly_filters_by_published_status(): void {
+		[ $attendee_id, $provisional_ids ] = $this->make_series_pass_attendee_with_occurrences();
+
+		$this->make_controller()->register();
+
+		$checked_in_id = end( $provisional_ids );
+
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		tribe_tickets_get_ticket_provider( $attendee_id )->checkin( $attendee_id, false, $checked_in_id );
+
+		wp_set_current_user( 0 );
+
+		// Re-assert the API key request vars: creating the order/ticket above goes through a simulated
+		// checkout that clears $_GET/$_REQUEST, wiping what the `@before` hook set.
+		$_GET['api_key']     = $this->api_key;
+		$_REQUEST['api_key'] = $this->api_key;
+
+		$request = new WP_REST_Request( 'GET', '/tribe/tickets/v1/attendees' );
+		$request->set_param( 'api_key', $this->api_key );
+		$request->set_param( 'post_id', $checked_in_id );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 25 );
+		$request->set_param( 'order_status', 'public' );
+		$request->set_param( 'post_status', 'publish' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$attendees = $response->get_data()['attendees'];
+
+		$this->assertCount(
+			1,
+			$attendees,
+			'The clone Attendee for a published Occurrence must not be hidden by an explicit, correct status filter.'
+		);
+	}
+
+	/**
+	 * The event_status skip is specific to Occurrence requests - it must not silently widen visibility for
+	 * every other ticket type too. A manage-access request for a regular (non-Series) draft Event's
+	 * Attendees, with no status filter of its own, should still default to the same narrowing a request
+	 * without manage access would get.
+	 *
+	 * @test
+	 */
+	public function should_not_list_attendees_of_a_regular_draft_event_via_manage_access_without_an_explicit_status_filter(): void {
+		$draft_event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Draft Event',
+				'status'     => 'draft',
+				'start_date' => '-1 hour',
+				'duration'   => 3 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+		$ticket_id = $this->create_tc_ticket( $draft_event_id, 1 );
+		$this->create_order( [ $ticket_id => 1 ] );
+
+		$this->make_controller()->register();
+
+		wp_set_current_user( 0 );
+
+		// Re-assert the API key request vars: creating the order/ticket above goes through a simulated
+		// checkout that clears $_GET/$_REQUEST, wiping what the `@before` hook set.
+		$_GET['api_key']     = $this->api_key;
+		$_REQUEST['api_key'] = $this->api_key;
+
+		$this->assertTrue(
+			tribe( 'tickets.rest-v1.main' )->request_has_manage_access(),
+			'This test is only meaningful if it actually exercises the manage-access branch.'
+		);
+
+		$request = new WP_REST_Request( 'GET', '/tribe/tickets/v1/attendees' );
+		$request->set_param( 'api_key', $this->api_key );
+		$request->set_param( 'post_id', $draft_event_id );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 25 );
+		$request->set_param( 'order_status', 'public' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount(
+			0,
+			$response->get_data()['attendees'],
+			"A regular Event's Attendees should still be narrowed to `publish` by default - only an Occurrence request skips that."
 		);
 	}
 }

--- a/tests/ft_integration/Tribe/Tickets/REST/V1/Endpoints/QR_Series_Pass_Test.php
+++ b/tests/ft_integration/Tribe/Tickets/REST/V1/Endpoints/QR_Series_Pass_Test.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Exercises the QR check-in REST endpoint against Series Pass Attendees to prove the
+ * checkin status reported back to the app, and detected on a repeat scan, reflects the
+ * per-Occurrence clone Attendee that actually carries the checkin meta, not the original
+ * Series-level Attendee.
+ */
+
+namespace Tribe\Tickets\REST\V1\Endpoints;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Events_Pro\Custom_Tables\V1\Series\Post_Type as Series_Post_Type;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Flexible_Tickets\Series_Passes\Attendees;
+use TEC\Tickets\Flexible_Tickets\Series_Passes\Series_Passes;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use WP_REST_Request;
+
+class QR_Series_Pass_Test extends Controller_Test_Case {
+	use Ticket_Maker;
+	use Order_Maker;
+
+	protected string $controller_class = Attendees::class;
+
+	/**
+	 * Creates a Series Pass Attendee and a single Event, part of the Series, that is the
+	 * only checkin candidate for that Attendee.
+	 *
+	 * @return array{0: int, 1: int} The Series Pass Attendee ID and the Event ID.
+	 */
+	private function make_series_pass_attendee_with_one_occurrence(): array {
+		$series_id = static::factory()->post->create( [
+			'post_type' => Series_Post_Type::POSTTYPE,
+		] );
+		$pass_id = $this->create_tc_ticket( $series_id, 1, [ 'ticket_type' => Series_Passes::TICKET_TYPE ] );
+		$this->create_order( [ $pass_id => 1 ] );
+
+		$attendee_id = tribe_attendees()->where( 'event', $series_id )->first_id();
+		$this->assertNotEmpty( $attendee_id, 'A Series Pass Attendee should have been created.' );
+
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Event in Series',
+			'status'     => 'publish',
+			'start_date' => '-30 minutes',
+			'duration'   => 3 * HOUR_IN_SECONDS,
+			'series'     => $series_id,
+		] )->create()->ID;
+
+		return [ $attendee_id, $event_id ];
+	}
+
+	private function build_qr_check_in_request( string $api_key, int $attendee_id, int $event_id ): WP_REST_Request {
+		$commerce = Module::get_instance();
+
+		$request = new WP_REST_Request( 'GET', '/tribe/tickets/v1/qr' );
+		$request->set_param( 'api_key', $api_key );
+		$request->set_param( 'ticket_id', (string) $attendee_id );
+		$request->set_param( 'security_code', get_post_meta( $attendee_id, $commerce->security_code, true ) );
+		$request->set_param( 'event_id', $event_id );
+
+		return $request;
+	}
+
+	/**
+	 * @before
+	 */
+	public function set_up_qr_check_in(): void {
+		// Become an administrator so the REST response includes the manage-access-only fields, e.g. `checked_in`.
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		// Do not restrict check-ins to Events currently happening.
+		tribe_update_option( 'tickets-plus-qr-check-in-events-happening-now', false );
+
+		if ( ! did_action( 'rest_api_init' ) ) {
+			do_action( 'rest_api_init' );
+		}
+
+		$this->make_controller()->register();
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_report_the_persisted_checkin_status_after_checking_in_a_series_pass_attendee_via_qr(): void {
+		$api_key = 'test-api-key';
+		tribe_update_option( 'tickets-plus-qr-options-api-key', $api_key );
+
+		[ $attendee_id, $event_id ] = $this->make_series_pass_attendee_with_one_occurrence();
+
+		$response = rest_get_server()->dispatch( $this->build_qr_check_in_request( $api_key, $attendee_id, $event_id ) );
+
+		$this->assertEquals( 201, $response->status, 'The check-in should succeed.' );
+		$this->assertArrayHasKey( 'attendee', $response->data );
+		$this->assertArrayHasKey(
+			'checked_in',
+			$response->data['attendee'],
+			'The check-in response should report the checkin status of the Attendee.'
+		);
+		$this->assertTrue(
+			$response->data['attendee']['checked_in'],
+			'The Attendee data returned by the check-in response should report the Attendee as checked in, ' .
+			'not the stale status of the original Series-level Attendee, which is never checked in itself.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_detect_a_duplicate_scan_of_a_checked_in_series_pass_attendee_via_qr(): void {
+		$api_key = 'test-api-key';
+		tribe_update_option( 'tickets-plus-qr-options-api-key', $api_key );
+
+		[ $attendee_id, $event_id ] = $this->make_series_pass_attendee_with_one_occurrence();
+
+		$first_response = rest_get_server()->dispatch( $this->build_qr_check_in_request( $api_key, $attendee_id, $event_id ) );
+		$this->assertEquals( 201, $first_response->status, 'The first check-in should succeed.' );
+
+		$second_response = rest_get_server()->dispatch( $this->build_qr_check_in_request( $api_key, $attendee_id, $event_id ) );
+
+		$this->assertEquals(
+			403,
+			$second_response->status,
+			'Scanning the same Series Pass Attendee for the same Occurrence again should be rejected as a duplicate.'
+		);
+		$this->assertEquals( 'attendee_already_checked_in', $second_response->data['error'] );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1739](https://linear.app/nexcess/issue/SMTNC-1739/series-pass-attendees-not-checking-in-via-etp-app)

### 🗒️ Description

**Fix** (bug fix - Series Pass Attendee check-in status not persisting)
Fixed the QR check-in endpoint and the Attendees admin table to read and report a Series Pass Attendee's checkin status from its per-Occurrence clone Attendee instead of the original Series-level Attendee, which never carries the real checkin meta. This resolved the check-in appearing to succeed but not persisting via the ETP app, the QR scanner reporting an attendee as already checked in, and the wp-admin attendees list never showing the checked-in status for Series Pass Attendees.

Depends on: https://github.com/the-events-calendar/event-tickets-plus/pull/2150

### 🎥 Artifacts <!-- if applicable-->

---
**Bug**
https://www.loom.com/share/024c0245c4e44c47a4884fec52a1f312

**Fix**
https://www.loom.com/share/501483f8817f4fbea4b83f8866bc9e17

---

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
