### PR TITLE
[SOFT-4441] Update migration screen helper text

### DIFF
--- a/src/Tickets/Migrations/Controller.php
+++ b/src/Tickets/Migrations/Controller.php
@@ -97,22 +97,19 @@ class Controller extends Controller_Contract {
 					return $filters;
 				};
 				?>
-				<?php
-				// Hide the tag search field and individual migration tags using inline CSS
-				// to avoid overriding the StellarWP migrations templates. Strategy requested
-				// these fields to be hidden from the Event Tickets migrations tab.
-				?>
-				<style>
-					.stellarwp-migrations-filters__row,
-					.stellarwp-migration-card__tags {
-						display: none !important;
-					}
-					.tickets_page_tec-tickets-settings .tec-settings-form.tec-settings-form__migrations-tab--active {
-						padding-top: 0;
-					}
-				</style>
-				<div class="tec-settings-form tec-settings-form__migrations-tab--active" style="grid-template-columns: 1fr;">
+				<div class="tec-settings-form tec-settings-form__migrations-tab--active">
 					<?php
+					// The migration card template escapes its description, so the backup link is rendered here instead.
+					printf(
+						'<div class="notice notice-info inline"><p>%s</p></div>',
+						sprintf(
+							// Translators: %1$s is the opening anchor tag for the site backup guide, %2$s is the closing anchor tag.
+							esc_html__( 'Just in case, we recommend doing a %1$ssite backup%2$s before starting migration.', 'event-tickets' ),
+							'<a href="' . esc_url( 'https://evnt.is/1bei' ) . '" target="_blank" rel="noopener noreferrer">',
+							'</a>'
+						)
+					);
+
 					add_filter( 'stellarwp_migrations_tec_filters', $add_tags );
 					$ui->render_list();
 					remove_filter( 'stellarwp_migrations_tec_filters', $add_tags );

--- a/src/Tickets/Migrations/Controller.php
+++ b/src/Tickets/Migrations/Controller.php
@@ -101,10 +101,10 @@ class Controller extends Controller_Contract {
 					<?php
 					// The migration card template escapes its description, so the backup link is rendered here instead.
 					printf(
-						'<div class="notice notice-info inline"><p>%s</p></div>',
+						'<div class="notice notice-info inline notice-info--migration"><p>%s</p></div>',
 						sprintf(
 							// Translators: %1$s is the opening anchor tag for the site backup guide, %2$s is the closing anchor tag.
-							esc_html__( 'Just in case, we recommend doing a %1$ssite backup%2$s before starting migration.', 'event-tickets' ),
+							esc_html__( 'We recommend doing a %1$ssite backup%2$s before starting migration.', 'event-tickets' ),
 							'<a href="' . esc_url( 'https://evnt.is/1bei' ) . '" target="_blank" rel="noopener noreferrer">',
 							'</a>'
 						)

--- a/src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php
+++ b/src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php
@@ -201,7 +201,7 @@ class RSVP_To_Tickets_Commerce extends Migration_Abstract {
 	 * @return string The migration description.
 	 */
 	public function get_description(): string {
-		return __( 'Migrate your RSVPs to the new data system', 'event-tickets' );
+		return __( 'Migrate your RSVPs to the new data system. During migration, RSVPs and ticket sales will be temporarily unavailable. For most users, this process will be completed quickly. If you have a significant number of RSVPs, you may want to run when your site traffic is light.', 'event-tickets' );
 	}
 
 	/**

--- a/src/resources/postcss/tickets-admin/settings/_migrations.pcss
+++ b/src/resources/postcss/tickets-admin/settings/_migrations.pcss
@@ -1,8 +1,37 @@
-.tec-settings-form__migrations-tab--active {
-	grid-template-columns: 1fr;
+.tribe_settings {
 
-	> .wrap {
-		grid-column: 1;
-		padding-left: var(--tec-spacer-settings-form-right-gap);
+	.tec-settings-form {
+
+		> .notice.notice-info.inline {
+			align-items: center;
+			background: var(--tec-admin-core-grey-0);
+			display: flex;
+			grid-column-end: 1;
+			margin-bottom: calc(var(--tec-spacer-2) * -1);
+			margin-left: 34px;
+			max-width: 765px;
+			padding-bottom: var(--tec-spacer-3);
+		}
+
+		/*
+			Hide the tag search field and individual migration tags using inline CSS
+			to avoid overriding the StellarWP migrations templates. Strategy requested
+			these fields to be hidden from the Event Tickets migrations tab.
+		*/
+
+		.stellarwp-migrations-filters__row,
+		.stellarwp-migration-card__tags {
+			display: none !important;
+		}
+
+		&__migrations-tab--active {
+			gap: 0;
+			grid-template-columns: 1fr;
+
+			> .wrap {
+				grid-column: 1;
+				padding-left: var(--tec-spacer-settings-form-right-gap);
+			}
+		}
 	}
 }

--- a/src/resources/postcss/tickets-admin/settings/_migrations.pcss
+++ b/src/resources/postcss/tickets-admin/settings/_migrations.pcss
@@ -2,11 +2,11 @@
 
 	.tec-settings-form {
 
-		> .notice.notice-info.inline {
+		> .notice.notice-info.notice-info--migration {
 			align-items: center;
 			background: var(--tec-admin-core-grey-0);
 			display: flex;
-			grid-column-end: 1;
+			grid-column: 1;
 			margin-bottom: calc(var(--tec-spacer-2) * -1);
 			margin-left: 34px;
 			max-width: 765px;
@@ -27,6 +27,7 @@
 		&__migrations-tab--active {
 			gap: 0;
 			grid-template-columns: 1fr;
+			padding-top: 0;
 
 			> .wrap {
 				grid-column: 1;

--- a/tests/integration/TEC/Tickets/Migrations/Controller_Test.php
+++ b/tests/integration/TEC/Tickets/Migrations/Controller_Test.php
@@ -55,4 +55,36 @@ class Controller_Test extends Controller_Test_Case {
 
 		remove_filter( 'stellarwp_migrations_tec_filters', $add_tags );
 	}
+
+	/**
+	 * @test
+	 */
+	public function should_render_backup_notice_with_link_in_display_callback(): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		// Capture the display callback when the tab is constructed.
+		$display_callback = null;
+		$capture          = static function ( $value, $id ) use ( &$display_callback ) {
+			if ( 'migrations' === $id ) {
+				$display_callback = $value;
+			}
+
+			return $value;
+		};
+		add_filter( 'tribe_settings_tab_display_callback', $capture, 10, 2 );
+
+		$controller->register_migrations_tab( 'tec-tickets-settings' );
+
+		remove_filter( 'tribe_settings_tab_display_callback', $capture );
+
+		$this->assertIsCallable( $display_callback, 'The migrations tab should register a display callback.' );
+
+		ob_start();
+		$display_callback();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice notice-info inline notice-info--migration', $html );
+		$this->assertStringContainsString( 'We recommend doing a <a href="https://evnt.is/1bei" target="_blank" rel="noopener noreferrer">site backup</a> before starting migration.', $html );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4441](https://linear.app/nexcess/issue/SOFT-4441/update-migration-screen-helper-text)

### 🗒️ Description

**Tweak** (copy update - migration screen helper text)

Expanded the RSVP migration helper text to explain the downtime and timing expectations before a migration is started, and surfaced the recommended site backup link above the migration list. The backup sentence is rendered from the Migrations tab callback rather than the migration description because the StellarWP Migrations card template escapes descriptions, which would have printed the anchor as literal text. Also moved the tab's previously inline styles into `_migrations.pcss`.

### 🎥 Artifacts <!-- if applicable-->
<img width="928" height="375" alt="Screenshot 2026-09-09 at 21 07 55" src="https://github.com/user-attachments/assets/7065757d-1e25-4eba-b294-16d49d46c775" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
