### PR TITLE
fix(promoter): send RSVP triggers for RSVP v2 responses

### DIFF
--- a/changelog/fix-SOFT-4455-promoter-rsvp-v2-triggers
+++ b/changelog/fix-SOFT-4455-promoter-rsvp-v2-triggers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed Promoter's "RSVP Going" and "RSVP Not Going" triggers never firing for RSVPs on the new RSVP experience, and added the missing trigger for an Attendee changing their response after the fact.

--- a/changelog/fix-SOFT-4455-promoter-rsvp-v2-triggers
+++ b/changelog/fix-SOFT-4455-promoter-rsvp-v2-triggers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed Promoter's "RSVP Going" and "RSVP Not Going" triggers never firing for RSVPs on the new RSVP experience, and added the missing trigger for an Attendee changing their response after the fact.

--- a/src/Tickets/Commerce/Promoter_Observer.php
+++ b/src/Tickets/Commerce/Promoter_Observer.php
@@ -40,6 +40,8 @@ class Promoter_Observer {
 	 * Attach hooks for trigger messages.
 	 *
 	 * @since 5.3.2
+	 * @since TBD Watch the RSVP status meta, so an Attendee changing their going/not-going answer
+	 *            after the order is placed triggers too.
 	 */
 	public function hook() {
 
@@ -53,6 +55,8 @@ class Promoter_Observer {
 	 * Action fired when a TC attendee is created.
 	 *
 	 * @since 5.3.2
+	 * @since TBD Report TC-RSVP Attendees as an RSVP response rather than a purchase, so Promoter's
+	 *            RSVP triggers match. Previously every generated Attendee reported `ticket_purchased`.
 	 *
 	 * @param \WP_Post $attendee Attendee object.
 	 */

--- a/src/Tickets/Commerce/Promoter_Observer.php
+++ b/src/Tickets/Commerce/Promoter_Observer.php
@@ -8,6 +8,7 @@
 
 namespace TEC\Tickets\Commerce;
 
+use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
 use Tribe\Tickets\Promoter\Triggers\Contracts\Attendee_Model;
 use Tribe\Tickets\Promoter\Triggers\Models\Attendee;
 
@@ -45,6 +46,7 @@ class Promoter_Observer {
 		add_action( 'tec_tickets_commerce_flag_action_generated_attendee', [ $this, 'attendee_created' ], 10, 5 );
 		add_action( 'tec_tickets_commerce_ticket_deleted', tribe_callback( 'tickets.promoter.observer', 'notify_event_id' ), 10, 2 );
 		add_action( 'event_tickets_checkin', [ $this, 'checkin' ], 10, 2 );
+		add_action( 'updated_post_meta', [ $this, 'rsvp_status_updated' ], 10, 4 );
 	}
 
 	/**
@@ -55,7 +57,50 @@ class Promoter_Observer {
 	 * @param \WP_Post $attendee Attendee object.
 	 */
 	public function attendee_created( \WP_Post $attendee ) {
-		$this->trigger( 'ticket_purchased', $attendee->ID );
+		$this->trigger( $this->attendee_trigger_type( $attendee->ID ), $attendee->ID );
+	}
+
+	/**
+	 * Responds to an Attendee changing their going/not-going answer after the fact, from the My
+	 * Tickets page or the Attendees screen. That answer never touches the order, so the
+	 * attendee-generated action cannot cover it.
+	 *
+	 * @since TBD
+	 *
+	 * @param int    $meta_id    ID of the updated metadata entry.
+	 * @param int    $object_id  The post ID the meta belongs to.
+	 * @param string $meta_key   The meta key.
+	 * @param mixed  $meta_value The new meta value.
+	 */
+	public function rsvp_status_updated( $meta_id, $object_id, $meta_key, $meta_value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		if ( RSVP_V2_Constants::RSVP_STATUS_META_KEY !== $meta_key ) {
+			return;
+		}
+
+		$this->trigger( tribe_is_truthy( $meta_value ) ? 'rsvp_going' : 'rsvp_not_going', (int) $object_id );
+	}
+
+	/**
+	 * Returns the trigger type an Attendee's creation should report.
+	 *
+	 * TC-RSVP Attendees travel this same Tickets Commerce pipeline as purchases, so reporting every
+	 * one of them as a purchase would leave Promoter's RSVP triggers permanently unmatched. The
+	 * presence of the RSVP status meta is what separates the two throughout Tickets Commerce.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $attendee_id The ID of the Attendee.
+	 *
+	 * @return string The trigger type.
+	 */
+	private function attendee_trigger_type( int $attendee_id ): string {
+		if ( ! metadata_exists( 'post', $attendee_id, RSVP_V2_Constants::RSVP_STATUS_META_KEY ) ) {
+			return 'ticket_purchased';
+		}
+
+		return tribe_is_truthy( get_post_meta( $attendee_id, RSVP_V2_Constants::RSVP_STATUS_META_KEY, true ) )
+			? 'rsvp_going'
+			: 'rsvp_not_going';
 	}
 
 	/**

--- a/tests/rsvp_v2_integration/RSVP/V2/Promoter_Triggers_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Promoter_Triggers_Test.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace TEC\Tickets\RSVP\V2;
+
+use Codeception\TestCase\WPTestCase;
+use stdClass;
+use TEC\Tickets\Commerce\Gateways\Free\Gateway;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\RSVP\V2\Cart\RSVP_Cart;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+
+/**
+ * TC-RSVP attendees travel the Tickets Commerce order pipeline, so they reach Promoter through the
+ * Commerce observer rather than the legacy RSVP one. Without a type distinction every RSVP arrives
+ * at Promoter labelled `ticket_purchased`, and a "RSVP Going" trigger configured on the Promoter
+ * side never matches, so its message is never sent.
+ */
+class Promoter_Triggers_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Order_Maker;
+
+	/**
+	 * Starts collecting dispatched trigger types from this point on, so the ones fired while
+	 * building a fixture are not counted.
+	 *
+	 * Returns an object rather than an array because objects are shared by handle: the closure
+	 * below and the caller then see the same list.
+	 *
+	 * @return stdClass An object whose `types` property collects the dispatched trigger types.
+	 */
+	private function record_triggers(): stdClass {
+		$log        = new stdClass();
+		$log->types = [];
+
+		add_action(
+			'tribe_tickets_promoter_trigger_attendee',
+			static function ( $type ) use ( $log ) {
+				$log->types[] = $type;
+			}
+		);
+
+		return $log;
+	}
+
+	/**
+	 * Builds a TC-RSVP order the way Order_Endpoint::process_rsvp_step() does: through the dedicated
+	 * RSVP_Cart, then Pending -> Completed.
+	 *
+	 * @return array<int> The created attendee IDs.
+	 */
+	private function create_tc_rsvp_attendees( int $ticket_id, string $order_status ): array {
+		/** @var RSVP_Cart $cart */
+		$cart = tribe( RSVP_Cart::class );
+		$cart->clear();
+		$cart->upsert_item(
+			$ticket_id,
+			1,
+			[
+				'type'         => Constants::TC_RSVP_TYPE,
+				'order_status' => $order_status,
+			]
+		);
+		$cart->save();
+
+		/** @var Order $orders */
+		$orders = tribe( Order::class );
+		$order  = $orders->create_from_cart(
+			tribe( Gateway::class ),
+			[
+				'purchaser_user_id'    => 0,
+				'purchaser_full_name'  => 'Test Purchaser',
+				'purchaser_first_name' => 'Test',
+				'purchaser_last_name'  => 'Purchaser',
+				'purchaser_email'      => 'attendee@example.com',
+			],
+			Constants::TC_RSVP_TYPE
+		);
+
+		$orders->modify_status( $order->ID, Pending::SLUG );
+		$orders->modify_status( $order->ID, Completed::SLUG );
+
+		$cart->clear();
+
+		return array_map(
+			'intval',
+			array_column( tribe( Module::class )->get_attendees_by_order_id( $order->ID ), 'attendee_id' )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_trigger_rsvp_going_when_an_attendee_rsvps_going(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$log = $this->record_triggers();
+		$this->create_tc_rsvp_attendees( $ticket_id, 'yes' );
+
+		$this->assertSame( [ 'rsvp_going' ], $log->types );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_trigger_rsvp_not_going_when_an_attendee_rsvps_not_going(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$log = $this->record_triggers();
+		$this->create_tc_rsvp_attendees( $ticket_id, 'no' );
+
+		$this->assertSame( [ 'rsvp_not_going' ], $log->types );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_still_trigger_ticket_purchased_for_a_regular_ticket(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+
+		$log = $this->record_triggers();
+		$this->create_order( [ $ticket_id => 1 ] );
+
+		$this->assertSame( [ 'ticket_purchased' ], $log->types );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_trigger_rsvp_going_when_an_attendee_changes_to_going(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$attendees = $this->create_tc_rsvp_attendees( $ticket_id, 'no' );
+
+		$log = $this->record_triggers();
+		update_post_meta( $attendees[0], Constants::RSVP_STATUS_META_KEY, 'yes' );
+
+		$this->assertSame( [ 'rsvp_going' ], $log->types );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_trigger_rsvp_not_going_when_an_attendee_changes_to_not_going(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$attendees = $this->create_tc_rsvp_attendees( $ticket_id, 'yes' );
+
+		$log = $this->record_triggers();
+		update_post_meta( $attendees[0], Constants::RSVP_STATUS_META_KEY, 'no' );
+
+		$this->assertSame( [ 'rsvp_not_going' ], $log->types );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[skip-changelog]

[SOFT-4455](https://linear.app/nexcess/issue/SOFT-4455/test-rsvp-v2-with-promoter)

### 🗒️ Description

Promoter's "RSVP Going" / "RSVP Not Going" triggers never fire for RSVPs created on RSVP v2, so their messages are never sent. Reproduced on a local site running `bucket/rsvp-merge`: creating an RSVP v2 response against a trigger configured for "RSVP Going" produced no email, while the identical flow on v1 worked.

Two defects, both in how v2 reports to Promoter:

**1. A v2 RSVP is reported as a ticket purchase.** RSVP v2 attendees are created through the Tickets Commerce order pipeline, so they reach Promoter through `TEC\Tickets\Commerce\Promoter_Observer` rather than the legacy RSVP observer — and that observer hardcoded `ticket_purchased` for every attendee it generated. Promoter keeps `rsvp_going`, `rsvp_not_going` and `ticket_purchased` as three distinct trigger slugs, so an RSVP trigger could never match.

**2. Changing a response after the fact fires nothing.** v1 watched `updated_postmeta` for `_tribe_rsvp_status`. v2 writes `_tec_tickets_commerce_rsvp_status` instead, and nothing watched it, so a guest flipping Going ↔ Not Going from My Tickets — or an admin doing it from the Attendees screen — was silent to Promoter.

The underlying cause is `RSVP_Controller_Methods::register_promoter_hooks()`, shared by the v1 and v2 controllers but registering only v1-shaped hooks (`event_tickets_rsvp_attendee_created`, and the legacy meta key), none of which fire under v2.

#### The change

One file, `src/Tickets/Commerce/Promoter_Observer.php` — the single point every TC attendee trigger already routes through:

- `attendee_created()` derives the trigger type instead of hardcoding it. Presence of the RSVP status meta is what distinguishes a TC-RSVP attendee from a purchase, matching the discriminator already used in `Module.php`, `Ticket.php` and `Tickets.php`.
- A new `updated_post_meta` watcher on that key restores the response-change trigger v1 had.

Non-RSVP purchases are unaffected and still report `ticket_purchased` (covered by a regression test).

### 🎥 Artifacts

https://www.loom.com/share/715c1a02e0364c8faac6e22eb97183c6

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) — **[skip-changelog]**: RSVP v2 has not shipped, so this fixes an unreleased path and there is nothing to announce
- [x] Code is covered by **NEW** `wpunit` or `integration` tests. — `tests/rsvp_v2_integration/RSVP/V2/Promoter_Triggers_Test.php`, 5 cases, written first: 4 red / 1 green (the `ticket_purchased` regression guard), then 5/5 after the fix
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing? 
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts? 
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
